### PR TITLE
Improve mobile responsiveness across the site

### DIFF
--- a/about.html
+++ b/about.html
@@ -202,5 +202,6 @@
     <script src="/js/copy-code.js"></script>
     <script src="/js/lightbox.js"></script>
     <script src="/js/search.js"></script>
+    <script src="/js/mobile-optimizations.js"></script>
 </body>
 </html>

--- a/deep-dive.html
+++ b/deep-dive.html
@@ -628,6 +628,7 @@
                     wrapper.appendChild(table);
                 }
                 table.classList.add('table-glass', 'text-sm');
+                table.setAttribute('data-responsive-table', '');
             });
             document.querySelectorAll('#deepDiveContent figure img').forEach((img) => {
                 img.setAttribute('loading', 'lazy');
@@ -726,5 +727,6 @@
     <script src="/js/copy-code.js"></script>
     <script src="/js/lightbox.js"></script>
     <script src="/js/search.js"></script>
+    <script src="/js/mobile-optimizations.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -673,5 +673,6 @@
     <script src="/js/copy-code.js"></script>
     <script src="/js/lightbox.js"></script>
     <script src="/js/search.js"></script>
+    <script src="/js/mobile-optimizations.js"></script>
 </body>
 </html>

--- a/js/mobile-optimizations.js
+++ b/js/mobile-optimizations.js
@@ -1,0 +1,68 @@
+(function () {
+  'use strict';
+  const processedTables = new WeakSet();
+
+  function getHeaderLabels(table) {
+    const headCells = Array.from(table.querySelectorAll('thead th'));
+    if (headCells.length) {
+      return headCells.map((cell) => cell.textContent.trim());
+    }
+    const firstRow = table.querySelector('tbody tr');
+    if (!firstRow) return [];
+    return Array.from(firstRow.children).map((cell) => cell.textContent.trim());
+  }
+
+  function decorateTable(table) {
+    if (!table || processedTables.has(table)) {
+      return;
+    }
+
+    const labels = getHeaderLabels(table);
+    if (!labels.length) {
+      return;
+    }
+
+    const rows = Array.from(table.querySelectorAll('tbody tr'));
+    rows.forEach((row) => {
+      Array.from(row.children).forEach((cell, index) => {
+        if (!(cell instanceof HTMLElement)) return;
+        if (!cell.hasAttribute('data-label') && labels[index]) {
+          cell.setAttribute('data-label', labels[index]);
+        }
+      });
+    });
+
+    processedTables.add(table);
+  }
+
+  function enhanceTables(root = document) {
+    const tables = Array.from(root.querySelectorAll('[data-responsive-table]'));
+    tables.forEach(decorateTable);
+  }
+
+  const observer = new MutationObserver((mutations) => {
+    let shouldRun = false;
+    mutations.forEach((mutation) => {
+      if (mutation.type === 'childList') {
+        mutation.addedNodes.forEach((node) => {
+          if (node.nodeType === Node.ELEMENT_NODE) {
+            if (node.matches?.('[data-responsive-table]')) {
+              decorateTable(node);
+            } else if (node.querySelector?.('[data-responsive-table]')) {
+              shouldRun = true;
+            }
+          }
+        });
+      }
+    });
+
+    if (shouldRun) {
+      enhanceTables();
+    }
+  });
+
+  document.addEventListener('DOMContentLoaded', () => {
+    enhanceTables();
+    observer.observe(document.body, { childList: true, subtree: true });
+  });
+})();

--- a/links.html
+++ b/links.html
@@ -387,5 +387,6 @@
     <script src="/js/copy-code.js"></script>
     <script src="/js/lightbox.js"></script>
     <script src="/js/search.js"></script>
+    <script src="/js/mobile-optimizations.js"></script>
 </body>
 </html>

--- a/pools.html
+++ b/pools.html
@@ -110,8 +110,8 @@
                     <h1 class="mt-6 text-4xl font-semibold tracking-tight text-white sm:text-5xl">Pools overview</h1>
                     <p class="mt-4 text-lg text-white/70">Monitor the health of Telcoin’s on-chain liquidity. Status chips reflect governance-defined lifecycle stages; metrics refresh alongside community updates.</p>
                 </div>
-                <div class="mt-10 overflow-hidden rounded-3xl border border-white/10 bg-white/5">
-                    <table class="table-glass">
+                <div class="mt-10 table-container rounded-3xl border border-white/10 bg-white/5">
+                    <table class="table-glass" data-responsive-table>
                         <thead>
                             <tr>
                                 <th>Pool</th>
@@ -224,5 +224,6 @@
     <script src="/js/copy-code.js"></script>
     <script src="/js/lightbox.js"></script>
     <script src="/js/search.js"></script>
+    <script src="/js/mobile-optimizations.js"></script>
 </body>
 </html>

--- a/portfolio.html
+++ b/portfolio.html
@@ -248,5 +248,6 @@
     <script src="/js/copy-code.js"></script>
     <script src="/js/lightbox.js"></script>
     <script src="/js/search.js"></script>
+    <script src="/js/mobile-optimizations.js"></script>
 </body>
 </html>

--- a/styles/site.css
+++ b/styles/site.css
@@ -6,6 +6,7 @@
 
 html {
   scroll-behavior: smooth;
+  font-size: clamp(15px, 0.45vw + 14px, 17px);
 }
 
 body {
@@ -22,6 +23,8 @@ body {
   display: flex;
   flex-direction: column;
   position: relative;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
 body::before {
@@ -158,6 +161,10 @@ main {
   background: linear-gradient(135deg, rgba(33, 126, 255, 0.42), rgba(12, 78, 168, 0.55));
   box-shadow: 0 14px 30px rgba(6, 30, 76, 0.45);
   transform: translateY(-1px);
+}
+
+:where(h1, h2, h3, h4, h5) {
+  text-wrap: balance;
 }
 
 .site-nav__link[aria-current="page"] {
@@ -353,36 +360,195 @@ summary:focus-visible {
   border-color: rgba(56, 189, 248, 0.3);
 }
 
-.table-glass {
-  width: 100%;
-  border-collapse: collapse;
-  border-radius: 1rem;
+.table-container {
   overflow: hidden;
+  border-radius: 1.75rem;
 }
 
-.table-glass thead {
+.table-glass,
+.platform-table,
+.governance-table,
+.resources-table {
+  width: 100%;
+  border-collapse: collapse;
+  border-radius: 1.25rem;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.table-glass thead,
+.platform-table thead,
+.governance-table thead,
+.resources-table thead {
   background: rgba(255, 255, 255, 0.05);
 }
 
 .table-glass th,
-.table-glass td {
+.table-glass td,
+.platform-table th,
+.platform-table td,
+.governance-table th,
+.governance-table td,
+.resources-table th,
+.resources-table td {
   padding: 0.85rem 1rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
   text-align: left;
+  vertical-align: top;
 }
 
-.table-glass th {
+.table-glass th,
+.platform-table th,
+.governance-table th,
+.resources-table th {
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.72);
   border-top: none;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
-.table-glass tbody tr {
+.table-glass tbody tr,
+.platform-table tbody tr,
+.governance-table tbody tr,
+.resources-table tbody tr {
   transition: background-color 0.2s ease;
 }
 
-.table-glass tbody tr:hover {
+.table-glass tbody tr:hover,
+.platform-table tbody tr:hover,
+.governance-table tbody tr:hover,
+.resources-table tbody tr:hover {
   background: rgba(255, 255, 255, 0.05);
+}
+
+[data-responsive-table] {
+  width: 100%;
+}
+
+[data-responsive-table] tbody td[data-label] {
+  position: relative;
+}
+
+@media (max-width: 768px) {
+  .site-header__brand {
+    padding: 0.5rem 0.7rem;
+  }
+
+  .site-header__logo {
+    height: 38px;
+  }
+
+  .table-container {
+    border-radius: 1.25rem;
+    overflow: visible;
+  }
+
+  .table-wrapper > table,
+  .table-container > table {
+    min-width: 0;
+  }
+
+  [data-responsive-table] {
+    display: block;
+    border-radius: 1.25rem;
+  }
+
+  [data-responsive-table] thead {
+    display: none;
+  }
+
+  [data-responsive-table] tbody {
+    display: grid;
+    gap: 1rem;
+  }
+
+  [data-responsive-table] tbody tr {
+    display: grid;
+    gap: 0.85rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 1.15rem;
+    padding: 1.1rem 1.2rem;
+    background: rgba(4, 17, 42, 0.65);
+    box-shadow: 0 16px 34px rgba(3, 16, 42, 0.4);
+  }
+
+  .table-container [data-responsive-table] tbody tr,
+  .table-wrapper [data-responsive-table] tbody tr {
+    background: rgba(255, 255, 255, 0.05);
+  }
+
+  [data-responsive-table] tbody tr td {
+    padding: 0;
+    border: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: 0.95rem;
+    color: rgba(232, 244, 255, 0.92);
+  }
+
+  [data-responsive-table] tbody tr td + td {
+    margin-top: 0.75rem;
+  }
+
+  [data-responsive-table] tbody tr td::before {
+    content: attr(data-label);
+    font-size: 0.7rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: rgba(206, 229, 255, 0.65);
+    font-weight: 600;
+  }
+
+  [data-responsive-table] .chip {
+    align-self: flex-start;
+  }
+
+  .stat-value {
+    font-size: 1.1rem;
+  }
+
+  .stat-label {
+    font-size: 0.7rem;
+    letter-spacing: 0.12em;
+  }
+
+  #hero h1 {
+    font-size: clamp(2.1rem, 7.5vw + 1rem, 2.75rem);
+    line-height: 1.2;
+  }
+
+  #hero p {
+    font-size: clamp(1rem, 3vw + 0.3rem, 1.15rem);
+  }
+
+  #hero .glass {
+    padding: 1.25rem;
+  }
+
+  article.glass > header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  article.glass > header .btn-primary,
+  article.glass > header .btn-secondary {
+    width: 100%;
+  }
+
+  .callout-info,
+  .callout-success,
+  .callout-warning,
+  .callout-danger {
+    padding: 1rem 1.1rem;
+  }
+
+  .table-wrapper {
+    overflow-x: visible;
+  }
 }
 
 .btn-primary {
@@ -736,5 +902,11 @@ pre {
 
 .table-wrapper {
   margin-top: 1.25rem;
+  overflow-x: auto;
+  border-radius: 1.5rem;
+}
+
+.table-wrapper > table {
+  min-width: 640px;
 }
 


### PR DESCRIPTION
## Summary
- tune the global stylesheet for smaller viewports, including base typography smoothing and shared glass table styling
- add a responsive table stack pattern and script-driven data labels so pool and deep-dive tables remain readable on phones
- load the new mobile enhancements script across the static pages and flag generated tables for the responsive treatment

## Testing
- Not run (static content only)


------
https://chatgpt.com/codex/tasks/task_e_68ca9cdd5184833088ae91f1488349f4