### PR TITLE
Align secondary pages with primary layout and theme

### DIFF
--- a/about.html
+++ b/about.html
@@ -6,6 +6,7 @@
     <title>About TELx — Welcome to Telcoin’s Liquidity Engine</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="description" content="Learn how TELx blends design, liquidity mining, and user ownership to power Telcoin’s regulated DeFi ecosystem." />
+    <meta name="theme-color" content="#0066cc">
     <meta name="robots" content="index, follow">
     <link rel="icon" type="image/svg+xml" href="logo.svg">
 
@@ -56,7 +57,7 @@
                 </a>
                 <div class="flex flex-1 items-center justify-center">
                     <div class="relative w-full max-w-xl">
-                        <label for="site-search" class="sr-only">Search about TELx</label>
+                        <label for="site-search" class="sr-only">Search Telcoin Wiki</label>
                         <input id="site-search" data-site-search type="search" placeholder="Search this page" autocomplete="off" class="site-search-input">
                         <div class="search-panel" data-search-results aria-hidden="true"></div>
                     </div>
@@ -96,10 +97,10 @@
                         <nav data-docs-nav class="docs-nav space-y-3"></nav>
                     </aside>
                     <main id="main-content" class="space-y-16">
-                        <section id="about-overview" class="space-y-10">
+                        <section id="about-overview" class="space-y-10 pt-16 sm:pt-20">
                             <div class="grid gap-8 lg:grid-cols-[minmax(0,1fr)_18rem]">
                                 <div class="space-y-8">
-                                    <div class="glass p-8">
+                                    <div class="glass overflow-hidden border border-white/10 bg-white/5 p-8 shadow-glass">
                                         <p class="text-sm font-semibold uppercase tracking-[0.3em] text-mint-300/80">Welcome to TELx</p>
                                         <h1 class="mt-6 text-4xl font-semibold tracking-tight text-white sm:text-5xl">The decentralized liquidity engine of the Telcoin Platform</h1>
                                         <p class="mt-4 text-lg text-white/70">TELx orchestrates user-owned liquidity across Telcoin’s regulated DeFi stack. Designers, liquidity miners, and everyday users co-create a compliant, mobile-first financial network.</p>

--- a/deep-dive.html
+++ b/deep-dive.html
@@ -166,7 +166,7 @@
                 </a>
                 <div class="flex flex-1 items-center justify-center">
                     <div class="relative w-full max-w-xl">
-                        <label for="site-search" class="sr-only">Search Telcoin Deep Dive</label>
+                        <label for="site-search" class="sr-only">Search Telcoin Wiki</label>
                         <input id="site-search" data-site-search type="search" placeholder="Search this page" autocomplete="off" class="site-search-input">
                         <div class="search-panel" data-search-results aria-hidden="true"></div>
                     </div>
@@ -205,9 +205,9 @@
                     <aside class="hidden lg:block sticky top-16 h-[calc(100dvh-4rem)] overflow-y-auto pr-2" data-docs-sidebar>
                         <nav data-docs-nav class="docs-nav space-y-3"></nav>
                     </aside>
-                    <main id="main-content" class="space-y-12">
-                        <section class="space-y-8">
-                            <div class="glass p-8">
+                    <main id="main-content" class="space-y-16">
+                        <section class="space-y-8 pt-16 sm:pt-20">
+                            <div class="glass overflow-hidden border border-white/10 bg-white/5 p-8 shadow-glass">
                                 <p class="text-sm font-semibold uppercase tracking-[0.3em] text-mint-300/80">Deep dive knowledge base</p>
                                 <h1 class="mt-6 text-4xl font-semibold tracking-tight text-white sm:text-5xl">Explore Telcoin’s decentralized liquidity engine</h1>
                                 <p class="mt-4 text-lg text-white/70">This guide assembles the core research, governance documentation, and staking mechanics that power the Telcoin platform. Use the in-page navigation to jump between topics and copy snippets into your own research notes.</p>

--- a/links.html
+++ b/links.html
@@ -197,7 +197,7 @@
                 </a>
                 <div class="flex flex-1 items-center justify-center">
                     <div class="relative w-full max-w-xl">
-                        <label for="site-search" class="sr-only">Search Telcoin links</label>
+                        <label for="site-search" class="sr-only">Search Telcoin Wiki</label>
                         <input id="site-search" data-site-search type="search" placeholder="Search this page" autocomplete="off" class="site-search-input">
                         <div class="search-panel" data-search-results aria-hidden="true"></div>
                     </div>
@@ -236,9 +236,9 @@
                     <aside class="hidden lg:block sticky top-16 h-[calc(100dvh-4rem)] overflow-y-auto pr-2" data-docs-sidebar>
                         <nav data-docs-nav class="docs-nav space-y-3"></nav>
                     </aside>
-                    <main id="main-content" class="space-y-12">
-                        <section id="links-overview" class="space-y-8">
-                            <div class="glass p-8">
+                    <main id="main-content" class="space-y-16">
+                        <section id="links-overview" class="space-y-8 pt-16 sm:pt-20">
+                            <div class="glass overflow-hidden border border-white/10 bg-white/5 p-8 shadow-glass">
                                 <p class="text-sm font-semibold uppercase tracking-[0.3em] text-mint-300/80">Resource library</p>
                                 <h1 class="mt-6 text-4xl font-semibold tracking-tight text-white sm:text-5xl">Works cited &amp; trusted Telcoin resources</h1>
                                 <p class="mt-4 text-lg text-white/70">Every resource referenced across the Telcoin Wiki lives here. Explore official documentation, liquidity tools, regulatory filings, and community hubs—all organized into glass cards for quick scanning.</p>

--- a/pools.html
+++ b/pools.html
@@ -6,6 +6,7 @@
     <title>TELx Pools Dashboard — Telcoin Liquidity Overview</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="description" content="Snapshot of TELx liquidity pools with status chips, TVL, staking balances, 24h volume, fees, and reward programs." />
+    <meta name="theme-color" content="#0066cc">
     <meta name="robots" content="index, follow">
     <link rel="icon" type="image/svg+xml" href="logo.svg">
 
@@ -56,7 +57,7 @@
                 </a>
                 <div class="flex flex-1 items-center justify-center">
                     <div class="relative w-full max-w-xl">
-                        <label for="site-search" class="sr-only">Search TELx pools</label>
+                        <label for="site-search" class="sr-only">Search Telcoin Wiki</label>
                         <input id="site-search" data-site-search type="search" placeholder="Search this page" autocomplete="off" class="site-search-input">
                         <div class="search-panel" data-search-results aria-hidden="true"></div>
                     </div>
@@ -96,8 +97,8 @@
                         <nav data-docs-nav class="docs-nav space-y-3"></nav>
                     </aside>
                     <main id="main-content" class="space-y-16">
-                        <section id="pools-overview" class="space-y-8">
-                            <div class="glass p-8">
+                        <section id="pools-overview" class="space-y-8 pt-16 sm:pt-20">
+                            <div class="glass overflow-hidden border border-white/10 bg-white/5 p-8 shadow-glass">
                                 <p class="text-sm font-semibold uppercase tracking-[0.3em] text-mint-300/80">TELx liquidity radar</p>
                                 <h1 class="mt-6 text-4xl font-semibold tracking-tight text-white sm:text-5xl">Pools overview</h1>
                                 <p class="mt-4 text-lg text-white/70">Monitor the health of Telcoin’s on-chain liquidity. Status chips reflect governance-defined lifecycle stages; metrics refresh alongside community updates.</p>

--- a/portfolio.html
+++ b/portfolio.html
@@ -6,6 +6,7 @@
     <title>TELx Portfolio — Claimable Rewards & LPT Stakes</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="description" content="Track simulated TELx rewards, LPT stakes, and deprecated pool notices in a TELx-inspired portfolio dashboard." />
+    <meta name="theme-color" content="#0066cc">
     <meta name="robots" content="index, follow">
     <link rel="icon" type="image/svg+xml" href="logo.svg">
 
@@ -56,7 +57,7 @@
                 </a>
                 <div class="flex flex-1 items-center justify-center">
                     <div class="relative w-full max-w-xl">
-                        <label for="site-search" class="sr-only">Search TELx portfolio</label>
+                        <label for="site-search" class="sr-only">Search Telcoin Wiki</label>
                         <input id="site-search" data-site-search type="search" placeholder="Search this page" autocomplete="off" class="site-search-input">
                         <div class="search-panel" data-search-results aria-hidden="true"></div>
                     </div>
@@ -96,8 +97,8 @@
                         <nav data-docs-nav class="docs-nav space-y-3"></nav>
                     </aside>
                     <main id="main-content" class="space-y-16">
-                        <section id="portfolio-overview" class="space-y-8">
-                            <div class="glass p-8">
+                        <section id="portfolio-overview" class="space-y-8 pt-16 sm:pt-20">
+                            <div class="glass overflow-hidden border border-white/10 bg-white/5 p-8 shadow-glass">
                                 <p class="text-sm font-semibold uppercase tracking-[0.3em] text-mint-300/80">Portfolio snapshot</p>
                                 <h1 class="mt-6 text-4xl font-semibold tracking-tight text-white sm:text-5xl">Your TELx positions</h1>
                                 <p class="mt-4 text-lg text-white/70">A design-time view of TEL claimable rewards and liquidity provider tokens. Use it to imagine how TELx wallets surface positions with glass panels, friendly chips, and clear callouts.</p>


### PR DESCRIPTION
## Summary
- Give the hero sections on the About, Deep Dive, Links, Pools, and Portfolio pages the same glass card treatment and top spacing used on the homepage
- Standardise the header search label copy so every page presents the unified navigation from the main layout
- Add the missing theme-color meta tag to secondary pages so browser chrome matches the primary color scheme

## Testing
- Not run (static content update)

------
https://chatgpt.com/codex/tasks/task_e_68d285b1f8b88330b9eebf8c5c523161