### PR TITLE
Make theme follow system preference and update deep dive navigation

### DIFF
--- a/about.html
+++ b/about.html
@@ -33,6 +33,16 @@
     }
   }
     </script>
+    <script>
+      (function () {
+        const root = document.documentElement;
+        if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+          root.classList.add('dark');
+        } else {
+          root.classList.remove('dark');
+        }
+      })();
+    </script>
     <link rel="stylesheet" href="/styles/site.css">
 </head>
 <body data-page="about" class="bg-ink-950 text-white/90 antialiased">
@@ -51,8 +61,7 @@
                         <div class="search-panel" data-search-results aria-hidden="true"></div>
                     </div>
                 </div>
-                <div class="flex items-center gap-2">
-                    <button type="button" data-theme-toggle class="icon-button focus-ring"><span aria-hidden="true">🌗</span><span class="sr-only">Toggle theme</span></button>
+                <div class="flex items-center">
                     <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button lg:hidden focus-ring">
                         <span class="sr-only">Open navigation</span>
                         ☰

--- a/deep-dive.html
+++ b/deep-dive.html
@@ -143,6 +143,16 @@
     }
   }
     </script>
+    <script>
+      (function () {
+        const root = document.documentElement;
+        if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+          root.classList.add('dark');
+        } else {
+          root.classList.remove('dark');
+        }
+      })();
+    </script>
     <link rel="stylesheet" href="/styles/site.css">
 </head>
 <body data-page="deep-dive" class="bg-ink-950 text-white/90 antialiased">
@@ -161,8 +171,7 @@
                         <div class="search-panel" data-search-results aria-hidden="true"></div>
                     </div>
                 </div>
-                <div class="flex items-center gap-2">
-                    <button type="button" data-theme-toggle class="icon-button focus-ring"><span aria-hidden="true">🌗</span><span class="sr-only">Toggle theme</span></button>
+                <div class="flex items-center">
                     <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button lg:hidden focus-ring">
                         <span class="sr-only">Open navigation</span>
                         ☰

--- a/index.html
+++ b/index.html
@@ -116,6 +116,16 @@
     }
   }
     </script>
+    <script>
+      (function () {
+        const root = document.documentElement;
+        if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+          root.classList.add('dark');
+        } else {
+          root.classList.remove('dark');
+        }
+      })();
+    </script>
     <link rel="stylesheet" href="/styles/site.css">
 </head>
 <body data-page="index" class="bg-ink-950 text-white/90 antialiased">
@@ -134,8 +144,7 @@
                         <div class="search-panel" data-search-results aria-hidden="true"></div>
                     </div>
                 </div>
-                <div class="flex items-center gap-2">
-                    <button type="button" data-theme-toggle class="icon-button focus-ring"><span aria-hidden="true">🌗</span><span class="sr-only">Toggle theme</span></button>
+                <div class="flex items-center">
                     <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button lg:hidden focus-ring">
                         <span class="sr-only">Open navigation</span>
                         ☰
@@ -341,7 +350,7 @@
 <li>Telcoin (TEL) is a blockchain-based platform established in Singapore in 2017, aiming to make affordable remittances accessible globally through mobile networks and decentralized finance (DeFi) solutions.</li>
 <li>Its core mission is to bridge traditional fiat currencies and digital assets by providing fast, affordable, and compliant infrastructure for mobile-based financial services.</li>
 <li>The platform emphasizes a "RegFi" (regulated DeFi) model, integrating telecom partners as compliance-aware on-ramps and off-ramps.</li>
-<li><a href="deep-dive.html?category=differentiators" target="_blank" class="citation-link">See Deep Dive: Telcoin Differentiators</a></li>
+<li><a href="deep-dive.html?category=differentiators" class="citation-link">See Deep Dive: Telcoin Differentiators</a></li>
 </ul>`
             },
             {
@@ -353,7 +362,7 @@
 <li>Regulated DeFi (RegFi): Integrates traditional finance with blockchain through regulatory adherence, exemplified by Telcoin Bank and eUSD.</li>
 <li>User Ownership: Designed to be user-owned with governance and economic incentives distributed across its layers.</li>
 <li>Digital Cash: Developing multi-currency stablecoins (e.g., eUSD, eEUR) for seamless cross-border payments and blockchain banking.</li>
-<li><a href="deep-dive.html?category=differentiators" target="_blank" class="citation-link">See Deep Dive: Telcoin Differentiators</a></li>
+<li><a href="deep-dive.html?category=differentiators" class="citation-link">See Deep Dive: Telcoin Differentiators</a></li>
 </ul>`
             },
             {
@@ -382,7 +391,7 @@
 <li>Native Utility Token: TEL is the native token of the Telcoin platform, used for governance, staking, and ecosystem incentives.</li>
 <li>Multi-Chain: Initially launched on Ethereum, TEL is now available on Polygon and other EVM-compatible chains.</li>
 <li>Tokenomics: Total supply is capped, with a portion allocated for ecosystem development and community incentives.</li>
-<li><a href="deep-dive.html?category=tokenomics" target="_blank" class="citation-link">See Deep Dive: Tokenomics</a></li>
+<li><a href="deep-dive.html?category=tokenomics" class="citation-link">See Deep Dive: Tokenomics</a></li>
 </ul>`
             },
             {
@@ -392,7 +401,7 @@
 <li>It's a Swiss-based non-profit organization that legally represents the Telcoin Platform's decentralized governance structure.</li>
 <li>Its mission is to represent the interests of GSMA Mobile Networks and other stakeholders in the ongoing maintenance and development of the Telcoin Network.</li>
 <li>It oversees the platform through various "Miner Councils" that manage different aspects of the network, ensuring long-term sustainability and self-management.</li>
-<li><a href="deep-dive.html?category=governance" target="_blank" class="citation-link">See Deep Dive: Association Governance</a></li>
+<li><a href="deep-dive.html?category=governance" class="citation-link">See Deep Dive: Association Governance</a></li>
 </ul>`
             },
             {
@@ -403,7 +412,7 @@
 <li>TELx Council: Manages the decentralized exchange (TELx), including liquidity allocation and incentive distribution.</li>
 <li>TAN Council: Governs the Telcoin Application Network (TAN), ensuring transparent rules for mobile access and user-level rewards.</li>
 <li>Compliance Council: Enforces platform rules and external regulations, with the authority to veto transactions that violate these standards.</li>
-<li><a href="deep-dive.html?category=governance" target="_blank" class="citation-link">See Deep Dive: Association Governance</a></li>
+<li><a href="deep-dive.html?category=governance" class="citation-link">See Deep Dive: Association Governance</a></li>
 </ul>`
             },
             {
@@ -412,7 +421,7 @@
                 answer: `<ul>
 <li>Telcoin Holdings: This is the Singapore-based for-profit entity that initially founded Telcoin and is responsible for developing and operating Telcoin applications and services, such as the Telcoin Wallet.</li>
 <li>Telcoin Association: This is the Swiss-based non-profit organization that governs the underlying Telcoin Network and manages the TEL token, representing the interests of stakeholders in the decentralized protocol.</li>
-<li><a href="deep-dive.html?category=governance" target="_blank" class="citation-link">See Deep Dive: Association Governance</a></li>
+<li><a href="deep-dive.html?category=governance" class="citation-link">See Deep Dive: Association Governance</a></li>
 </ul>`
             },
             {
@@ -422,7 +431,7 @@
 <li>TANIP1 stands for Telcoin Application Network Improvement Proposal 1.</li>
 <li>Its core purpose is to activate and define the mechanisms for distributing TEL incentives to stakers within the Telcoin Application Network (TAN).</li>
 <li>It focuses on a referral program as the primary means for regular users to earn TEL rewards by referring new users who actively transact on the Telcoin App.</li>
-<li><a href="deep-dive.html?category=earning" target="_blank" class="citation-link">See Deep Dive: Earning Mechanisms</a></li>
+<li><a href="deep-dive.html?category=earning" class="citation-link">See Deep Dive: Earning Mechanisms</a></li>
 </ul>`
             },
             {
@@ -433,7 +442,7 @@
 <li>It operates on a permissioned Proof-of-Stake (PoS) consensus mechanism, where only GSMA full-member Mobile Network Operators (MNOs) are authorized to validate blocks and earn rewards.</li>
 <li>The network currently reports "all systems operational" with no incidents for the past month, indicating stability.</li>
 <li>The Telcoin Network roadmap includes Alpha Mainnet (2025 Q3 - In Progress) and Beta Mainnet (2025 Q4).</li>
-<li><a href="deep-dive.html?category=network" target="_blank" class="citation-link">See Deep Dive: Network Status</a></li>
+<li><a href="deep-dive.html?category=network" class="citation-link">See Deep Dive: Network Status</a></li>
 </ul>`
             },
             {
@@ -443,7 +452,7 @@
 <li>Telcoin received conditional approval to open Nebraska's first Digital Asset Bank in February 2025.</li>
 <li>Telcoin Bank is scheduled to commence operations "early this year" (referring to 2025) and anticipates receiving the full charter in the near future.</li>
 <li>After approval, Telcoin Bank is poised to offer regulated "Digital Cash" stablecoins (like eUSD in 2025) and blockchain banking services.</li>
-<li><a href="deep-dive.html?category=banking" target="_blank" class="citation-link">See Deep Dive: Bank & Digital Cash</a></li>
+<li><a href="deep-dive.html?category=banking" class="citation-link">See Deep Dive: Bank & Digital Cash</a></li>
 </ul>`
             },
             {
@@ -453,7 +462,7 @@
 <li>TEL is currently tradable on exchanges like KuCoin, Bitget, and others.</li>
 <li>It is not currently listed on major US-centric Tier-1 exchanges like Coinbase or Binance.</li>
 <li>Telcoin's "RegFi" approach suggests a focus on regulated product development before pursuing listings on certain top-tier exchanges.</li>
-<li><a href="deep-dive.html?category=marketing" target="_blank" class="citation-link">See Deep Dive: Marketing Strategy</a></li>
+<li><a href="deep-dive.html?category=marketing" class="citation-link">See Deep Dive: Marketing Strategy</a></li>
 </ul>`
             },
             {
@@ -463,7 +472,7 @@
 <li><strong>Centralized Exchanges:</strong> KuCoin, Bitget, MEXC, Bybit, etc.</li>
 <li><strong>Wallets/Apps:</strong> The Telcoin App itself is a primary option.</li>
 <li><strong>Decentralized Exchanges (DEXs):</strong> Uniswap and Balancer.</li>
-<li><a href="deep-dive.html?category=getting-started" target="_blank" class="citation-link">See Deep Dive: Getting Started</a></li>
+<li><a href="deep-dive.html?category=getting-started" class="citation-link">See Deep Dive: Getting Started</a></li>
 </ul>`
             },
             {
@@ -473,7 +482,7 @@
 <li>The primary method for users to earn TEL from staking in the app is via a referral program.</li>
 <li>Users stake TEL as "Proof of Alignment" and then earn a percentage of transaction fees from users they refer.</li>
 <li>Direct network validation staking is reserved for GSMA mobile network operators.</li>
-<li><a href="deep-dive.html?category=earning" target="_blank" class="citation-link">See Deep Dive: Earning Mechanisms</a></li>
+<li><a href="deep-dive.html?category=earning" class="citation-link">See Deep Dive: Earning Mechanisms</a></li>
 </ul>`
             },
             {
@@ -638,7 +647,7 @@
             const considerStakingChecklist = document.getElementById('considerStakingChecklist');
             if (considerStakingChecklist) {
                 considerStakingChecklist.addEventListener('click', () => {
-                    window.open('deep-dive.html?category=earning', '_blank');
+                    window.location.href = 'deep-dive.html?category=earning';
                 });
             }
 

--- a/links.html
+++ b/links.html
@@ -174,6 +174,16 @@
     }
   }
     </script>
+    <script>
+      (function () {
+        const root = document.documentElement;
+        if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+          root.classList.add('dark');
+        } else {
+          root.classList.remove('dark');
+        }
+      })();
+    </script>
     <link rel="stylesheet" href="/styles/site.css">
 </head>
 <body data-page="links" class="bg-ink-950 text-white/90 antialiased">
@@ -192,8 +202,7 @@
                         <div class="search-panel" data-search-results aria-hidden="true"></div>
                     </div>
                 </div>
-                <div class="flex items-center gap-2">
-                    <button type="button" data-theme-toggle class="icon-button focus-ring"><span aria-hidden="true">🌗</span><span class="sr-only">Toggle theme</span></button>
+                <div class="flex items-center">
                     <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button lg:hidden focus-ring">
                         <span class="sr-only">Open navigation</span>
                         ☰

--- a/pools.html
+++ b/pools.html
@@ -33,6 +33,16 @@
     }
   }
     </script>
+    <script>
+      (function () {
+        const root = document.documentElement;
+        if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+          root.classList.add('dark');
+        } else {
+          root.classList.remove('dark');
+        }
+      })();
+    </script>
     <link rel="stylesheet" href="/styles/site.css">
 </head>
 <body data-page="pools" class="bg-ink-950 text-white/90 antialiased">
@@ -51,8 +61,7 @@
                         <div class="search-panel" data-search-results aria-hidden="true"></div>
                     </div>
                 </div>
-                <div class="flex items-center gap-2">
-                    <button type="button" data-theme-toggle class="icon-button focus-ring"><span aria-hidden="true">🌗</span><span class="sr-only">Toggle theme</span></button>
+                <div class="flex items-center">
                     <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button lg:hidden focus-ring">
                         <span class="sr-only">Open navigation</span>
                         ☰

--- a/portfolio.html
+++ b/portfolio.html
@@ -33,6 +33,16 @@
     }
   }
     </script>
+    <script>
+      (function () {
+        const root = document.documentElement;
+        if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+          root.classList.add('dark');
+        } else {
+          root.classList.remove('dark');
+        }
+      })();
+    </script>
     <link rel="stylesheet" href="/styles/site.css">
 </head>
 <body data-page="portfolio" class="bg-ink-950 text-white/90 antialiased">
@@ -51,8 +61,7 @@
                         <div class="search-panel" data-search-results aria-hidden="true"></div>
                     </div>
                 </div>
-                <div class="flex items-center gap-2">
-                    <button type="button" data-theme-toggle class="icon-button focus-ring"><span aria-hidden="true">🌗</span><span class="sr-only">Toggle theme</span></button>
+                <div class="flex items-center">
                     <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button lg:hidden focus-ring">
                         <span class="sr-only">Open navigation</span>
                         ☰


### PR DESCRIPTION
## Summary
- apply the dark mode class based on prefers-color-scheme before styles load and drop the manual toggle buttons from each header
- update the theme toggle script to follow system changes and dispatch themechange events without storing user overrides
- open deep dive resources in the same tab by updating internal links and the checklist redirect

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d19775bf5c83309e450dae2a1489c9