### PR TITLE
Scale header logo size on large screens

### DIFF
--- a/styles/site.css
+++ b/styles/site.css
@@ -127,7 +127,7 @@ main {
 
 @media (min-width: 1024px) {
   .site-header__logo {
-    height: 48px;
+    height: clamp(56px, 5vw, 72px);
   }
 }
 


### PR DESCRIPTION
## Summary
- increase the desktop logo size by using a clamp-based height at large breakpoints
- retain the existing mobile logo sizing rules so the small-screen appearance stays the same

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cacf7a0e34833099cfe741bd5315ab