### PR TITLE
Fix mobile drawer height

### DIFF
--- a/styles/site.css
+++ b/styles/site.css
@@ -660,6 +660,7 @@ summary:focus-visible {
   -webkit-backdrop-filter: blur(4px);
   display: none;
   z-index: 1020;
+  height: 100vh;
 }
 
 .mobile-overlay.active {
@@ -680,6 +681,19 @@ summary:focus-visible {
   z-index: 1030;
   display: flex;
   flex-direction: column;
+  height: 100vh;
+  max-height: 100vh;
+}
+
+@supports (height: 100dvh) {
+  .mobile-overlay {
+    height: 100dvh;
+  }
+
+  .mobile-drawer {
+    height: 100dvh;
+    max-height: 100dvh;
+  }
 }
 
 .mobile-drawer button[data-mobile-toggle] {


### PR DESCRIPTION
## Summary
- ensure the mobile overlay and drawer span the full viewport height so the menu fully opens
- add support for dynamic viewport units to cover iOS/Android browser chrome adjustments

## Testing
- manual Playwright check of the mobile drawer (http://127.0.0.1:8000/index.html)

------
https://chatgpt.com/codex/tasks/task_e_68cb1b447c2c8330a88f5f481ab24d85