### PR TITLE
Enhance header glass styling and mobile nav

### DIFF
--- a/styles/site.css
+++ b/styles/site.css
@@ -63,31 +63,36 @@ main {
   position: sticky;
   top: 0;
   z-index: 70;
-  background: linear-gradient(120deg, rgba(5, 16, 42, 0.94) 0%, rgba(9, 43, 104, 0.96) 52%, rgba(14, 114, 202, 0.96) 100%);
+  background: linear-gradient(120deg, rgba(5, 16, 42, 0.78) 0%, rgba(9, 43, 104, 0.82) 52%, rgba(14, 114, 202, 0.82) 100%);
   border-bottom: 1px solid rgba(108, 199, 255, 0.38);
-  box-shadow: 0 18px 45px -20px rgba(3, 15, 40, 0.85);
-  backdrop-filter: blur(18px);
-  -webkit-backdrop-filter: blur(18px);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 22px 55px -24px rgba(3, 15, 40, 0.85);
+  backdrop-filter: blur(22px) saturate(140%);
+  -webkit-backdrop-filter: blur(22px) saturate(140%);
   overflow: hidden;
+  isolation: isolate;
 }
 
 .site-header::before {
   content: "";
   position: absolute;
-  inset: -40% -20% -60% -20%;
+  inset: -42% -26% -64% -26%;
   background:
     radial-gradient(120% 120% at 12% 10%, rgba(109, 230, 255, 0.28), transparent 60%),
     radial-gradient(110% 80% at 88% 0%, rgba(30, 107, 255, 0.45), transparent 70%);
-  opacity: 0.75;
+  opacity: 0.8;
   pointer-events: none;
+  filter: blur(8px);
+  transform: translate3d(0, 0, 0);
 }
 
 .site-header::after {
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(180deg, rgba(5, 17, 42, 0.25) 0%, rgba(5, 17, 42, 0.55) 100%);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.04) 0%, rgba(5, 17, 42, 0.6) 55%, rgba(5, 17, 42, 0.85) 100%);
   pointer-events: none;
+  box-shadow: inset 0 0 0 1px rgba(109, 230, 255, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
 .site-header__inner {


### PR DESCRIPTION
## Summary
- rework the sticky header layering to deliver a glass treatment without changing the existing palette
- refine header overlays with subtle blur and edge highlights for added depth
- harden the mobile navigation drawer toggles so multiple buttons, focus handling, and desktop breakpoints behave reliably

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca9b087fcc8330b7fac90f4e0e350c