### PR TITLE
Move docs navigation into header

### DIFF
--- a/about.html
+++ b/about.html
@@ -49,23 +49,28 @@
     <div class="relative flex min-h-screen flex-col">
         <div id="top"></div>
         <header class="sticky top-0 z-50 border-b border-white/10 bg-ink-950/80 backdrop-blur-xs">
-            <div class="mx-auto flex w-full max-w-7xl items-center gap-3 px-4 py-4">
-                <a href="index.html" class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-white/80 transition hover:bg-white/10 focus-ring" aria-label="Telcoin Wiki home">
-                    <img src="logo.svg" alt="Telcoin Wiki" class="h-10 w-auto">
-                    <span class="sr-only">Telcoin Wiki</span>
-                </a>
-                <div class="flex flex-1 items-center justify-center">
-                    <div class="relative w-full max-w-xl">
-                        <label for="site-search" class="sr-only">Search about TELx</label>
-                        <input id="site-search" data-site-search type="search" placeholder="Search this page" autocomplete="off" class="site-search-input">
-                        <div class="search-panel" data-search-results aria-hidden="true"></div>
+            <div class="mx-auto w-full max-w-7xl px-4 py-4">
+                <div class="flex w-full items-center gap-3">
+                    <a href="index.html" class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-white/80 transition hover:bg-white/10 focus-ring" aria-label="Telcoin Wiki home">
+                        <img src="logo.svg" alt="Telcoin Wiki" class="h-10 w-auto">
+                        <span class="sr-only">Telcoin Wiki</span>
+                    </a>
+                    <div class="flex flex-1 items-center justify-center">
+                        <div class="relative w-full max-w-xl">
+                            <label for="site-search" class="sr-only">Search about TELx</label>
+                            <input id="site-search" data-site-search type="search" placeholder="Search this page" autocomplete="off" class="site-search-input">
+                            <div class="search-panel" data-search-results aria-hidden="true"></div>
+                        </div>
+                    </div>
+                    <div class="flex items-center">
+                        <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button lg:hidden focus-ring">
+                            <span class="sr-only">Open navigation</span>
+                            ☰
+                        </button>
                     </div>
                 </div>
-                <div class="flex items-center">
-                    <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button lg:hidden focus-ring">
-                        <span class="sr-only">Open navigation</span>
-                        ☰
-                    </button>
+                <div class="mt-4 hidden lg:block" data-docs-header-nav>
+                    <nav data-docs-nav class="docs-nav docs-nav--header"></nav>
                 </div>
             </div>
         </header>
@@ -91,10 +96,7 @@
 
         <div class="flex-1 w-full">
             <div class="mx-auto max-w-7xl px-4 pb-24 pt-12 sm:pt-16">
-                <div class="grid grid-cols-1 gap-6 lg:grid-cols-[16rem_minmax(0,1fr)_14rem]">
-                    <aside class="hidden lg:block sticky top-16 h-[calc(100dvh-4rem)] overflow-y-auto pr-2" data-docs-sidebar>
-                        <nav data-docs-nav class="docs-nav space-y-3"></nav>
-                    </aside>
+                <div class="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,1fr)_14rem]">
                     <main id="main-content" class="space-y-16">
                         <section id="about-overview" class="space-y-10">
                             <div class="grid gap-8 lg:grid-cols-[minmax(0,1fr)_18rem]">

--- a/about.html
+++ b/about.html
@@ -49,28 +49,28 @@
     <div class="relative flex min-h-screen flex-col">
         <div id="top"></div>
         <header class="sticky top-0 z-50 border-b border-white/10 bg-ink-950/80 backdrop-blur-xs">
-            <div class="mx-auto w-full max-w-7xl px-4 py-4">
-                <div class="flex w-full items-center gap-3">
+            <div class="mx-auto w-full max-w-7xl px-4 py-3 lg:py-2.5">
+                <div class="flex w-full flex-wrap items-center gap-3 lg:grid lg:grid-cols-[auto_minmax(0,1fr)_minmax(0,15rem)] lg:items-center lg:gap-4">
                     <a href="index.html" class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-white/80 transition hover:bg-white/10 focus-ring" aria-label="Telcoin Wiki home">
                         <img src="logo.svg" alt="Telcoin Wiki" class="h-10 w-auto">
                         <span class="sr-only">Telcoin Wiki</span>
                     </a>
-                    <div class="flex flex-1 items-center justify-center">
-                        <div class="relative w-full max-w-xl">
+                    <div class="order-3 hidden w-full lg:order-2 lg:block lg:justify-self-center" data-docs-header-nav>
+                        <nav data-docs-nav class="docs-nav docs-nav--header"></nav>
+                    </div>
+                    <div class="order-2 flex flex-1 items-center justify-end lg:order-3 lg:flex-none lg:justify-self-end">
+                        <div class="relative w-full max-w-md lg:max-w-xs">
                             <label for="site-search" class="sr-only">Search about TELx</label>
                             <input id="site-search" data-site-search type="search" placeholder="Search this page" autocomplete="off" class="site-search-input">
                             <div class="search-panel" data-search-results aria-hidden="true"></div>
                         </div>
                     </div>
-                    <div class="flex items-center">
-                        <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button lg:hidden focus-ring">
+                    <div class="order-4 flex items-center flex-shrink-0 lg:hidden">
+                        <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button focus-ring">
                             <span class="sr-only">Open navigation</span>
                             ☰
                         </button>
                     </div>
-                </div>
-                <div class="mt-4 hidden lg:block" data-docs-header-nav>
-                    <nav data-docs-nav class="docs-nav docs-nav--header"></nav>
                 </div>
             </div>
         </header>

--- a/deep-dive.html
+++ b/deep-dive.html
@@ -159,23 +159,28 @@
     <div class="relative flex min-h-screen flex-col">
         <div id="top"></div>
         <header class="sticky top-0 z-50 border-b border-white/10 bg-ink-950/80 backdrop-blur-xs">
-            <div class="mx-auto flex w-full max-w-7xl items-center gap-3 px-4 py-4">
-                <a href="index.html" class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-white/80 transition hover:bg-white/10 focus-ring" aria-label="Telcoin Wiki home">
-                    <img src="logo.svg" alt="Telcoin Wiki" class="h-10 w-auto">
-                    <span class="sr-only">Telcoin Wiki</span>
-                </a>
-                <div class="flex flex-1 items-center justify-center">
-                    <div class="relative w-full max-w-xl">
-                        <label for="site-search" class="sr-only">Search Telcoin Deep Dive</label>
-                        <input id="site-search" data-site-search type="search" placeholder="Search this page" autocomplete="off" class="site-search-input">
-                        <div class="search-panel" data-search-results aria-hidden="true"></div>
+            <div class="mx-auto w-full max-w-7xl px-4 py-4">
+                <div class="flex w-full items-center gap-3">
+                    <a href="index.html" class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-white/80 transition hover:bg-white/10 focus-ring" aria-label="Telcoin Wiki home">
+                        <img src="logo.svg" alt="Telcoin Wiki" class="h-10 w-auto">
+                        <span class="sr-only">Telcoin Wiki</span>
+                    </a>
+                    <div class="flex flex-1 items-center justify-center">
+                        <div class="relative w-full max-w-xl">
+                            <label for="site-search" class="sr-only">Search Telcoin Deep Dive</label>
+                            <input id="site-search" data-site-search type="search" placeholder="Search this page" autocomplete="off" class="site-search-input">
+                            <div class="search-panel" data-search-results aria-hidden="true"></div>
+                        </div>
+                    </div>
+                    <div class="flex items-center">
+                        <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button lg:hidden focus-ring">
+                            <span class="sr-only">Open navigation</span>
+                            ☰
+                        </button>
                     </div>
                 </div>
-                <div class="flex items-center">
-                    <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button lg:hidden focus-ring">
-                        <span class="sr-only">Open navigation</span>
-                        ☰
-                    </button>
+                <div class="mt-4 hidden lg:block" data-docs-header-nav>
+                    <nav data-docs-nav class="docs-nav docs-nav--header"></nav>
                 </div>
             </div>
         </header>
@@ -201,10 +206,7 @@
 
         <div class="flex-1 w-full">
             <div class="mx-auto max-w-7xl px-4 pb-24 pt-12 sm:pt-16">
-                <div class="grid grid-cols-1 gap-6 lg:grid-cols-[16rem_minmax(0,1fr)_14rem]">
-                    <aside class="hidden lg:block sticky top-16 h-[calc(100dvh-4rem)] overflow-y-auto pr-2" data-docs-sidebar>
-                        <nav data-docs-nav class="docs-nav space-y-3"></nav>
-                    </aside>
+                <div class="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,1fr)_14rem]">
                     <main id="main-content" class="space-y-12">
                         <section class="space-y-8">
                             <div class="glass p-8">

--- a/deep-dive.html
+++ b/deep-dive.html
@@ -159,28 +159,28 @@
     <div class="relative flex min-h-screen flex-col">
         <div id="top"></div>
         <header class="sticky top-0 z-50 border-b border-white/10 bg-ink-950/80 backdrop-blur-xs">
-            <div class="mx-auto w-full max-w-7xl px-4 py-4">
-                <div class="flex w-full items-center gap-3">
+            <div class="mx-auto w-full max-w-7xl px-4 py-3 lg:py-2.5">
+                <div class="flex w-full flex-wrap items-center gap-3 lg:grid lg:grid-cols-[auto_minmax(0,1fr)_minmax(0,15rem)] lg:items-center lg:gap-4">
                     <a href="index.html" class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-white/80 transition hover:bg-white/10 focus-ring" aria-label="Telcoin Wiki home">
                         <img src="logo.svg" alt="Telcoin Wiki" class="h-10 w-auto">
                         <span class="sr-only">Telcoin Wiki</span>
                     </a>
-                    <div class="flex flex-1 items-center justify-center">
-                        <div class="relative w-full max-w-xl">
+                    <div class="order-3 hidden w-full lg:order-2 lg:block lg:justify-self-center" data-docs-header-nav>
+                        <nav data-docs-nav class="docs-nav docs-nav--header"></nav>
+                    </div>
+                    <div class="order-2 flex flex-1 items-center justify-end lg:order-3 lg:flex-none lg:justify-self-end">
+                        <div class="relative w-full max-w-md lg:max-w-xs">
                             <label for="site-search" class="sr-only">Search Telcoin Deep Dive</label>
                             <input id="site-search" data-site-search type="search" placeholder="Search this page" autocomplete="off" class="site-search-input">
                             <div class="search-panel" data-search-results aria-hidden="true"></div>
                         </div>
                     </div>
-                    <div class="flex items-center">
-                        <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button lg:hidden focus-ring">
+                    <div class="order-4 flex items-center flex-shrink-0 lg:hidden">
+                        <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button focus-ring">
                             <span class="sr-only">Open navigation</span>
                             ☰
                         </button>
                     </div>
-                </div>
-                <div class="mt-4 hidden lg:block" data-docs-header-nav>
-                    <nav data-docs-nav class="docs-nav docs-nav--header"></nav>
                 </div>
             </div>
         </header>

--- a/index.html
+++ b/index.html
@@ -132,28 +132,28 @@
     <div class="relative flex min-h-screen flex-col">
         <div id="top"></div>
         <header class="sticky top-0 z-50 border-b border-white/10 bg-ink-950/80 backdrop-blur-xs">
-            <div class="mx-auto w-full max-w-7xl px-4 py-4">
-                <div class="flex w-full items-center gap-3">
+            <div class="mx-auto w-full max-w-7xl px-4 py-3 lg:py-2.5">
+                <div class="flex w-full flex-wrap items-center gap-3 lg:grid lg:grid-cols-[auto_minmax(0,1fr)_minmax(0,15rem)] lg:items-center lg:gap-4">
                     <a href="index.html" class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-white/80 transition hover:bg-white/10 focus-ring" aria-label="Telcoin Wiki home">
                         <img src="logo.svg" alt="Telcoin Wiki" class="h-10 w-auto">
                         <span class="sr-only">Telcoin Wiki</span>
                     </a>
-                    <div class="flex flex-1 items-center justify-center">
-                        <div class="relative w-full max-w-xl">
+                    <div class="order-3 hidden w-full lg:order-2 lg:block lg:justify-self-center" data-docs-header-nav>
+                        <nav data-docs-nav class="docs-nav docs-nav--header"></nav>
+                    </div>
+                    <div class="order-2 flex flex-1 items-center justify-end lg:order-3 lg:flex-none lg:justify-self-end">
+                        <div class="relative w-full max-w-md lg:max-w-xs">
                             <label for="site-search" class="sr-only">Search Telcoin Wiki</label>
                             <input id="site-search" data-site-search type="search" placeholder="Search this page" autocomplete="off" class="site-search-input">
                             <div class="search-panel" data-search-results aria-hidden="true"></div>
                         </div>
                     </div>
-                    <div class="flex items-center">
-                        <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button lg:hidden focus-ring">
+                    <div class="order-4 flex items-center flex-shrink-0 lg:hidden">
+                        <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button focus-ring">
                             <span class="sr-only">Open navigation</span>
                             ☰
                         </button>
                     </div>
-                </div>
-                <div class="mt-4 hidden lg:block" data-docs-header-nav>
-                    <nav data-docs-nav class="docs-nav docs-nav--header"></nav>
                 </div>
             </div>
         </header>

--- a/index.html
+++ b/index.html
@@ -132,23 +132,28 @@
     <div class="relative flex min-h-screen flex-col">
         <div id="top"></div>
         <header class="sticky top-0 z-50 border-b border-white/10 bg-ink-950/80 backdrop-blur-xs">
-            <div class="mx-auto flex w-full max-w-7xl items-center gap-3 px-4 py-4">
-                <a href="index.html" class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-white/80 transition hover:bg-white/10 focus-ring" aria-label="Telcoin Wiki home">
-                    <img src="logo.svg" alt="Telcoin Wiki" class="h-10 w-auto">
-                    <span class="sr-only">Telcoin Wiki</span>
-                </a>
-                <div class="flex flex-1 items-center justify-center">
-                    <div class="relative w-full max-w-xl">
-                        <label for="site-search" class="sr-only">Search Telcoin Wiki</label>
-                        <input id="site-search" data-site-search type="search" placeholder="Search this page" autocomplete="off" class="site-search-input">
-                        <div class="search-panel" data-search-results aria-hidden="true"></div>
+            <div class="mx-auto w-full max-w-7xl px-4 py-4">
+                <div class="flex w-full items-center gap-3">
+                    <a href="index.html" class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-white/80 transition hover:bg-white/10 focus-ring" aria-label="Telcoin Wiki home">
+                        <img src="logo.svg" alt="Telcoin Wiki" class="h-10 w-auto">
+                        <span class="sr-only">Telcoin Wiki</span>
+                    </a>
+                    <div class="flex flex-1 items-center justify-center">
+                        <div class="relative w-full max-w-xl">
+                            <label for="site-search" class="sr-only">Search Telcoin Wiki</label>
+                            <input id="site-search" data-site-search type="search" placeholder="Search this page" autocomplete="off" class="site-search-input">
+                            <div class="search-panel" data-search-results aria-hidden="true"></div>
+                        </div>
+                    </div>
+                    <div class="flex items-center">
+                        <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button lg:hidden focus-ring">
+                            <span class="sr-only">Open navigation</span>
+                            ☰
+                        </button>
                     </div>
                 </div>
-                <div class="flex items-center">
-                    <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button lg:hidden focus-ring">
-                        <span class="sr-only">Open navigation</span>
-                        ☰
-                    </button>
+                <div class="mt-4 hidden lg:block" data-docs-header-nav>
+                    <nav data-docs-nav class="docs-nav docs-nav--header"></nav>
                 </div>
             </div>
         </header>
@@ -174,10 +179,7 @@
 
         <div class="flex-1 w-full">
             <div class="mx-auto max-w-7xl px-4 pb-24 pt-12 sm:pt-16">
-                <div class="grid grid-cols-1 gap-6 lg:grid-cols-[16rem_minmax(0,1fr)_14rem]">
-                    <aside class="hidden lg:block sticky top-16 h-[calc(100dvh-4rem)] overflow-y-auto pr-2" data-docs-sidebar>
-                        <nav data-docs-nav class="docs-nav space-y-3"></nav>
-                    </aside>
+                <div class="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,1fr)_14rem]">
                     <main id="main-content" class="space-y-16">
                         <section id="hero" class="space-y-10 pt-16 sm:pt-20">
                             <div class="glass overflow-hidden border border-white/10 bg-white/5 p-8 shadow-glass">

--- a/index.html
+++ b/index.html
@@ -237,13 +237,13 @@
                         <section id="getting-started" class="space-y-8">
                             <div class="glass p-8">
                                 <div class="prose prose-invert max-w-none">
-                                    <h2>Getting Started Checklist</h2>
+                                    <h2 id="wallet-basics">Wallet Basics Checklist</h2>
                                     <p>Follow these high-impact steps to get aligned with Telcoin’s ecosystem and the TELx liquidity engine. Each card links to official documentation or trusted community explainers.</p>
                                 </div>
                                 <div class="mt-10 grid gap-6 lg:grid-cols-2">
                                     <a href="https://telcoin.org" target="_blank" rel="noopener" class="glass block p-6 transition-transform duration-base ease-smooth hover:scale-[1.01] focus-ring">
-                                        <h3 class="text-lg font-semibold text-white">📚 Learn the Basics</h3>
-                                        <p class="mt-2 text-sm text-white/70">Read through this FAQ and visit telcoin.org</p>
+                                        <h3 id="create-account" class="text-lg font-semibold text-white">🆕 Create Account</h3>
+                                        <p class="mt-2 text-sm text-white/70">Download the Telcoin App, complete verification, and unlock in-app support.</p>
                                         <span class="mt-4 inline-flex items-center text-xs font-medium text-mint-300">Open telcoin.org →</span>
                                     </a>
                                     <div class="glass relative p-6" id="joinCommunityChecklist">
@@ -263,15 +263,15 @@
                                             </ul>
                                         </div>
                                     </div>
-                                    <button type="button" id="considerStakingChecklist" class="glass p-6 text-left transition-transform duration-base ease-smooth hover:scale-[1.01] focus-ring">
-                                        <h3 class="text-lg font-semibold text-white">🔒 Consider Staking</h3>
-                                        <p class="mt-2 text-sm text-white/70">Stake TEL to earn rewards and participate in governance</p>
-                                        <span class="mt-4 inline-flex items-center text-xs font-medium text-mint-300">Read about staking →</span>
+                                    <button type="button" id="fundWalletChecklist" class="glass p-6 text-left transition-transform duration-base ease-smooth hover:scale-[1.01] focus-ring">
+                                        <h3 id="fund-wallet" class="text-lg font-semibold text-white">💳 Fund Your Wallet</h3>
+                                        <p class="mt-2 text-sm text-white/70">Explore trusted on-ramps and exchange partners that support TEL.</p>
+                                        <span class="mt-4 inline-flex items-center text-xs font-medium text-mint-300">View funding options →</span>
                                     </button>
-                                    <button type="button" id="stayUpdatedChecklist" class="glass p-6 text-left transition-transform duration-base ease-smooth hover:scale-[1.01] focus-ring">
-                                        <h3 class="text-lg font-semibold text-white">📢 Stay Updated</h3>
-                                        <p class="mt-2 text-sm text-white/70">Follow official channels for the latest developments</p>
-                                        <span class="mt-4 inline-flex items-center text-xs font-medium text-mint-300">Jump to community links →</span>
+                                    <button type="button" id="securityChecklist" class="glass p-6 text-left transition-transform duration-base ease-smooth hover:scale-[1.01] focus-ring">
+                                        <h3 id="security-checklist" class="text-lg font-semibold text-white">✅ Security Checklist</h3>
+                                        <p class="mt-2 text-sm text-white/70">Review safety tips, official alerts, and where to report suspicious activity.</p>
+                                        <span class="mt-4 inline-flex items-center text-xs font-medium text-mint-300">Read safety guidance →</span>
                                     </button>
                                 </div>
                             </div>
@@ -281,8 +281,10 @@
                             <div class="glass p-8">
                                 <div class="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
                                     <div class="prose prose-invert max-w-none lg:max-w-3xl">
-                                        <h2>Community Q&amp;A - Get the Facts Fast</h2>
+                                        <h2 id="quick-facts">Community Q&amp;A - Get the Facts Fast</h2>
                                         <p>Browse verified community answers spanning Telcoin governance, liquidity mining, digital cash, and more. Use the filter or the global search to jump straight to the insight you need.</p>
+                                        <h3 id="faq-troubleshooting">Troubleshooting</h3>
+                                        <p>If you hit an error in the Telcoin App, search for the exact message, then cross-check the answers below or escalate through the in-app support form. For outages, review the Telcoin Network status update in the TELx DeFi section.</p>
                                     </div>
                                     <div class="lg:min-w-[280px]">
                                         <label for="searchBox" class="text-xs uppercase tracking-[0.25em] text-white/50">Filter Q&amp;A</label>
@@ -595,7 +597,7 @@
                 "@context": "https://schema.org",
                 "@type": "FAQPage",
                 "@id": "https://telcoinwiki.com/#faq",
-                "url": "https://telcoinwiki.com/#quick-qa",
+                "url": "https://telcoinwiki.com/#quick-facts",
                 "name": "Telcoin Wiki Quick Q&A",
                 "inLanguage": "en-US",
                 "isPartOf": {
@@ -646,17 +648,17 @@
                 });
             }
 
-            const considerStakingChecklist = document.getElementById('considerStakingChecklist');
-            if (considerStakingChecklist) {
-                considerStakingChecklist.addEventListener('click', () => {
-                    window.location.href = 'deep-dive.html?category=earning';
+            const fundWalletChecklist = document.getElementById('fundWalletChecklist');
+            if (fundWalletChecklist) {
+                fundWalletChecklist.addEventListener('click', () => {
+                    window.location.href = 'links.html#trading-wallets';
                 });
             }
 
-            const stayUpdatedChecklist = document.getElementById('stayUpdatedChecklist');
-            if (stayUpdatedChecklist) {
-                stayUpdatedChecklist.addEventListener('click', () => {
-                    document.getElementById('community').scrollIntoView({ behavior: 'smooth' });
+            const securityChecklist = document.getElementById('securityChecklist');
+            if (securityChecklist) {
+                securityChecklist.addEventListener('click', () => {
+                    window.location.href = 'links.html#official-resources';
                 });
             }
         }

--- a/js/docs-layout.js
+++ b/js/docs-layout.js
@@ -332,22 +332,66 @@
   function setupAccordion(container) {
     if (!container) return;
     const triggers = Array.from(container.querySelectorAll('.docs-nav-trigger'));
+    if (!triggers.length) return;
+
+    const hoverEnabled = container.classList.contains('docs-nav--header');
+
+    const closeOthers = (activeTrigger) => {
+      triggers.forEach((other) => {
+        if (other === activeTrigger) return;
+        const otherPanelId = other.getAttribute('aria-controls');
+        if (!otherPanelId) return;
+        const otherPanel = document.getElementById(otherPanelId);
+        if (!otherPanel) return;
+        other.setAttribute('aria-expanded', 'false');
+        otherPanel.hidden = true;
+      });
+    };
+
     triggers.forEach((trigger) => {
+      const panelId = trigger.getAttribute('aria-controls');
+      if (!panelId) return;
+      const panel = document.getElementById(panelId);
+      if (!panel) return;
+
+      const section = trigger.closest('.docs-nav-section');
+
+      const openPanel = () => {
+        closeOthers(trigger);
+        trigger.setAttribute('aria-expanded', 'true');
+        panel.hidden = false;
+      };
+
+      const closePanel = () => {
+        trigger.setAttribute('aria-expanded', 'false');
+        panel.hidden = true;
+      };
+
       trigger.addEventListener('click', () => {
         const expanded = trigger.getAttribute('aria-expanded') === 'true';
-        triggers.forEach((other) => {
-          if (other === trigger) return;
-          const otherPanel = document.getElementById(other.getAttribute('aria-controls'));
-          if (!otherPanel) return;
-          other.setAttribute('aria-expanded', 'false');
-          otherPanel.hidden = true;
-        });
-        const panelId = trigger.getAttribute('aria-controls');
-        const panel = document.getElementById(panelId);
-        if (!panel) return;
-        trigger.setAttribute('aria-expanded', expanded ? 'false' : 'true');
-        panel.hidden = expanded;
+        if (expanded) {
+          closePanel();
+        } else {
+          openPanel();
+        }
       });
+
+      trigger.addEventListener('focus', openPanel);
+
+      if (hoverEnabled) {
+        trigger.addEventListener('mouseenter', openPanel);
+        if (section) {
+          section.addEventListener('mouseleave', () => {
+            if (section.contains(document.activeElement)) return;
+            closePanel();
+          });
+          section.addEventListener('focusout', (event) => {
+            if (!section.contains(event.relatedTarget)) {
+              closePanel();
+            }
+          });
+        }
+      }
     });
   }
 

--- a/links.html
+++ b/links.html
@@ -190,28 +190,28 @@
     <div class="relative flex min-h-screen flex-col">
         <div id="top"></div>
         <header class="sticky top-0 z-50 border-b border-white/10 bg-ink-950/80 backdrop-blur-xs">
-            <div class="mx-auto w-full max-w-7xl px-4 py-4">
-                <div class="flex w-full items-center gap-3">
+            <div class="mx-auto w-full max-w-7xl px-4 py-3 lg:py-2.5">
+                <div class="flex w-full flex-wrap items-center gap-3 lg:grid lg:grid-cols-[auto_minmax(0,1fr)_minmax(0,15rem)] lg:items-center lg:gap-4">
                     <a href="index.html" class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-white/80 transition hover:bg-white/10 focus-ring" aria-label="Telcoin Wiki home">
                         <img src="logo.svg" alt="Telcoin Wiki" class="h-10 w-auto">
                         <span class="sr-only">Telcoin Wiki</span>
                     </a>
-                    <div class="flex flex-1 items-center justify-center">
-                        <div class="relative w-full max-w-xl">
+                    <div class="order-3 hidden w-full lg:order-2 lg:block lg:justify-self-center" data-docs-header-nav>
+                        <nav data-docs-nav class="docs-nav docs-nav--header"></nav>
+                    </div>
+                    <div class="order-2 flex flex-1 items-center justify-end lg:order-3 lg:flex-none lg:justify-self-end">
+                        <div class="relative w-full max-w-md lg:max-w-xs">
                             <label for="site-search" class="sr-only">Search Telcoin links</label>
                             <input id="site-search" data-site-search type="search" placeholder="Search this page" autocomplete="off" class="site-search-input">
                             <div class="search-panel" data-search-results aria-hidden="true"></div>
                         </div>
                     </div>
-                    <div class="flex items-center">
-                        <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button lg:hidden focus-ring">
+                    <div class="order-4 flex items-center flex-shrink-0 lg:hidden">
+                        <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button focus-ring">
                             <span class="sr-only">Open navigation</span>
                             ☰
                         </button>
                     </div>
-                </div>
-                <div class="mt-4 hidden lg:block" data-docs-header-nav>
-                    <nav data-docs-nav class="docs-nav docs-nav--header"></nav>
                 </div>
             </div>
         </header>

--- a/links.html
+++ b/links.html
@@ -291,8 +291,8 @@
                                     </ul>
                                 </article>
 
-                                <article class="glass p-6" aria-labelledby="community-media">
-                                    <h2 id="community-media" class="text-xl font-semibold text-white">Community &amp; media</h2>
+                                <article class="glass p-6" aria-labelledby="contact">
+                                    <h2 id="contact" class="text-xl font-semibold text-white">Community &amp; contact</h2>
                                     <ul class="mt-4 space-y-2 text-sm text-white/75">
                                         <li><a class="link-ux inline-flex items-center gap-2" href="https://www.reddit.com/r/Telcoin/" target="_blank" rel="noopener">r/Telcoin — subreddit hub<span aria-hidden="true">↗</span></a></li>
                                         <li><a class="link-ux inline-flex items-center gap-2" href="https://www.reddit.com/r/Telcoin/comments/1kgn74h/telcoin_cares_about_your_security_so_heres_a/" target="_blank" rel="noopener">Security reminder — r/Telcoin<span aria-hidden="true">↗</span></a></li>

--- a/links.html
+++ b/links.html
@@ -190,23 +190,28 @@
     <div class="relative flex min-h-screen flex-col">
         <div id="top"></div>
         <header class="sticky top-0 z-50 border-b border-white/10 bg-ink-950/80 backdrop-blur-xs">
-            <div class="mx-auto flex w-full max-w-7xl items-center gap-3 px-4 py-4">
-                <a href="index.html" class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-white/80 transition hover:bg-white/10 focus-ring" aria-label="Telcoin Wiki home">
-                    <img src="logo.svg" alt="Telcoin Wiki" class="h-10 w-auto">
-                    <span class="sr-only">Telcoin Wiki</span>
-                </a>
-                <div class="flex flex-1 items-center justify-center">
-                    <div class="relative w-full max-w-xl">
-                        <label for="site-search" class="sr-only">Search Telcoin links</label>
-                        <input id="site-search" data-site-search type="search" placeholder="Search this page" autocomplete="off" class="site-search-input">
-                        <div class="search-panel" data-search-results aria-hidden="true"></div>
+            <div class="mx-auto w-full max-w-7xl px-4 py-4">
+                <div class="flex w-full items-center gap-3">
+                    <a href="index.html" class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-white/80 transition hover:bg-white/10 focus-ring" aria-label="Telcoin Wiki home">
+                        <img src="logo.svg" alt="Telcoin Wiki" class="h-10 w-auto">
+                        <span class="sr-only">Telcoin Wiki</span>
+                    </a>
+                    <div class="flex flex-1 items-center justify-center">
+                        <div class="relative w-full max-w-xl">
+                            <label for="site-search" class="sr-only">Search Telcoin links</label>
+                            <input id="site-search" data-site-search type="search" placeholder="Search this page" autocomplete="off" class="site-search-input">
+                            <div class="search-panel" data-search-results aria-hidden="true"></div>
+                        </div>
+                    </div>
+                    <div class="flex items-center">
+                        <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button lg:hidden focus-ring">
+                            <span class="sr-only">Open navigation</span>
+                            ☰
+                        </button>
                     </div>
                 </div>
-                <div class="flex items-center">
-                    <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button lg:hidden focus-ring">
-                        <span class="sr-only">Open navigation</span>
-                        ☰
-                    </button>
+                <div class="mt-4 hidden lg:block" data-docs-header-nav>
+                    <nav data-docs-nav class="docs-nav docs-nav--header"></nav>
                 </div>
             </div>
         </header>
@@ -232,10 +237,7 @@
 
         <div class="flex-1 w-full">
             <div class="mx-auto max-w-7xl px-4 pb-24 pt-12 sm:pt-16">
-                <div class="grid grid-cols-1 gap-6 lg:grid-cols-[16rem_minmax(0,1fr)_14rem]">
-                    <aside class="hidden lg:block sticky top-16 h-[calc(100dvh-4rem)] overflow-y-auto pr-2" data-docs-sidebar>
-                        <nav data-docs-nav class="docs-nav space-y-3"></nav>
-                    </aside>
+                <div class="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,1fr)_14rem]">
                     <main id="main-content" class="space-y-12">
                         <section id="links-overview" class="space-y-8">
                             <div class="glass p-8">

--- a/pools.html
+++ b/pools.html
@@ -49,28 +49,28 @@
     <div class="relative flex min-h-screen flex-col">
         <div id="top"></div>
         <header class="sticky top-0 z-50 border-b border-white/10 bg-ink-950/80 backdrop-blur-xs">
-            <div class="mx-auto w-full max-w-7xl px-4 py-4">
-                <div class="flex w-full items-center gap-3">
+            <div class="mx-auto w-full max-w-7xl px-4 py-3 lg:py-2.5">
+                <div class="flex w-full flex-wrap items-center gap-3 lg:grid lg:grid-cols-[auto_minmax(0,1fr)_minmax(0,15rem)] lg:items-center lg:gap-4">
                     <a href="index.html" class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-white/80 transition hover:bg-white/10 focus-ring" aria-label="Telcoin Wiki home">
                         <img src="logo.svg" alt="Telcoin Wiki" class="h-10 w-auto">
                         <span class="sr-only">Telcoin Wiki</span>
                     </a>
-                    <div class="flex flex-1 items-center justify-center">
-                        <div class="relative w-full max-w-xl">
+                    <div class="order-3 hidden w-full lg:order-2 lg:block lg:justify-self-center" data-docs-header-nav>
+                        <nav data-docs-nav class="docs-nav docs-nav--header"></nav>
+                    </div>
+                    <div class="order-2 flex flex-1 items-center justify-end lg:order-3 lg:flex-none lg:justify-self-end">
+                        <div class="relative w-full max-w-md lg:max-w-xs">
                             <label for="site-search" class="sr-only">Search TELx pools</label>
                             <input id="site-search" data-site-search type="search" placeholder="Search this page" autocomplete="off" class="site-search-input">
                             <div class="search-panel" data-search-results aria-hidden="true"></div>
                         </div>
                     </div>
-                    <div class="flex items-center">
-                        <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button lg:hidden focus-ring">
+                    <div class="order-4 flex items-center flex-shrink-0 lg:hidden">
+                        <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button focus-ring">
                             <span class="sr-only">Open navigation</span>
                             ☰
                         </button>
                     </div>
-                </div>
-                <div class="mt-4 hidden lg:block" data-docs-header-nav>
-                    <nav data-docs-nav class="docs-nav docs-nav--header"></nav>
                 </div>
             </div>
         </header>

--- a/pools.html
+++ b/pools.html
@@ -49,23 +49,28 @@
     <div class="relative flex min-h-screen flex-col">
         <div id="top"></div>
         <header class="sticky top-0 z-50 border-b border-white/10 bg-ink-950/80 backdrop-blur-xs">
-            <div class="mx-auto flex w-full max-w-7xl items-center gap-3 px-4 py-4">
-                <a href="index.html" class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-white/80 transition hover:bg-white/10 focus-ring" aria-label="Telcoin Wiki home">
-                    <img src="logo.svg" alt="Telcoin Wiki" class="h-10 w-auto">
-                    <span class="sr-only">Telcoin Wiki</span>
-                </a>
-                <div class="flex flex-1 items-center justify-center">
-                    <div class="relative w-full max-w-xl">
-                        <label for="site-search" class="sr-only">Search TELx pools</label>
-                        <input id="site-search" data-site-search type="search" placeholder="Search this page" autocomplete="off" class="site-search-input">
-                        <div class="search-panel" data-search-results aria-hidden="true"></div>
+            <div class="mx-auto w-full max-w-7xl px-4 py-4">
+                <div class="flex w-full items-center gap-3">
+                    <a href="index.html" class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-white/80 transition hover:bg-white/10 focus-ring" aria-label="Telcoin Wiki home">
+                        <img src="logo.svg" alt="Telcoin Wiki" class="h-10 w-auto">
+                        <span class="sr-only">Telcoin Wiki</span>
+                    </a>
+                    <div class="flex flex-1 items-center justify-center">
+                        <div class="relative w-full max-w-xl">
+                            <label for="site-search" class="sr-only">Search TELx pools</label>
+                            <input id="site-search" data-site-search type="search" placeholder="Search this page" autocomplete="off" class="site-search-input">
+                            <div class="search-panel" data-search-results aria-hidden="true"></div>
+                        </div>
+                    </div>
+                    <div class="flex items-center">
+                        <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button lg:hidden focus-ring">
+                            <span class="sr-only">Open navigation</span>
+                            ☰
+                        </button>
                     </div>
                 </div>
-                <div class="flex items-center">
-                    <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button lg:hidden focus-ring">
-                        <span class="sr-only">Open navigation</span>
-                        ☰
-                    </button>
+                <div class="mt-4 hidden lg:block" data-docs-header-nav>
+                    <nav data-docs-nav class="docs-nav docs-nav--header"></nav>
                 </div>
             </div>
         </header>
@@ -91,10 +96,7 @@
 
         <div class="flex-1 w-full">
             <div class="mx-auto max-w-7xl px-4 pb-24 pt-12 sm:pt-16">
-                <div class="grid grid-cols-1 gap-6 lg:grid-cols-[16rem_minmax(0,1fr)_14rem]">
-                    <aside class="hidden lg:block sticky top-16 h-[calc(100dvh-4rem)] overflow-y-auto pr-2" data-docs-sidebar>
-                        <nav data-docs-nav class="docs-nav space-y-3"></nav>
-                    </aside>
+                <div class="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,1fr)_14rem]">
                     <main id="main-content" class="space-y-16">
                         <section id="pools-overview" class="space-y-8">
                             <div class="glass p-8">

--- a/portfolio.html
+++ b/portfolio.html
@@ -49,28 +49,28 @@
     <div class="relative flex min-h-screen flex-col">
         <div id="top"></div>
         <header class="sticky top-0 z-50 border-b border-white/10 bg-ink-950/80 backdrop-blur-xs">
-            <div class="mx-auto w-full max-w-7xl px-4 py-4">
-                <div class="flex w-full items-center gap-3">
+            <div class="mx-auto w-full max-w-7xl px-4 py-3 lg:py-2.5">
+                <div class="flex w-full flex-wrap items-center gap-3 lg:grid lg:grid-cols-[auto_minmax(0,1fr)_minmax(0,15rem)] lg:items-center lg:gap-4">
                     <a href="index.html" class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-white/80 transition hover:bg-white/10 focus-ring" aria-label="Telcoin Wiki home">
                         <img src="logo.svg" alt="Telcoin Wiki" class="h-10 w-auto">
                         <span class="sr-only">Telcoin Wiki</span>
                     </a>
-                    <div class="flex flex-1 items-center justify-center">
-                        <div class="relative w-full max-w-xl">
+                    <div class="order-3 hidden w-full lg:order-2 lg:block lg:justify-self-center" data-docs-header-nav>
+                        <nav data-docs-nav class="docs-nav docs-nav--header"></nav>
+                    </div>
+                    <div class="order-2 flex flex-1 items-center justify-end lg:order-3 lg:flex-none lg:justify-self-end">
+                        <div class="relative w-full max-w-md lg:max-w-xs">
                             <label for="site-search" class="sr-only">Search TELx portfolio</label>
                             <input id="site-search" data-site-search type="search" placeholder="Search this page" autocomplete="off" class="site-search-input">
                             <div class="search-panel" data-search-results aria-hidden="true"></div>
                         </div>
                     </div>
-                    <div class="flex items-center">
-                        <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button lg:hidden focus-ring">
+                    <div class="order-4 flex items-center flex-shrink-0 lg:hidden">
+                        <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button focus-ring">
                             <span class="sr-only">Open navigation</span>
                             ☰
                         </button>
                     </div>
-                </div>
-                <div class="mt-4 hidden lg:block" data-docs-header-nav>
-                    <nav data-docs-nav class="docs-nav docs-nav--header"></nav>
                 </div>
             </div>
         </header>

--- a/portfolio.html
+++ b/portfolio.html
@@ -49,23 +49,28 @@
     <div class="relative flex min-h-screen flex-col">
         <div id="top"></div>
         <header class="sticky top-0 z-50 border-b border-white/10 bg-ink-950/80 backdrop-blur-xs">
-            <div class="mx-auto flex w-full max-w-7xl items-center gap-3 px-4 py-4">
-                <a href="index.html" class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-white/80 transition hover:bg-white/10 focus-ring" aria-label="Telcoin Wiki home">
-                    <img src="logo.svg" alt="Telcoin Wiki" class="h-10 w-auto">
-                    <span class="sr-only">Telcoin Wiki</span>
-                </a>
-                <div class="flex flex-1 items-center justify-center">
-                    <div class="relative w-full max-w-xl">
-                        <label for="site-search" class="sr-only">Search TELx portfolio</label>
-                        <input id="site-search" data-site-search type="search" placeholder="Search this page" autocomplete="off" class="site-search-input">
-                        <div class="search-panel" data-search-results aria-hidden="true"></div>
+            <div class="mx-auto w-full max-w-7xl px-4 py-4">
+                <div class="flex w-full items-center gap-3">
+                    <a href="index.html" class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-white/80 transition hover:bg-white/10 focus-ring" aria-label="Telcoin Wiki home">
+                        <img src="logo.svg" alt="Telcoin Wiki" class="h-10 w-auto">
+                        <span class="sr-only">Telcoin Wiki</span>
+                    </a>
+                    <div class="flex flex-1 items-center justify-center">
+                        <div class="relative w-full max-w-xl">
+                            <label for="site-search" class="sr-only">Search TELx portfolio</label>
+                            <input id="site-search" data-site-search type="search" placeholder="Search this page" autocomplete="off" class="site-search-input">
+                            <div class="search-panel" data-search-results aria-hidden="true"></div>
+                        </div>
+                    </div>
+                    <div class="flex items-center">
+                        <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button lg:hidden focus-ring">
+                            <span class="sr-only">Open navigation</span>
+                            ☰
+                        </button>
                     </div>
                 </div>
-                <div class="flex items-center">
-                    <button type="button" data-mobile-toggle aria-controls="mobile-drawer" aria-expanded="false" class="icon-button lg:hidden focus-ring">
-                        <span class="sr-only">Open navigation</span>
-                        ☰
-                    </button>
+                <div class="mt-4 hidden lg:block" data-docs-header-nav>
+                    <nav data-docs-nav class="docs-nav docs-nav--header"></nav>
                 </div>
             </div>
         </header>
@@ -91,10 +96,7 @@
 
         <div class="flex-1 w-full">
             <div class="mx-auto max-w-7xl px-4 pb-24 pt-12 sm:pt-16">
-                <div class="grid grid-cols-1 gap-6 lg:grid-cols-[16rem_minmax(0,1fr)_14rem]">
-                    <aside class="hidden lg:block sticky top-16 h-[calc(100dvh-4rem)] overflow-y-auto pr-2" data-docs-sidebar>
-                        <nav data-docs-nav class="docs-nav space-y-3"></nav>
-                    </aside>
+                <div class="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,1fr)_14rem]">
                     <main id="main-content" class="space-y-16">
                         <section id="portfolio-overview" class="space-y-8">
                             <div class="glass p-8">

--- a/styles/site.css
+++ b/styles/site.css
@@ -263,6 +263,23 @@ html:not(.dark) .docs-drawer {
   gap: 0.65rem;
 }
 
+[data-docs-header-nav] {
+  overflow-x: auto;
+  padding-bottom: 0.25rem;
+}
+
+.docs-nav--header {
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.docs-nav--header .docs-nav-section {
+  flex: 1 1 13rem;
+  min-width: 12rem;
+  max-width: 16rem;
+}
+
 .docs-nav-section {
   border: 1px solid rgba(120, 180, 255, 0.2);
   border-radius: 1.1rem;

--- a/styles/site.css
+++ b/styles/site.css
@@ -275,9 +275,10 @@ html:not(.dark) .docs-drawer {
 }
 
 .docs-nav--header .docs-nav-section {
-  flex: 1 1 13rem;
-  min-width: 12rem;
-  max-width: 16rem;
+  flex: 0 0 auto;
+  min-width: 10rem;
+  max-width: 11rem;
+  width: 11rem;
 }
 
 .docs-nav-section {
@@ -293,11 +294,11 @@ html:not(.dark) .docs-drawer {
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
-  padding: 0.75rem 1rem;
+  padding: 0.4rem 0.85rem;
   background: transparent;
   border: none;
   color: rgba(230, 240, 255, 0.8);
-  font-size: 0.85rem;
+  font-size: 0.7rem;
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -326,6 +327,8 @@ html:not(.dark) .docs-drawer {
 .docs-nav-panel {
   display: flex;
   flex-direction: column;
+  max-width: 11rem;
+  width: 100%;
   padding: 0.35rem 0.5rem 0.75rem;
   gap: 0.25rem;
 }

--- a/styles/site.css
+++ b/styles/site.css
@@ -125,8 +125,8 @@ html:not(.dark) .icon-button:focus-visible {
   border: 1px solid rgba(114, 178, 255, 0.38);
   background: rgba(6, 22, 51, 0.62);
   color: #edf4ff;
-  padding: 0.65rem 1.1rem;
-  font-size: 0.9rem;
+  padding: 0.55rem 1rem;
+  font-size: 0.85rem;
   box-shadow: inset 0 0 0 1px rgba(122, 214, 255, 0.1), 0 12px 30px rgba(5, 18, 45, 0.35);
   transition: border-color 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
 }
@@ -270,8 +270,9 @@ html:not(.dark) .docs-drawer {
 
 .docs-nav--header {
   flex-direction: row;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 0.75rem;
+  justify-content: center;
 }
 
 .docs-nav--header .docs-nav-section {


### PR DESCRIPTION
## Summary
- reposition the docs accordion navigation into the sticky header on each knowledge page
- adjust the main layout grid to drop the empty sidebar column while keeping the TOC panel
- add header-specific styling so the navigation sections lay out horizontally while preserving their look

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d2a58395f88330abf31e45a8066a86