### PR TITLE
Allow community dropdown to fully expand

### DIFF
--- a/styles/site.css
+++ b/styles/site.css
@@ -65,13 +65,14 @@ main {
 .site-header {
   position: sticky;
   top: 0;
-  z-index: 70;
+  z-index: 1000;
   background: linear-gradient(120deg, rgba(5, 16, 42, 0.94) 0%, rgba(9, 43, 104, 0.96) 52%, rgba(14, 114, 202, 0.96) 100%);
   border-bottom: 1px solid rgba(108, 199, 255, 0.38);
   box-shadow: 0 18px 45px -20px rgba(3, 15, 40, 0.85);
   backdrop-filter: blur(18px);
   -webkit-backdrop-filter: blur(18px);
-  overflow: hidden;
+  overflow: visible;
+  isolation: isolate;
 }
 
 .site-header::before {
@@ -83,6 +84,8 @@ main {
     radial-gradient(110% 80% at 88% 0%, rgba(30, 107, 255, 0.45), transparent 70%);
   opacity: 0.75;
   pointer-events: none;
+  -webkit-clip-path: inset(0 round 0);
+  clip-path: inset(0 round 0);
 }
 
 .site-header::after {
@@ -286,6 +289,22 @@ summary:focus-visible {
 .glass:focus-within {
   transform: scale(1.01);
   box-shadow: 0 0 0 1px rgba(120, 180, 255, 0.18), 0 14px 44px rgba(41, 112, 255, 0.22);
+}
+
+#joinCommunityChecklist {
+  position: relative;
+}
+
+#joinCommunityDropdown {
+  z-index: 80;
+}
+
+@media (max-width: 1023px) {
+  #joinCommunityDropdown {
+    position: static;
+    width: 100%;
+    margin-top: 1rem;
+  }
 }
 
 .stat-label {
@@ -605,7 +624,7 @@ summary:focus-visible {
   display: none;
   max-height: 24rem;
   overflow-y: auto;
-  z-index: 70;
+  z-index: 1010;
 }
 
 .search-panel[aria-hidden="false"] {
@@ -640,7 +659,7 @@ summary:focus-visible {
   backdrop-filter: blur(4px);
   -webkit-backdrop-filter: blur(4px);
   display: none;
-  z-index: 60;
+  z-index: 1020;
 }
 
 .mobile-overlay.active {
@@ -658,7 +677,7 @@ summary:focus-visible {
   box-shadow: -26px 0 60px rgba(3, 14, 34, 0.55);
   transform: translateX(100%);
   transition: transform 0.3s cubic-bezier(.22,.61,.36,1);
-  z-index: 70;
+  z-index: 1030;
   display: flex;
   flex-direction: column;
 }
@@ -797,7 +816,7 @@ pre {
   align-items: center;
   justify-content: center;
   padding: 2rem;
-  z-index: 80;
+  z-index: 1200;
   opacity: 0;
   transition: opacity 0.2s ease;
 }


### PR DESCRIPTION
## Summary
- keep the Join the Community checklist anchored with an explicit stacking context
- let its dropdown switch to static positioning below 1024px so the menu expands in the document flow instead of being clipped

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68caa8fe12f08330ac13c3ae2fbbf342