### PR TITLE
Align deep dive styling with main theme

### DIFF
--- a/deep-dive.html
+++ b/deep-dive.html
@@ -310,7 +310,7 @@
                 </div>
                 <div class="deep-dive-section">
                     <h3>Council Membership Chart</h3>
-                    <table class="governance-table" style="width:100%;margin:2rem 0;">
+                    <table class="governance-table">
                         <thead>
                             <tr>
                                 <th>Council</th>
@@ -341,9 +341,9 @@
                             <tr><td>TELx Council</td><td>Validators</td><td>Mike McNearney</td></tr>
                         </tbody>
                     </table>
-                    <div style="text-align:center; margin: 2rem 0;">
-                        <img src="assets/governance-diagram-1.jpg" alt="Telcoin Governance Model Diagram 1" style="max-width:100%;margin-bottom:2rem;box-shadow:0 4px 20px rgba(0,0,0,0.08);border-radius:12px;" />
-                        <img src="assets/governance-diagram-2.jpg" alt="Telcoin Governance Model Diagram 2" style="max-width:100%;box-shadow:0 4px 20px rgba(0,0,0,0.08);border-radius:12px;" />
+                    <div class="deep-dive-media">
+                        <img src="assets/governance-diagram-1.jpg" alt="Telcoin Governance Model Diagram 1" class="deep-dive-media-img" />
+                        <img src="assets/governance-diagram-2.jpg" alt="Telcoin Governance Model Diagram 2" class="deep-dive-media-img" />
                     </div>
                 </div>
             `
@@ -376,9 +376,9 @@
                         <li><strong>Earn Rewards:</strong> By staking your LP tokens, you earn a portion of the trading fees generated within the pool, as well as TEL issuance incentives over time.</li>
                     </ol>
                     <p>For detailed information on each pool, including reward rates and vesting periods, please refer to the Rewards section on the Telx website.</p>
-                    <div style="background: #fff3cd; border-left: 4px solid #ffcc00; padding: 1rem; border-radius: 8px; margin-bottom: 1.5rem; color: #856404;">
-                        <h4 style="color:#c00; margin-top:0;">⚠️ Risk Warning & Disclaimer</h4>
-                        <ul style="margin-bottom:0;">
+                    <div class="deep-dive-callout">
+                        <h4>⚠️ Risk Warning & Disclaimer</h4>
+                        <ul>
                             <li><strong>Impermanent Loss:</strong> Providing liquidity to DeFi pools exposes you to impermanent loss, where the value of your deposited assets may decrease compared to simply holding them.</li>
                             <li><strong>Smart Contract Risk:</strong> All DeFi protocols, including TELx, carry risks of bugs or vulnerabilities in smart contracts that could result in loss of funds.</li>
                             <li><strong>Regulatory & Platform Risk:</strong> Earning mechanisms may be subject to change based on regulatory developments or platform updates.</li>
@@ -432,7 +432,7 @@
                         <tr><td>eSDR</td><td>IMF Special Drawing Rights</td><td>Live</td><td>Available</td><td>IMF</td></tr>
                         <tr><td>eZAR</td><td>South African Rand</td><td>Live</td><td>Available</td><td>South Africa</td></tr>
                     </table>
-                    <p style="font-size: 0.95rem; color: #555;">Note: Contract addresses are truncated for brevity. Full addresses are available on the Telcoin Digital Cash page.</p>
+                    <p class="deep-dive-note">Note: Contract addresses are truncated for brevity. Full addresses are available on the Telcoin Digital Cash page.</p>
                 </div>
             `
         },
@@ -550,8 +550,8 @@
                         <li><a href="https://t.me/TelcoinPowerHolders" target="_blank">Telegram</a> - Telcoin POWER Holders</li>
                         <li><a href="https://t.me/telfamcommunity" target="_blank">Telegram</a> - TEL Community</li>
                     </ul>
-                    <div style="background: #fff3cd; border-left: 4px solid #ffcc00; padding: 1rem; border-radius: 8px; margin: 1.5rem 0; color: #856404;">
-                        <p style="margin: 0;"><strong>⚠️ Security Reminder:</strong> Always verify official channels to avoid scams and impostors. For official information and support, always visit <a href="https://telcoin.org" target="_blank">telcoin.org</a>.</p>
+                    <div class="deep-dive-callout">
+                        <p><strong>⚠️ Security Reminder:</strong> Always verify official channels to avoid scams and impostors. For official information and support, always visit <a href="https://telcoin.org" target="_blank">telcoin.org</a>.</p>
                     </div>
                 </div>
             `
@@ -598,7 +598,7 @@
                             <p class="text-xs uppercase tracking-[0.25em] text-white/50">Topic Insight</p>
                             <h2 class="mt-2 text-2xl font-semibold text-white">${value.title}</h2>
                         </header>
-                        <div class="prose max-w-none">${value.content}</div>
+                        <div class="prose prose-invert max-w-none">${value.content}</div>
                     </div>
                 `;
                 container.appendChild(section);

--- a/styles/site.css
+++ b/styles/site.css
@@ -700,6 +700,126 @@ html:not(.dark) .callout-warning {
   }
 }
 
+/* Deep dive content theming */
+.deep-dive-media {
+  margin: 2.5rem auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.75rem;
+}
+
+.deep-dive-media-img {
+  width: min(100%, 960px);
+  border-radius: 1.5rem;
+  border: 1px solid rgba(122, 214, 255, 0.28);
+  box-shadow: 0 24px 48px rgba(6, 18, 45, 0.45);
+  margin: 0 !important;
+}
+
+.deep-dive-callout {
+  margin: 2rem 0;
+  padding: 1.25rem 1.5rem;
+  border-radius: 1.35rem;
+  border-left: 4px solid rgba(250, 204, 21, 0.75);
+  background: linear-gradient(135deg, rgba(250, 204, 21, 0.18), rgba(250, 204, 21, 0.06));
+  color: rgba(255, 250, 230, 0.9);
+  box-shadow: 0 16px 36px rgba(6, 18, 45, 0.38);
+}
+
+.deep-dive-callout h4 {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #fef3c7;
+}
+
+.deep-dive-callout p {
+  margin: 0.75rem 0 0;
+  color: inherit;
+}
+
+.deep-dive-callout p:first-child {
+  margin-top: 0;
+}
+
+.deep-dive-callout ul {
+  margin: 0.75rem 0 0;
+  padding-left: 1.15rem;
+}
+
+.deep-dive-callout li {
+  margin-bottom: 0.5rem;
+}
+
+.deep-dive-callout a {
+  color: #7ef2da;
+  text-decoration: underline;
+}
+
+.deep-dive-note {
+  margin: 1rem 0 0;
+  font-size: 0.95rem;
+  color: rgba(214, 229, 255, 0.75);
+}
+
+.governance-table,
+.platform-table,
+.resources-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 2rem 0;
+  border-radius: 1.35rem;
+  overflow: hidden;
+  background: rgba(6, 22, 51, 0.88);
+  border: 1px solid rgba(122, 214, 255, 0.16);
+  box-shadow: 0 18px 42px rgba(4, 12, 28, 0.48);
+}
+
+.governance-table th,
+.platform-table th,
+.resources-table th {
+  padding: 1rem 1.25rem;
+  text-align: left;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(244, 248, 255, 0.92);
+  background: linear-gradient(135deg, rgba(52, 114, 255, 0.9), rgba(12, 40, 112, 0.92));
+  border-bottom: 1px solid rgba(122, 214, 255, 0.2);
+}
+
+.governance-table td,
+.platform-table td,
+.resources-table td {
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid rgba(122, 214, 255, 0.12);
+  color: rgba(222, 235, 255, 0.85);
+}
+
+.governance-table tr:last-child td,
+.platform-table tr:last-child td,
+.resources-table tr:last-child td {
+  border-bottom: none;
+}
+
+.governance-table tbody tr:hover td,
+.platform-table tbody tr:hover td,
+.resources-table tbody tr:hover td {
+  background: rgba(73, 180, 255, 0.12);
+}
+
+@media (max-width: 768px) {
+  .governance-table,
+  .platform-table,
+  .resources-table {
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
+}
+
 .table-wrapper {
   overflow-x: auto;
 }


### PR DESCRIPTION
## Summary
- replace inline-styled deep dive components with themed classes so every section inherits the dark Telcoin Wiki palette
- introduce scoped CSS for deep dive tables, media, callouts, and notes to keep typography and accents consistent across subpages
- invert the dynamically rendered prose so body copy remains readable on the unified dark background

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d2a4f471448330b1642e2d0eac7ec0