### PR TITLE
Refresh header branding and Telx palette

### DIFF
--- a/about.html
+++ b/about.html
@@ -15,10 +15,10 @@
       darkMode:'class',
       theme:{ extend:{
         colors:{
-          ink:{950:'#070b14',900:'#0b1220',800:'#0e1a33',700:'#112142',600:'#152a53'},
-          cobalt:{300:'#7db9ff',400:'#5aa8ff',500:'#4196ff',600:'#267dff',700:'#1a5ef0'},
-          primary:{400:'#4e72ff',500:'#3a63ff',600:'#2e50e6',700:'#2746c0',800:'#1f3a9b'},
-          mint:{300:'#9af2e0',400:'#7ef2da',500:'#49e0c5',600:'#2bd0b2'}
+          ink:{950:'#030b1f',900:'#051330',800:'#071d45',700:'#0a285d',600:'#0c3275'},
+          cobalt:{300:'#6ec9ff',400:'#4fb8ff',500:'#2f9cff',600:'#1c7df0',700:'#155fcc'},
+          primary:{400:'#4fb8ff',500:'#2f9cff',600:'#1c7df0',700:'#1353c2',800:'#0d419b'},
+          mint:{300:'#8ff0e6',400:'#6ce3d8',500:'#3dd0c3',600:'#26b9ae'}
         },
         borderRadius:{xl:'1rem','2xl':'1.25rem','3xl':'1.75rem',pill:'9999px'},
         boxShadow:{
@@ -34,38 +34,38 @@
     <link rel="stylesheet" href="/styles/site.css">
 </head>
 <body class="min-h-screen flex flex-col text-white/90">
-    <header class="sticky top-0 z-50 border-b border-white/10 bg-black/30 backdrop-blur-xs">
-        <div class="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 sm:px-6 lg:py-5">
-            <a href="index.html" class="flex items-center gap-3 rounded-2xl px-3 py-2 text-white transition hover:bg-white/5 focus-ring" aria-label="Telcoin Wiki home">
-                <span class="flex h-10 w-10 items-center justify-center rounded-2xl bg-white/10 text-lg font-semibold text-mint-400 shadow-inner">T</span>
-                <span class="text-sm font-semibold uppercase tracking-[0.2em] text-white/70">Telcoin Wiki</span>
+    <header class="site-header">
+        <div class="site-header__inner mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 sm:px-6 lg:py-5">
+            <a href="index.html" class="site-header__brand focus-ring" aria-label="Telcoin Wiki home">
+                <img src="logo.svg" alt="Telcoin Wiki" class="site-header__logo">
+                <span class="sr-only">Telcoin Wiki</span>
             </a>
             <div class="hidden flex-1 items-center justify-end gap-6 lg:flex">
-                <nav aria-label="Main" class="flex items-center">
-                    <ul class="flex items-center gap-4 text-sm font-medium text-white/70">
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="index.html#getting-started">Getting Started</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="index.html#quick-qa">Quick Q&amp;A</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="deep-dive.html">Deep Dive</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="index.html#community">Community</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="links.html">Links</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="pools.html">Pools</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="portfolio.html">Portfolio</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2 text-white" href="about.html">About</a></li>
-                        <li><a class="hover:text-mint-400 focus-ring rounded-xl px-3 py-2" href="https://telcoin.org" target="_blank" rel="noopener">Official Site</a></li>
+                <nav aria-label="Main" class="site-nav">
+                    <ul class="site-nav__list">
+                        <li><a class="site-nav__link focus-ring" href="index.html#getting-started">Getting Started</a></li>
+                        <li><a class="site-nav__link focus-ring" href="index.html#quick-qa">Quick Q&amp;A</a></li>
+                        <li><a class="site-nav__link focus-ring" href="deep-dive.html">Deep Dive</a></li>
+                        <li><a class="site-nav__link focus-ring" href="index.html#community">Community</a></li>
+                        <li><a class="site-nav__link focus-ring" href="links.html">Links</a></li>
+                        <li><a class="site-nav__link focus-ring" href="pools.html">Pools</a></li>
+                        <li><a class="site-nav__link focus-ring" href="portfolio.html">Portfolio</a></li>
+                        <li><a class="site-nav__link focus-ring" href="about.html" aria-current="page">About</a></li>
+                        <li><a class="site-nav__link site-nav__link--cta focus-ring" href="https://telcoin.org" target="_blank" rel="noopener">Official Site</a></li>
                     </ul>
                 </nav>
                 <div class="flex items-center gap-3">
                     <div class="relative w-64">
                         <label for="site-search" class="visually-hidden">Search about TELx</label>
-                        <input id="site-search" data-site-search type="search" placeholder="Search this page" class="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white placeholder:text-white/50 focus:border-mint-400 focus:outline-none focus:ring-0" autocomplete="off">
+                        <input id="site-search" data-site-search type="search" placeholder="Search this page" class="site-search" autocomplete="off">
                         <div class="search-panel" data-search-results aria-hidden="true"></div>
                     </div>
-                    <button type="button" data-theme-toggle class="btn-secondary focus-ring"><span aria-hidden="true">🌗</span><span class="sr-only">Toggle theme</span></button>
+                    <button type="button" data-theme-toggle class="site-header__icon-button focus-ring"><span aria-hidden="true">🌗</span><span class="sr-only">Toggle theme</span></button>
                 </div>
             </div>
             <div class="flex items-center gap-3 lg:hidden">
-                <button type="button" data-theme-toggle class="rounded-2xl border border-white/10 bg-white/5 p-2 text-lg text-white focus-ring" aria-label="Toggle theme"><span aria-hidden="true">🌗</span></button>
-                <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="rounded-2xl border border-white/10 bg-white/5 p-2 text-white focus-ring">
+                <button type="button" data-theme-toggle class="site-header__icon-button focus-ring" aria-label="Toggle theme"><span aria-hidden="true">🌗</span></button>
+                <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="site-header__icon-button focus-ring">
                     <span class="sr-only">Open navigation</span>
                     ☰
                 </button>
@@ -80,8 +80,8 @@
             <div class="flex-1 overflow-y-auto px-6 py-6">
                 <div class="mb-6">
                     <label for="mobile-search" class="text-xs uppercase tracking-[0.2em] text-white/50">Search</label>
-                    <div class="mt-2">
-                        <input id="mobile-search" data-site-search type="search" placeholder="Search this page" class="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white placeholder:text-white/50 focus:border-mint-400 focus:outline-none" autocomplete="off">
+                    <div class="relative mt-2">
+                        <input id="mobile-search" data-site-search type="search" placeholder="Search this page" class="site-search site-search--mobile" autocomplete="off">
                         <div class="search-panel" data-search-results aria-hidden="true"></div>
                     </div>
                 </div>

--- a/deep-dive.html
+++ b/deep-dive.html
@@ -125,10 +125,10 @@
       darkMode:'class',
       theme:{ extend:{
         colors:{
-          ink:{950:'#070b14',900:'#0b1220',800:'#0e1a33',700:'#112142',600:'#152a53'},
-          cobalt:{300:'#7db9ff',400:'#5aa8ff',500:'#4196ff',600:'#267dff',700:'#1a5ef0'},
-          primary:{400:'#4e72ff',500:'#3a63ff',600:'#2e50e6',700:'#2746c0',800:'#1f3a9b'},
-          mint:{300:'#9af2e0',400:'#7ef2da',500:'#49e0c5',600:'#2bd0b2'}
+          ink:{950:'#030b1f',900:'#051330',800:'#071d45',700:'#0a285d',600:'#0c3275'},
+          cobalt:{300:'#6ec9ff',400:'#4fb8ff',500:'#2f9cff',600:'#1c7df0',700:'#155fcc'},
+          primary:{400:'#4fb8ff',500:'#2f9cff',600:'#1c7df0',700:'#1353c2',800:'#0d419b'},
+          mint:{300:'#8ff0e6',400:'#6ce3d8',500:'#3dd0c3',600:'#26b9ae'}
         },
         borderRadius:{xl:'1rem','2xl':'1.25rem','3xl':'1.75rem',pill:'9999px'},
         boxShadow:{
@@ -144,38 +144,38 @@
     <link rel="stylesheet" href="/styles/site.css">
 </head>
 <body class="min-h-screen flex flex-col text-white/90">
-    <header class="sticky top-0 z-50 border-b border-white/10 bg-black/30 backdrop-blur-xs">
-        <div class="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 sm:px-6 lg:py-5">
-            <a href="index.html" class="flex items-center gap-3 rounded-2xl px-3 py-2 text-white transition hover:bg-white/5 focus-ring" aria-label="Telcoin Wiki home">
-                <span class="flex h-10 w-10 items-center justify-center rounded-2xl bg-white/10 text-lg font-semibold text-mint-400 shadow-inner">T</span>
-                <span class="text-sm font-semibold uppercase tracking-[0.2em] text-white/70">Telcoin Wiki</span>
+    <header class="site-header">
+        <div class="site-header__inner mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 sm:px-6 lg:py-5">
+            <a href="index.html" class="site-header__brand focus-ring" aria-label="Telcoin Wiki home">
+                <img src="logo.svg" alt="Telcoin Wiki" class="site-header__logo">
+                <span class="sr-only">Telcoin Wiki</span>
             </a>
             <div class="hidden flex-1 items-center justify-end gap-6 lg:flex">
-                <nav aria-label="Main" class="flex items-center">
-                    <ul class="flex items-center gap-4 text-sm font-medium text-white/70">
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="index.html#getting-started">Getting Started</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="index.html#quick-qa">Quick Q&amp;A</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2 text-white" href="deep-dive.html">Deep Dive</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="index.html#community">Community</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="links.html">Links</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="pools.html">Pools</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="portfolio.html">Portfolio</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="about.html">About</a></li>
-                        <li><a class="hover:text-mint-400 focus-ring rounded-xl px-3 py-2" href="https://telcoin.org" target="_blank" rel="noopener">Official Site</a></li>
+                <nav aria-label="Main" class="site-nav">
+                    <ul class="site-nav__list">
+                        <li><a class="site-nav__link focus-ring" href="index.html#getting-started">Getting Started</a></li>
+                        <li><a class="site-nav__link focus-ring" href="index.html#quick-qa">Quick Q&amp;A</a></li>
+                        <li><a class="site-nav__link focus-ring" href="deep-dive.html" aria-current="page">Deep Dive</a></li>
+                        <li><a class="site-nav__link focus-ring" href="index.html#community">Community</a></li>
+                        <li><a class="site-nav__link focus-ring" href="links.html">Links</a></li>
+                        <li><a class="site-nav__link focus-ring" href="pools.html">Pools</a></li>
+                        <li><a class="site-nav__link focus-ring" href="portfolio.html">Portfolio</a></li>
+                        <li><a class="site-nav__link focus-ring" href="about.html">About</a></li>
+                        <li><a class="site-nav__link site-nav__link--cta focus-ring" href="https://telcoin.org" target="_blank" rel="noopener">Official Site</a></li>
                     </ul>
                 </nav>
                 <div class="flex items-center gap-3">
                     <div class="relative w-64">
                         <label for="site-search" class="visually-hidden">Search Telcoin Deep Dive</label>
-                        <input id="site-search" data-site-search type="search" placeholder="Search this page" class="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white placeholder:text-white/50 focus:border-mint-400 focus:outline-none focus:ring-0" autocomplete="off">
+                        <input id="site-search" data-site-search type="search" placeholder="Search this page" class="site-search" autocomplete="off">
                         <div class="search-panel" data-search-results aria-hidden="true"></div>
                     </div>
-                    <button type="button" data-theme-toggle class="btn-secondary focus-ring"><span aria-hidden="true">🌗</span><span class="sr-only">Toggle theme</span></button>
+                    <button type="button" data-theme-toggle class="site-header__icon-button focus-ring"><span aria-hidden="true">🌗</span><span class="sr-only">Toggle theme</span></button>
                 </div>
             </div>
             <div class="flex items-center gap-3 lg:hidden">
-                <button type="button" data-theme-toggle class="rounded-2xl border border-white/10 bg-white/5 p-2 text-lg text-white focus-ring" aria-label="Toggle theme"><span aria-hidden="true">🌗</span></button>
-                <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="rounded-2xl border border-white/10 bg-white/5 p-2 text-white focus-ring">
+                <button type="button" data-theme-toggle class="site-header__icon-button focus-ring" aria-label="Toggle theme"><span aria-hidden="true">🌗</span></button>
+                <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="site-header__icon-button focus-ring">
                     <span class="sr-only">Open navigation</span>
                     ☰
                 </button>
@@ -192,8 +192,8 @@
             <div class="flex-1 overflow-y-auto px-6 py-6">
                 <div class="mb-6">
                     <label for="mobile-search" class="text-xs uppercase tracking-[0.2em] text-white/50">Search</label>
-                    <div class="mt-2">
-                        <input id="mobile-search" data-site-search type="search" placeholder="Search this page" class="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white placeholder:text-white/50 focus:border-mint-400 focus:outline-none" autocomplete="off">
+                    <div class="relative mt-2">
+                        <input id="mobile-search" data-site-search type="search" placeholder="Search this page" class="site-search site-search--mobile" autocomplete="off">
                         <div class="search-panel" data-search-results aria-hidden="true"></div>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -97,10 +97,10 @@
       darkMode:'class',
       theme:{ extend:{
         colors:{
-          ink:{950:'#070b14',900:'#0b1220',800:'#0e1a33',700:'#112142',600:'#152a53'},
-          cobalt:{300:'#7db9ff',400:'#5aa8ff',500:'#4196ff',600:'#267dff',700:'#1a5ef0'},
-          primary:{400:'#4e72ff',500:'#3a63ff',600:'#2e50e6',700:'#2746c0',800:'#1f3a9b'},
-          mint:{300:'#9af2e0',400:'#7ef2da',500:'#49e0c5',600:'#2bd0b2'}
+          ink:{950:'#030b1f',900:'#051330',800:'#071d45',700:'#0a285d',600:'#0c3275'},
+          cobalt:{300:'#6ec9ff',400:'#4fb8ff',500:'#2f9cff',600:'#1c7df0',700:'#155fcc'},
+          primary:{400:'#4fb8ff',500:'#2f9cff',600:'#1c7df0',700:'#1353c2',800:'#0d419b'},
+          mint:{300:'#8ff0e6',400:'#6ce3d8',500:'#3dd0c3',600:'#26b9ae'}
         },
         borderRadius:{xl:'1rem','2xl':'1.25rem','3xl':'1.75rem',pill:'9999px'},
         boxShadow:{
@@ -116,38 +116,38 @@
     <link rel="stylesheet" href="/styles/site.css">
 </head>
 <body class="min-h-screen flex flex-col text-white/90">
-    <header class="sticky top-0 z-50 border-b border-white/10 bg-black/30 backdrop-blur-xs">
-        <div class="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 sm:px-6 lg:py-5">
-            <a href="index.html" class="flex items-center gap-3 rounded-2xl px-3 py-2 text-white transition hover:bg-white/5 focus-ring" aria-label="Telcoin Wiki home">
-                <span class="flex h-10 w-10 items-center justify-center rounded-2xl bg-white/10 text-lg font-semibold text-mint-400 shadow-inner">T</span>
-                <span class="text-sm font-semibold uppercase tracking-[0.2em] text-white/70">Telcoin Wiki</span>
+    <header class="site-header">
+        <div class="site-header__inner mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 sm:px-6 lg:py-5">
+            <a href="index.html" class="site-header__brand focus-ring" aria-label="Telcoin Wiki home">
+                <img src="logo.svg" alt="Telcoin Wiki" class="site-header__logo">
+                <span class="sr-only">Telcoin Wiki</span>
             </a>
             <div class="hidden flex-1 items-center justify-end gap-6 lg:flex">
-                <nav aria-label="Main" class="flex items-center">
-                    <ul class="flex items-center gap-4 text-sm font-medium text-white/70">
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="#getting-started">Getting Started</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="#quick-qa">Quick Q&amp;A</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="deep-dive.html">Deep Dive</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="#community">Community</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="links.html">Links</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="pools.html">Pools</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="portfolio.html">Portfolio</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="about.html">About</a></li>
-                        <li><a class="hover:text-mint-400 focus-ring rounded-xl px-3 py-2" href="https://telcoin.org" target="_blank" rel="noopener">Official Site</a></li>
+                <nav aria-label="Main" class="site-nav">
+                    <ul class="site-nav__list">
+                        <li><a class="site-nav__link focus-ring" href="#getting-started">Getting Started</a></li>
+                        <li><a class="site-nav__link focus-ring" href="#quick-qa">Quick Q&amp;A</a></li>
+                        <li><a class="site-nav__link focus-ring" href="deep-dive.html">Deep Dive</a></li>
+                        <li><a class="site-nav__link focus-ring" href="#community">Community</a></li>
+                        <li><a class="site-nav__link focus-ring" href="links.html">Links</a></li>
+                        <li><a class="site-nav__link focus-ring" href="pools.html">Pools</a></li>
+                        <li><a class="site-nav__link focus-ring" href="portfolio.html">Portfolio</a></li>
+                        <li><a class="site-nav__link focus-ring" href="about.html">About</a></li>
+                        <li><a class="site-nav__link site-nav__link--cta focus-ring" href="https://telcoin.org" target="_blank" rel="noopener">Official Site</a></li>
                     </ul>
                 </nav>
                 <div class="flex items-center gap-3">
                     <div class="relative w-64">
                         <label for="site-search" class="visually-hidden">Search Telcoin Wiki</label>
-                        <input id="site-search" data-site-search type="search" placeholder="Search this page" class="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white placeholder:text-white/50 focus:border-mint-400 focus:outline-none focus:ring-0" autocomplete="off">
+                        <input id="site-search" data-site-search type="search" placeholder="Search this page" class="site-search" autocomplete="off">
                         <div class="search-panel" data-search-results aria-hidden="true"></div>
                     </div>
-                    <button type="button" data-theme-toggle class="btn-secondary focus-ring"><span aria-hidden="true">🌗</span><span class="sr-only">Toggle theme</span></button>
+                    <button type="button" data-theme-toggle class="site-header__icon-button focus-ring"><span aria-hidden="true">🌗</span><span class="sr-only">Toggle theme</span></button>
                 </div>
             </div>
             <div class="flex items-center gap-3 lg:hidden">
-                <button type="button" data-theme-toggle class="rounded-2xl border border-white/10 bg-white/5 p-2 text-lg text-white focus-ring" aria-label="Toggle theme"><span aria-hidden="true">🌗</span></button>
-                <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="rounded-2xl border border-white/10 bg-white/5 p-2 text-white focus-ring">
+                <button type="button" data-theme-toggle class="site-header__icon-button focus-ring" aria-label="Toggle theme"><span aria-hidden="true">🌗</span></button>
+                <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="site-header__icon-button focus-ring">
                     <span class="sr-only">Open navigation</span>
                     ☰
                 </button>
@@ -164,8 +164,8 @@
             <div class="flex-1 overflow-y-auto px-6 py-6">
                 <div class="mb-6">
                     <label for="mobile-search" class="text-xs uppercase tracking-[0.2em] text-white/50">Search</label>
-                    <div class="mt-2">
-                        <input id="mobile-search" data-site-search type="search" placeholder="Search this page" class="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white placeholder:text-white/50 focus:border-mint-400 focus:outline-none" autocomplete="off">
+                    <div class="relative mt-2">
+                        <input id="mobile-search" data-site-search type="search" placeholder="Search this page" class="site-search site-search--mobile" autocomplete="off">
                         <div class="search-panel" data-search-results aria-hidden="true"></div>
                     </div>
                 </div>

--- a/links.html
+++ b/links.html
@@ -156,10 +156,10 @@
       darkMode:'class',
       theme:{ extend:{
         colors:{
-          ink:{950:'#070b14',900:'#0b1220',800:'#0e1a33',700:'#112142',600:'#152a53'},
-          cobalt:{300:'#7db9ff',400:'#5aa8ff',500:'#4196ff',600:'#267dff',700:'#1a5ef0'},
-          primary:{400:'#4e72ff',500:'#3a63ff',600:'#2e50e6',700:'#2746c0',800:'#1f3a9b'},
-          mint:{300:'#9af2e0',400:'#7ef2da',500:'#49e0c5',600:'#2bd0b2'}
+          ink:{950:'#030b1f',900:'#051330',800:'#071d45',700:'#0a285d',600:'#0c3275'},
+          cobalt:{300:'#6ec9ff',400:'#4fb8ff',500:'#2f9cff',600:'#1c7df0',700:'#155fcc'},
+          primary:{400:'#4fb8ff',500:'#2f9cff',600:'#1c7df0',700:'#1353c2',800:'#0d419b'},
+          mint:{300:'#8ff0e6',400:'#6ce3d8',500:'#3dd0c3',600:'#26b9ae'}
         },
         borderRadius:{xl:'1rem','2xl':'1.25rem','3xl':'1.75rem',pill:'9999px'},
         boxShadow:{
@@ -175,38 +175,38 @@
     <link rel="stylesheet" href="/styles/site.css">
 </head>
 <body class="min-h-screen flex flex-col text-white/90">
-    <header class="sticky top-0 z-50 border-b border-white/10 bg-black/30 backdrop-blur-xs">
-        <div class="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 sm:px-6 lg:py-5">
-            <a href="index.html" class="flex items-center gap-3 rounded-2xl px-3 py-2 text-white transition hover:bg-white/5 focus-ring" aria-label="Telcoin Wiki home">
-                <span class="flex h-10 w-10 items-center justify-center rounded-2xl bg-white/10 text-lg font-semibold text-mint-400 shadow-inner">T</span>
-                <span class="text-sm font-semibold uppercase tracking-[0.2em] text-white/70">Telcoin Wiki</span>
+    <header class="site-header">
+        <div class="site-header__inner mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 sm:px-6 lg:py-5">
+            <a href="index.html" class="site-header__brand focus-ring" aria-label="Telcoin Wiki home">
+                <img src="logo.svg" alt="Telcoin Wiki" class="site-header__logo">
+                <span class="sr-only">Telcoin Wiki</span>
             </a>
             <div class="hidden flex-1 items-center justify-end gap-6 lg:flex">
-                <nav aria-label="Main" class="flex items-center">
-                    <ul class="flex items-center gap-4 text-sm font-medium text-white/70">
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="index.html#getting-started">Getting Started</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="index.html#quick-qa">Quick Q&amp;A</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="deep-dive.html">Deep Dive</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="index.html#community">Community</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2 text-white" href="links.html">Links</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="pools.html">Pools</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="portfolio.html">Portfolio</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="about.html">About</a></li>
-                        <li><a class="hover:text-mint-400 focus-ring rounded-xl px-3 py-2" href="https://telcoin.org" target="_blank" rel="noopener">Official Site</a></li>
+                <nav aria-label="Main" class="site-nav">
+                    <ul class="site-nav__list">
+                        <li><a class="site-nav__link focus-ring" href="index.html#getting-started">Getting Started</a></li>
+                        <li><a class="site-nav__link focus-ring" href="index.html#quick-qa">Quick Q&amp;A</a></li>
+                        <li><a class="site-nav__link focus-ring" href="deep-dive.html">Deep Dive</a></li>
+                        <li><a class="site-nav__link focus-ring" href="index.html#community">Community</a></li>
+                        <li><a class="site-nav__link focus-ring" href="links.html" aria-current="page">Links</a></li>
+                        <li><a class="site-nav__link focus-ring" href="pools.html">Pools</a></li>
+                        <li><a class="site-nav__link focus-ring" href="portfolio.html">Portfolio</a></li>
+                        <li><a class="site-nav__link focus-ring" href="about.html">About</a></li>
+                        <li><a class="site-nav__link site-nav__link--cta focus-ring" href="https://telcoin.org" target="_blank" rel="noopener">Official Site</a></li>
                     </ul>
                 </nav>
                 <div class="flex items-center gap-3">
                     <div class="relative w-64">
                         <label for="site-search" class="visually-hidden">Search Telcoin links</label>
-                        <input id="site-search" data-site-search type="search" placeholder="Search this page" class="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white placeholder:text-white/50 focus:border-mint-400 focus:outline-none focus:ring-0" autocomplete="off">
+                        <input id="site-search" data-site-search type="search" placeholder="Search this page" class="site-search" autocomplete="off">
                         <div class="search-panel" data-search-results aria-hidden="true"></div>
                     </div>
-                    <button type="button" data-theme-toggle class="btn-secondary focus-ring"><span aria-hidden="true">🌗</span><span class="sr-only">Toggle theme</span></button>
+                    <button type="button" data-theme-toggle class="site-header__icon-button focus-ring"><span aria-hidden="true">🌗</span><span class="sr-only">Toggle theme</span></button>
                 </div>
             </div>
             <div class="flex items-center gap-3 lg:hidden">
-                <button type="button" data-theme-toggle class="rounded-2xl border border-white/10 bg-white/5 p-2 text-lg text-white focus-ring" aria-label="Toggle theme"><span aria-hidden="true">🌗</span></button>
-                <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="rounded-2xl border border-white/10 bg-white/5 p-2 text-white focus-ring">
+                <button type="button" data-theme-toggle class="site-header__icon-button focus-ring" aria-label="Toggle theme"><span aria-hidden="true">🌗</span></button>
+                <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="site-header__icon-button focus-ring">
                     <span class="sr-only">Open navigation</span>
                     ☰
                 </button>
@@ -223,8 +223,8 @@
             <div class="flex-1 overflow-y-auto px-6 py-6">
                 <div class="mb-6">
                     <label for="mobile-search" class="text-xs uppercase tracking-[0.2em] text-white/50">Search</label>
-                    <div class="mt-2">
-                        <input id="mobile-search" data-site-search type="search" placeholder="Search this page" class="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white placeholder:text-white/50 focus:border-mint-400 focus:outline-none" autocomplete="off">
+                    <div class="relative mt-2">
+                        <input id="mobile-search" data-site-search type="search" placeholder="Search this page" class="site-search site-search--mobile" autocomplete="off">
                         <div class="search-panel" data-search-results aria-hidden="true"></div>
                     </div>
                 </div>

--- a/logo.svg
+++ b/logo.svg
@@ -1,1 +1,17 @@
-
+<svg width="260" height="72" viewBox="0 0 260 72" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="logoTitle logoDesc">
+  <title id="logoTitle">Telcoin Wiki logo</title>
+  <desc id="logoDesc">Wordmark showing the Telcoin name in white with Wiki in a bright Telx blue and a swoosh underline.</desc>
+  <defs>
+    <linearGradient id="wikiGradient" x1="188" y1="10" x2="188" y2="58" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#2DC9FF"/>
+      <stop offset="1" stop-color="#0F6BFF"/>
+    </linearGradient>
+    <linearGradient id="underlineGradient" x1="150" y1="60" x2="236" y2="60" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#2DC9FF"/>
+      <stop offset="1" stop-color="#0F6BFF"/>
+    </linearGradient>
+  </defs>
+  <text x="0" y="46" fill="#F4F8FF" font-family="'Inter', 'Inter var', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="38" font-weight="700" letter-spacing="0.015em">Telcoin</text>
+  <text x="146" y="46" fill="url(#wikiGradient)" font-family="'Inter', 'Inter var', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="38" font-weight="700" letter-spacing="0.015em">Wiki</text>
+  <path d="M150 56C166 64 186 66 204 64C214 63 224 60 236 56" stroke="url(#underlineGradient)" stroke-width="6" stroke-linecap="round"/>
+</svg>

--- a/pools.html
+++ b/pools.html
@@ -15,10 +15,10 @@
       darkMode:'class',
       theme:{ extend:{
         colors:{
-          ink:{950:'#070b14',900:'#0b1220',800:'#0e1a33',700:'#112142',600:'#152a53'},
-          cobalt:{300:'#7db9ff',400:'#5aa8ff',500:'#4196ff',600:'#267dff',700:'#1a5ef0'},
-          primary:{400:'#4e72ff',500:'#3a63ff',600:'#2e50e6',700:'#2746c0',800:'#1f3a9b'},
-          mint:{300:'#9af2e0',400:'#7ef2da',500:'#49e0c5',600:'#2bd0b2'}
+          ink:{950:'#030b1f',900:'#051330',800:'#071d45',700:'#0a285d',600:'#0c3275'},
+          cobalt:{300:'#6ec9ff',400:'#4fb8ff',500:'#2f9cff',600:'#1c7df0',700:'#155fcc'},
+          primary:{400:'#4fb8ff',500:'#2f9cff',600:'#1c7df0',700:'#1353c2',800:'#0d419b'},
+          mint:{300:'#8ff0e6',400:'#6ce3d8',500:'#3dd0c3',600:'#26b9ae'}
         },
         borderRadius:{xl:'1rem','2xl':'1.25rem','3xl':'1.75rem',pill:'9999px'},
         boxShadow:{
@@ -34,38 +34,38 @@
     <link rel="stylesheet" href="/styles/site.css">
 </head>
 <body class="min-h-screen flex flex-col text-white/90">
-    <header class="sticky top-0 z-50 border-b border-white/10 bg-black/30 backdrop-blur-xs">
-        <div class="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 sm:px-6 lg:py-5">
-            <a href="index.html" class="flex items-center gap-3 rounded-2xl px-3 py-2 text-white transition hover:bg-white/5 focus-ring" aria-label="Telcoin Wiki home">
-                <span class="flex h-10 w-10 items-center justify-center rounded-2xl bg-white/10 text-lg font-semibold text-mint-400 shadow-inner">T</span>
-                <span class="text-sm font-semibold uppercase tracking-[0.2em] text-white/70">Telcoin Wiki</span>
+    <header class="site-header">
+        <div class="site-header__inner mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 sm:px-6 lg:py-5">
+            <a href="index.html" class="site-header__brand focus-ring" aria-label="Telcoin Wiki home">
+                <img src="logo.svg" alt="Telcoin Wiki" class="site-header__logo">
+                <span class="sr-only">Telcoin Wiki</span>
             </a>
             <div class="hidden flex-1 items-center justify-end gap-6 lg:flex">
-                <nav aria-label="Main" class="flex items-center">
-                    <ul class="flex items-center gap-4 text-sm font-medium text-white/70">
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="index.html#getting-started">Getting Started</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="index.html#quick-qa">Quick Q&amp;A</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="deep-dive.html">Deep Dive</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="index.html#community">Community</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="links.html">Links</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2 text-white" href="pools.html">Pools</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="portfolio.html">Portfolio</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="about.html">About</a></li>
-                        <li><a class="hover:text-mint-400 focus-ring rounded-xl px-3 py-2" href="https://telcoin.org" target="_blank" rel="noopener">Official Site</a></li>
+                <nav aria-label="Main" class="site-nav">
+                    <ul class="site-nav__list">
+                        <li><a class="site-nav__link focus-ring" href="index.html#getting-started">Getting Started</a></li>
+                        <li><a class="site-nav__link focus-ring" href="index.html#quick-qa">Quick Q&amp;A</a></li>
+                        <li><a class="site-nav__link focus-ring" href="deep-dive.html">Deep Dive</a></li>
+                        <li><a class="site-nav__link focus-ring" href="index.html#community">Community</a></li>
+                        <li><a class="site-nav__link focus-ring" href="links.html">Links</a></li>
+                        <li><a class="site-nav__link focus-ring" href="pools.html" aria-current="page">Pools</a></li>
+                        <li><a class="site-nav__link focus-ring" href="portfolio.html">Portfolio</a></li>
+                        <li><a class="site-nav__link focus-ring" href="about.html">About</a></li>
+                        <li><a class="site-nav__link site-nav__link--cta focus-ring" href="https://telcoin.org" target="_blank" rel="noopener">Official Site</a></li>
                     </ul>
                 </nav>
                 <div class="flex items-center gap-3">
                     <div class="relative w-64">
                         <label for="site-search" class="visually-hidden">Search TELx pools</label>
-                        <input id="site-search" data-site-search type="search" placeholder="Search this page" class="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white placeholder:text-white/50 focus:border-mint-400 focus:outline-none focus:ring-0" autocomplete="off">
+                        <input id="site-search" data-site-search type="search" placeholder="Search this page" class="site-search" autocomplete="off">
                         <div class="search-panel" data-search-results aria-hidden="true"></div>
                     </div>
-                    <button type="button" data-theme-toggle class="btn-secondary focus-ring"><span aria-hidden="true">🌗</span><span class="sr-only">Toggle theme</span></button>
+                    <button type="button" data-theme-toggle class="site-header__icon-button focus-ring"><span aria-hidden="true">🌗</span><span class="sr-only">Toggle theme</span></button>
                 </div>
             </div>
             <div class="flex items-center gap-3 lg:hidden">
-                <button type="button" data-theme-toggle class="rounded-2xl border border-white/10 bg-white/5 p-2 text-lg text-white focus-ring" aria-label="Toggle theme"><span aria-hidden="true">🌗</span></button>
-                <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="rounded-2xl border border-white/10 bg-white/5 p-2 text-white focus-ring">
+                <button type="button" data-theme-toggle class="site-header__icon-button focus-ring" aria-label="Toggle theme"><span aria-hidden="true">🌗</span></button>
+                <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="site-header__icon-button focus-ring">
                     <span class="sr-only">Open navigation</span>
                     ☰
                 </button>
@@ -82,8 +82,8 @@
             <div class="flex-1 overflow-y-auto px-6 py-6">
                 <div class="mb-6">
                     <label for="mobile-search" class="text-xs uppercase tracking-[0.2em] text-white/50">Search</label>
-                    <div class="mt-2">
-                        <input id="mobile-search" data-site-search type="search" placeholder="Search this page" class="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white placeholder:text-white/50 focus:border-mint-400 focus:outline-none" autocomplete="off">
+                    <div class="relative mt-2">
+                        <input id="mobile-search" data-site-search type="search" placeholder="Search this page" class="site-search site-search--mobile" autocomplete="off">
                         <div class="search-panel" data-search-results aria-hidden="true"></div>
                     </div>
                 </div>

--- a/portfolio.html
+++ b/portfolio.html
@@ -15,10 +15,10 @@
       darkMode:'class',
       theme:{ extend:{
         colors:{
-          ink:{950:'#070b14',900:'#0b1220',800:'#0e1a33',700:'#112142',600:'#152a53'},
-          cobalt:{300:'#7db9ff',400:'#5aa8ff',500:'#4196ff',600:'#267dff',700:'#1a5ef0'},
-          primary:{400:'#4e72ff',500:'#3a63ff',600:'#2e50e6',700:'#2746c0',800:'#1f3a9b'},
-          mint:{300:'#9af2e0',400:'#7ef2da',500:'#49e0c5',600:'#2bd0b2'}
+          ink:{950:'#030b1f',900:'#051330',800:'#071d45',700:'#0a285d',600:'#0c3275'},
+          cobalt:{300:'#6ec9ff',400:'#4fb8ff',500:'#2f9cff',600:'#1c7df0',700:'#155fcc'},
+          primary:{400:'#4fb8ff',500:'#2f9cff',600:'#1c7df0',700:'#1353c2',800:'#0d419b'},
+          mint:{300:'#8ff0e6',400:'#6ce3d8',500:'#3dd0c3',600:'#26b9ae'}
         },
         borderRadius:{xl:'1rem','2xl':'1.25rem','3xl':'1.75rem',pill:'9999px'},
         boxShadow:{
@@ -34,38 +34,38 @@
     <link rel="stylesheet" href="/styles/site.css">
 </head>
 <body class="min-h-screen flex flex-col text-white/90">
-    <header class="sticky top-0 z-50 border-b border-white/10 bg-black/30 backdrop-blur-xs">
-        <div class="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 sm:px-6 lg:py-5">
-            <a href="index.html" class="flex items-center gap-3 rounded-2xl px-3 py-2 text-white transition hover:bg-white/5 focus-ring" aria-label="Telcoin Wiki home">
-                <span class="flex h-10 w-10 items-center justify-center rounded-2xl bg-white/10 text-lg font-semibold text-mint-400 shadow-inner">T</span>
-                <span class="text-sm font-semibold uppercase tracking-[0.2em] text-white/70">Telcoin Wiki</span>
+    <header class="site-header">
+        <div class="site-header__inner mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 sm:px-6 lg:py-5">
+            <a href="index.html" class="site-header__brand focus-ring" aria-label="Telcoin Wiki home">
+                <img src="logo.svg" alt="Telcoin Wiki" class="site-header__logo">
+                <span class="sr-only">Telcoin Wiki</span>
             </a>
             <div class="hidden flex-1 items-center justify-end gap-6 lg:flex">
-                <nav aria-label="Main" class="flex items-center">
-                    <ul class="flex items-center gap-4 text-sm font-medium text-white/70">
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="index.html#getting-started">Getting Started</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="index.html#quick-qa">Quick Q&amp;A</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="deep-dive.html">Deep Dive</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="index.html#community">Community</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="links.html">Links</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="pools.html">Pools</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2 text-white" href="portfolio.html">Portfolio</a></li>
-                        <li><a class="hover:text-white focus-ring rounded-xl px-3 py-2" href="about.html">About</a></li>
-                        <li><a class="hover:text-mint-400 focus-ring rounded-xl px-3 py-2" href="https://telcoin.org" target="_blank" rel="noopener">Official Site</a></li>
+                <nav aria-label="Main" class="site-nav">
+                    <ul class="site-nav__list">
+                        <li><a class="site-nav__link focus-ring" href="index.html#getting-started">Getting Started</a></li>
+                        <li><a class="site-nav__link focus-ring" href="index.html#quick-qa">Quick Q&amp;A</a></li>
+                        <li><a class="site-nav__link focus-ring" href="deep-dive.html">Deep Dive</a></li>
+                        <li><a class="site-nav__link focus-ring" href="index.html#community">Community</a></li>
+                        <li><a class="site-nav__link focus-ring" href="links.html">Links</a></li>
+                        <li><a class="site-nav__link focus-ring" href="pools.html">Pools</a></li>
+                        <li><a class="site-nav__link focus-ring" href="portfolio.html" aria-current="page">Portfolio</a></li>
+                        <li><a class="site-nav__link focus-ring" href="about.html">About</a></li>
+                        <li><a class="site-nav__link site-nav__link--cta focus-ring" href="https://telcoin.org" target="_blank" rel="noopener">Official Site</a></li>
                     </ul>
                 </nav>
                 <div class="flex items-center gap-3">
                     <div class="relative w-64">
                         <label for="site-search" class="visually-hidden">Search TELx portfolio</label>
-                        <input id="site-search" data-site-search type="search" placeholder="Search this page" class="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white placeholder:text-white/50 focus:border-mint-400 focus:outline-none focus:ring-0" autocomplete="off">
+                        <input id="site-search" data-site-search type="search" placeholder="Search this page" class="site-search" autocomplete="off">
                         <div class="search-panel" data-search-results aria-hidden="true"></div>
                     </div>
-                    <button type="button" data-theme-toggle class="btn-secondary focus-ring"><span aria-hidden="true">🌗</span><span class="sr-only">Toggle theme</span></button>
+                    <button type="button" data-theme-toggle class="site-header__icon-button focus-ring"><span aria-hidden="true">🌗</span><span class="sr-only">Toggle theme</span></button>
                 </div>
             </div>
             <div class="flex items-center gap-3 lg:hidden">
-                <button type="button" data-theme-toggle class="rounded-2xl border border-white/10 bg-white/5 p-2 text-lg text-white focus-ring" aria-label="Toggle theme"><span aria-hidden="true">🌗</span></button>
-                <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="rounded-2xl border border-white/10 bg-white/5 p-2 text-white focus-ring">
+                <button type="button" data-theme-toggle class="site-header__icon-button focus-ring" aria-label="Toggle theme"><span aria-hidden="true">🌗</span></button>
+                <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="site-header__icon-button focus-ring">
                     <span class="sr-only">Open navigation</span>
                     ☰
                 </button>
@@ -80,8 +80,8 @@
             <div class="flex-1 overflow-y-auto px-6 py-6">
                 <div class="mb-6">
                     <label for="mobile-search" class="text-xs uppercase tracking-[0.2em] text-white/50">Search</label>
-                    <div class="mt-2">
-                        <input id="mobile-search" data-site-search type="search" placeholder="Search this page" class="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white placeholder:text-white/50 focus:border-mint-400 focus:outline-none" autocomplete="off">
+                    <div class="relative mt-2">
+                        <input id="mobile-search" data-site-search type="search" placeholder="Search this page" class="site-search site-search--mobile" autocomplete="off">
                         <div class="search-panel" data-search-results aria-hidden="true"></div>
                     </div>
                 </div>

--- a/styles/site.css
+++ b/styles/site.css
@@ -14,10 +14,10 @@ body {
   line-height: 1.6;
   color: #f8fbff;
   background:
-    radial-gradient(1200px 520px at -10% -10%, rgba(78, 114, 255, 0.22), transparent 60%),
-    radial-gradient(900px 600px at 110% 0%, rgba(73, 224, 197, 0.16), transparent 60%),
-    radial-gradient(800px 800px at 50% 120%, rgba(30, 64, 175, 0.35), transparent 60%),
-    linear-gradient(180deg, #0b1220, #152a53);
+    radial-gradient(1200px 540px at -10% -10%, rgba(64, 176, 255, 0.25), transparent 65%),
+    radial-gradient(920px 620px at 115% -5%, rgba(55, 205, 255, 0.18), transparent 60%),
+    radial-gradient(880px 820px at 46% 120%, rgba(10, 61, 146, 0.45), transparent 65%),
+    linear-gradient(180deg, #040b1d 0%, #07255a 40%, #0a4496 80%, #0c5fc4 100%);
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -54,9 +54,176 @@ main {
   flex: 1;
 }
 
-.footer, header {
+.footer, .site-header {
   position: relative;
   z-index: 10;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 70;
+  background: linear-gradient(120deg, rgba(5, 16, 42, 0.94) 0%, rgba(9, 43, 104, 0.96) 52%, rgba(14, 114, 202, 0.96) 100%);
+  border-bottom: 1px solid rgba(108, 199, 255, 0.38);
+  box-shadow: 0 18px 45px -20px rgba(3, 15, 40, 0.85);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  overflow: hidden;
+}
+
+.site-header::before {
+  content: "";
+  position: absolute;
+  inset: -40% -20% -60% -20%;
+  background:
+    radial-gradient(120% 120% at 12% 10%, rgba(109, 230, 255, 0.28), transparent 60%),
+    radial-gradient(110% 80% at 88% 0%, rgba(30, 107, 255, 0.45), transparent 70%);
+  opacity: 0.75;
+  pointer-events: none;
+}
+
+.site-header::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(5, 17, 42, 0.25) 0%, rgba(5, 17, 42, 0.55) 100%);
+  pointer-events: none;
+}
+
+.site-header__inner {
+  position: relative;
+  z-index: 1;
+}
+
+.site-header__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 0.9rem;
+  border-radius: 1.25rem;
+  color: #e8f4ff;
+  text-decoration: none;
+  transition: background 0.25s ease, box-shadow 0.25s cubic-bezier(.22,.61,.36,1), transform 0.25s cubic-bezier(.22,.61,.36,1);
+}
+
+.site-header__brand:hover,
+.site-header__brand:focus-visible {
+  background: rgba(10, 54, 130, 0.45);
+  box-shadow: 0 16px 34px rgba(8, 32, 90, 0.45);
+  transform: translateY(-1px);
+}
+
+.site-header__logo {
+  display: block;
+  height: 44px;
+  width: auto;
+}
+
+@media (min-width: 1024px) {
+  .site-header__logo {
+    height: 48px;
+  }
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+}
+
+.site-nav__list {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.site-nav__link {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.55rem 0.95rem;
+  border-radius: 1rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.015em;
+  color: rgba(224, 237, 255, 0.78);
+  text-decoration: none;
+  transition: color 0.25s ease, background-color 0.25s ease, transform 0.25s cubic-bezier(.22,.61,.36,1), box-shadow 0.25s ease;
+}
+
+.site-nav__link:hover,
+.site-nav__link:focus-visible {
+  color: #f8fbff;
+  background: linear-gradient(135deg, rgba(33, 126, 255, 0.42), rgba(12, 78, 168, 0.55));
+  box-shadow: 0 14px 30px rgba(6, 30, 76, 0.45);
+  transform: translateY(-1px);
+}
+
+.site-nav__link[aria-current="page"] {
+  color: #ffffff;
+  background: linear-gradient(135deg, rgba(33, 126, 255, 0.55), rgba(16, 94, 203, 0.75));
+  box-shadow: 0 16px 32px rgba(6, 32, 84, 0.55);
+}
+
+.site-nav__link--cta {
+  color: #041335;
+  background: linear-gradient(135deg, #6de6ff, #1e6bff);
+  box-shadow: 0 14px 32px rgba(10, 78, 170, 0.55);
+}
+
+.site-nav__link--cta:hover,
+.site-nav__link--cta:focus-visible {
+  color: #041335;
+  background: linear-gradient(135deg, #7af0ff, #3a86ff);
+  box-shadow: 0 16px 36px rgba(13, 84, 180, 0.6);
+}
+
+.site-header__icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 1.1rem;
+  border: 1px solid rgba(110, 198, 255, 0.45);
+  background: rgba(6, 29, 72, 0.65);
+  color: #e6f3ff;
+  padding: 0.55rem 0.65rem;
+  font-size: 1.05rem;
+  transition: background 0.25s ease, transform 0.25s cubic-bezier(.22,.61,.36,1), box-shadow 0.25s ease;
+}
+
+.site-header__icon-button:hover,
+.site-header__icon-button:focus-visible {
+  background: rgba(12, 66, 150, 0.8);
+  box-shadow: 0 14px 34px rgba(5, 28, 72, 0.5);
+  transform: translateY(-1px);
+}
+
+.site-search {
+  width: 100%;
+  border-radius: 9999px;
+  border: 1px solid rgba(110, 198, 255, 0.4);
+  background: rgba(4, 24, 58, 0.55);
+  color: #e9f4ff;
+  padding: 0.6rem 1rem;
+  font-size: 0.85rem;
+  box-shadow: inset 0 0 0 1px rgba(109, 230, 255, 0.08), 0 8px 22px rgba(4, 24, 58, 0.25);
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+}
+
+.site-search::placeholder {
+  color: rgba(206, 229, 255, 0.55);
+}
+
+.site-search:focus {
+  border-color: rgba(109, 230, 255, 0.9);
+  box-shadow: 0 0 0 4px rgba(109, 230, 255, 0.25);
+  background: rgba(5, 37, 86, 0.8);
+  outline: none;
+}
+
+.site-search--mobile {
+  box-shadow: inset 0 0 0 1px rgba(109, 230, 255, 0.08), 0 6px 18px rgba(4, 24, 58, 0.2);
 }
 
 .focus-ring:focus-visible,
@@ -67,7 +234,7 @@ select:focus-visible,
 textarea:focus-visible,
 summary:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 3px rgba(73, 224, 197, 0.75);
+  box-shadow: 0 0 0 3px rgba(109, 230, 255, 0.7);
   border-radius: 12px;
 }
 
@@ -226,14 +393,14 @@ summary:focus-visible {
   border-radius: 1.25rem;
   font-weight: 600;
   color: #fff;
-  background-image: linear-gradient(90deg, #4196ff, #2746c0);
-  box-shadow: 0 0 0 1px rgba(120, 180, 255, 0.18), 0 14px 44px rgba(41, 112, 255, 0.22);
+  background-image: linear-gradient(135deg, #55c0ff, #1c6dff);
+  box-shadow: 0 0 0 1px rgba(110, 198, 255, 0.28), 0 18px 48px rgba(12, 78, 170, 0.35);
   transition: transform 0.2s cubic-bezier(.22,.61,.36,1), box-shadow 0.2s cubic-bezier(.22,.61,.36,1);
 }
 
 .btn-primary:hover {
   transform: scale(1.01);
-  box-shadow: 0 0 0 1px rgba(120, 180, 255, 0.25), 0 18px 52px rgba(41, 112, 255, 0.3);
+  box-shadow: 0 0 0 1px rgba(110, 198, 255, 0.35), 0 22px 56px rgba(13, 90, 190, 0.4);
 }
 
 .btn-secondary {
@@ -243,15 +410,17 @@ summary:focus-visible {
   padding: 0.75rem 1.25rem;
   border-radius: 1.25rem;
   font-weight: 500;
-  color: rgba(255, 255, 255, 0.85);
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  transition: background-color 0.2s ease, transform 0.2s ease;
+  color: rgba(232, 244, 255, 0.9);
+  background: linear-gradient(135deg, rgba(7, 36, 84, 0.65), rgba(11, 68, 148, 0.68));
+  border: 1px solid rgba(110, 198, 255, 0.35);
+  box-shadow: 0 12px 28px rgba(5, 24, 62, 0.45);
+  transition: background-color 0.25s ease, transform 0.25s ease, box-shadow 0.25s ease;
 }
 
 .btn-secondary:hover {
-  background: rgba(255, 255, 255, 0.1);
+  background: linear-gradient(135deg, rgba(9, 48, 105, 0.78), rgba(17, 92, 190, 0.78));
   transform: translateY(-1px);
+  box-shadow: 0 14px 34px rgba(6, 28, 70, 0.52);
 }
 
 .search-panel {
@@ -260,12 +429,12 @@ summary:focus-visible {
   left: 0;
   right: 0;
   margin-top: 0.75rem;
-  background: rgba(12, 18, 32, 0.95);
+  background: rgba(5, 16, 42, 0.96);
   border-radius: 1rem;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
+  border: 1px solid rgba(110, 198, 255, 0.3);
+  box-shadow: 0 24px 52px rgba(3, 16, 42, 0.6);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
   padding: 0.75rem 0;
   display: none;
   max-height: 24rem;
@@ -280,14 +449,15 @@ summary:focus-visible {
 .search-result-item {
   display: block;
   padding: 0.75rem 1.25rem;
-  color: rgba(255, 255, 255, 0.85);
+  color: rgba(229, 241, 255, 0.9);
   text-decoration: none;
-  transition: background-color 0.2s ease;
+  transition: background 0.25s ease, transform 0.25s ease;
 }
 
 .search-result-item:hover,
 .search-result-item:focus-visible {
-  background: rgba(78, 114, 255, 0.18);
+  background: linear-gradient(135deg, rgba(33, 126, 255, 0.35), rgba(12, 78, 168, 0.45));
+  transform: translateX(4px);
 }
 
 .search-result-item small {
@@ -300,9 +470,9 @@ summary:focus-visible {
 .mobile-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(7, 11, 20, 0.65);
-  backdrop-filter: blur(2px);
-  -webkit-backdrop-filter: blur(2px);
+  background: rgba(3, 12, 28, 0.7);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
   display: none;
   z-index: 60;
 }
@@ -315,16 +485,66 @@ summary:focus-visible {
   position: fixed;
   inset: 0 0 0 auto;
   width: min(20rem, 88vw);
-  background: rgba(12, 18, 32, 0.95);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  border-left: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: -20px 0 50px rgba(0, 0, 0, 0.35);
+  background: linear-gradient(160deg, rgba(5, 16, 42, 0.97), rgba(10, 52, 132, 0.96));
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  border-left: 1px solid rgba(110, 198, 255, 0.35);
+  box-shadow: -26px 0 60px rgba(3, 14, 34, 0.55);
   transform: translateX(100%);
   transition: transform 0.3s cubic-bezier(.22,.61,.36,1);
   z-index: 70;
   display: flex;
   flex-direction: column;
+}
+
+.mobile-drawer button[data-mobile-toggle] {
+  border-radius: 9999px;
+  border: 1px solid rgba(110, 198, 255, 0.35);
+  background: rgba(6, 29, 72, 0.65);
+  color: rgba(229, 241, 255, 0.9);
+  padding: 0.4rem 0.9rem;
+  transition: background 0.25s ease, transform 0.25s ease;
+}
+
+.mobile-drawer button[data-mobile-toggle]:hover,
+.mobile-drawer button[data-mobile-toggle]:focus-visible {
+  background: rgba(12, 66, 150, 0.8);
+  transform: translateY(-1px);
+}
+
+.mobile-drawer nav a {
+  display: block;
+  border-radius: 1rem;
+  border: 1px solid rgba(110, 198, 255, 0.2);
+  background: rgba(7, 29, 70, 0.58);
+  color: rgba(225, 238, 255, 0.85) !important;
+  transition: background 0.25s ease, transform 0.25s ease, color 0.25s ease;
+}
+
+.mobile-drawer nav a:hover,
+.mobile-drawer nav a:focus-visible {
+  background: linear-gradient(135deg, rgba(33, 126, 255, 0.45), rgba(12, 78, 168, 0.55));
+  color: #f8fbff !important;
+  transform: translateX(6px);
+}
+
+.mobile-drawer input[type="search"] {
+  border-radius: 9999px;
+  border: 1px solid rgba(110, 198, 255, 0.35);
+  background: rgba(5, 24, 58, 0.6);
+  color: #e9f4ff;
+  padding: 0.6rem 1rem;
+}
+
+.mobile-drawer input[type="search"]::placeholder {
+  color: rgba(206, 229, 255, 0.55);
+}
+
+.mobile-drawer input[type="search"]:focus {
+  border-color: rgba(109, 230, 255, 0.85);
+  box-shadow: 0 0 0 4px rgba(109, 230, 255, 0.22);
+  background: rgba(5, 37, 86, 0.78);
+  outline: none;
 }
 
 .mobile-drawer.active {


### PR DESCRIPTION
## Summary
- replace the site-wide header with the official Telcoin Wiki wordmark and updated navigation/search controls
- realign Tailwind color tokens and custom CSS to the new Telx gradient palette across desktop and mobile experiences
- add the refreshed Telcoin Wiki SVG asset for reuse in the header

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ca27081fe88330964a44c04cd84b6f