### PR TITLE
Refresh header community notice and background styling

### DIFF
--- a/about.html
+++ b/about.html
@@ -49,7 +49,7 @@
     <div class="relative flex min-h-screen flex-col">
         <div id="top"></div>
         <header class="sticky top-0 z-50 border-b border-white/10 bg-ink-950/80 backdrop-blur-xs">
-            <div class="mx-auto w-full max-w-7xl px-4 py-3 lg:py-2.5">
+            <div class="mx-auto w-full max-w-7xl px-4 py-3 lg:py-3">
                 <div class="flex w-full flex-wrap items-center gap-3 lg:grid lg:grid-cols-[auto_minmax(0,1fr)_minmax(0,15rem)] lg:items-center lg:gap-4">
                     <a href="index.html" class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-white/80 transition hover:bg-white/10 focus-ring" aria-label="Telcoin Wiki home">
                         <img src="logo.svg" alt="Telcoin Wiki" class="h-10 w-auto">
@@ -71,6 +71,17 @@
                             ☰
                         </button>
                     </div>
+                </div>
+                <div class="mt-3 w-full" data-community-banner-container>
+                    <details class="community-banner" open>
+                        <summary>
+                            <span>Community Repository</span>
+                            <span aria-hidden="true" class="banner-icon">▾</span>
+                        </summary>
+                        <div class="banner-body">
+                            This is an unofficial, community-created guide. For official information, visit <a class="link-ux" href="https://telcoin.org" target="_blank" rel="noopener">telcoin.org</a>.
+                        </div>
+                    </details>
                 </div>
             </div>
         </header>

--- a/deep-dive.html
+++ b/deep-dive.html
@@ -159,7 +159,7 @@
     <div class="relative flex min-h-screen flex-col">
         <div id="top"></div>
         <header class="sticky top-0 z-50 border-b border-white/10 bg-ink-950/80 backdrop-blur-xs">
-            <div class="mx-auto w-full max-w-7xl px-4 py-3 lg:py-2.5">
+            <div class="mx-auto w-full max-w-7xl px-4 py-3 lg:py-3">
                 <div class="flex w-full flex-wrap items-center gap-3 lg:grid lg:grid-cols-[auto_minmax(0,1fr)_minmax(0,15rem)] lg:items-center lg:gap-4">
                     <a href="index.html" class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-white/80 transition hover:bg-white/10 focus-ring" aria-label="Telcoin Wiki home">
                         <img src="logo.svg" alt="Telcoin Wiki" class="h-10 w-auto">
@@ -181,6 +181,17 @@
                             ☰
                         </button>
                     </div>
+                </div>
+                <div class="mt-3 w-full" data-community-banner-container>
+                    <details class="community-banner" open>
+                        <summary>
+                            <span>Community Repository</span>
+                            <span aria-hidden="true" class="banner-icon">▾</span>
+                        </summary>
+                        <div class="banner-body">
+                            This is an unofficial, community-created guide. For official information, visit <a class="link-ux" href="https://telcoin.org" target="_blank" rel="noopener">telcoin.org</a>.
+                        </div>
+                    </details>
                 </div>
             </div>
         </header>

--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@
     <div class="relative flex min-h-screen flex-col">
         <div id="top"></div>
         <header class="sticky top-0 z-50 border-b border-white/10 bg-ink-950/80 backdrop-blur-xs">
-            <div class="mx-auto w-full max-w-7xl px-4 py-3 lg:py-2.5">
+            <div class="mx-auto w-full max-w-7xl px-4 py-3 lg:py-3">
                 <div class="flex w-full flex-wrap items-center gap-3 lg:grid lg:grid-cols-[auto_minmax(0,1fr)_minmax(0,15rem)] lg:items-center lg:gap-4">
                     <a href="index.html" class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-white/80 transition hover:bg-white/10 focus-ring" aria-label="Telcoin Wiki home">
                         <img src="logo.svg" alt="Telcoin Wiki" class="h-10 w-auto">
@@ -154,6 +154,17 @@
                             ☰
                         </button>
                     </div>
+                </div>
+                <div class="mt-3 w-full" data-community-banner-container>
+                    <details class="community-banner" open>
+                        <summary>
+                            <span>Community Repository</span>
+                            <span aria-hidden="true" class="banner-icon">▾</span>
+                        </summary>
+                        <div class="banner-body">
+                            This is an unofficial, community-created guide. For official information, visit <a class="link-ux" href="https://telcoin.org" target="_blank" rel="noopener">telcoin.org</a>.
+                        </div>
+                    </details>
                 </div>
             </div>
         </header>
@@ -183,7 +194,7 @@
                     <main id="main-content" class="space-y-16">
                         <section id="hero" class="space-y-10 pt-16 sm:pt-20">
                             <div class="glass overflow-hidden border border-white/10 bg-white/5 p-8 shadow-glass">
-                                <p class="text-xs font-semibold uppercase tracking-[0.3em] text-mint-300/80">Community knowledge for TELx builders</p>
+                                <p class="text-xs font-semibold uppercase tracking-[0.3em] text-cobalt-300/90">Community Repository</p>
                                 <h1 class="mt-6 text-4xl font-semibold tracking-tight text-white sm:text-5xl">Telcoin Community Q&amp;A</h1>
                                 <p class="mt-4 max-w-2xl text-lg text-white/70">Unofficial Community Guide for New Telcoin Users - The Future of Global Finance, Now in Your Pocket</p>
                                 <div class="mt-8 rounded-2xl border border-white/10 bg-ink-900/60 p-6">
@@ -227,10 +238,6 @@
                                     <p class="mt-3 text-sm text-white/70">From the Nebraska Digital Asset Bank charter to TANIP-1 incentives, Telcoin aligns telecom operators, developers, and regulators so mobile users can access compliant digital cash, remittance, and liquidity services globally.</p>
                                     <a href="deep-dive.html?category=banking" class="mt-4 inline-flex items-center gap-2 text-sm font-medium text-mint-300 link-ux">Understand governance &amp; bank strategy →</a>
                                 </article>
-                            </div>
-                            <div class="glass border-l-4 border-amber-300/60 bg-amber-400/10 px-6 py-4 text-sm text-amber-100">
-                                <p class="font-medium">⚠️ Community Resource:</p>
-                                <p class="mt-2 text-amber-50/90">This is an unofficial, community-created guide. For official information, visit <a class="link-ux" href="https://telcoin.org" target="_blank" rel="noopener">telcoin.org</a>.</p>
                             </div>
                         </section>
 

--- a/links.html
+++ b/links.html
@@ -190,7 +190,7 @@
     <div class="relative flex min-h-screen flex-col">
         <div id="top"></div>
         <header class="sticky top-0 z-50 border-b border-white/10 bg-ink-950/80 backdrop-blur-xs">
-            <div class="mx-auto w-full max-w-7xl px-4 py-3 lg:py-2.5">
+            <div class="mx-auto w-full max-w-7xl px-4 py-3 lg:py-3">
                 <div class="flex w-full flex-wrap items-center gap-3 lg:grid lg:grid-cols-[auto_minmax(0,1fr)_minmax(0,15rem)] lg:items-center lg:gap-4">
                     <a href="index.html" class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-white/80 transition hover:bg-white/10 focus-ring" aria-label="Telcoin Wiki home">
                         <img src="logo.svg" alt="Telcoin Wiki" class="h-10 w-auto">
@@ -212,6 +212,17 @@
                             ☰
                         </button>
                     </div>
+                </div>
+                <div class="mt-3 w-full" data-community-banner-container>
+                    <details class="community-banner" open>
+                        <summary>
+                            <span>Community Repository</span>
+                            <span aria-hidden="true" class="banner-icon">▾</span>
+                        </summary>
+                        <div class="banner-body">
+                            This is an unofficial, community-created guide. For official information, visit <a class="link-ux" href="https://telcoin.org" target="_blank" rel="noopener">telcoin.org</a>.
+                        </div>
+                    </details>
                 </div>
             </div>
         </header>

--- a/pools.html
+++ b/pools.html
@@ -49,7 +49,7 @@
     <div class="relative flex min-h-screen flex-col">
         <div id="top"></div>
         <header class="sticky top-0 z-50 border-b border-white/10 bg-ink-950/80 backdrop-blur-xs">
-            <div class="mx-auto w-full max-w-7xl px-4 py-3 lg:py-2.5">
+            <div class="mx-auto w-full max-w-7xl px-4 py-3 lg:py-3">
                 <div class="flex w-full flex-wrap items-center gap-3 lg:grid lg:grid-cols-[auto_minmax(0,1fr)_minmax(0,15rem)] lg:items-center lg:gap-4">
                     <a href="index.html" class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-white/80 transition hover:bg-white/10 focus-ring" aria-label="Telcoin Wiki home">
                         <img src="logo.svg" alt="Telcoin Wiki" class="h-10 w-auto">
@@ -71,6 +71,17 @@
                             ☰
                         </button>
                     </div>
+                </div>
+                <div class="mt-3 w-full" data-community-banner-container>
+                    <details class="community-banner" open>
+                        <summary>
+                            <span>Community Repository</span>
+                            <span aria-hidden="true" class="banner-icon">▾</span>
+                        </summary>
+                        <div class="banner-body">
+                            This is an unofficial, community-created guide. For official information, visit <a class="link-ux" href="https://telcoin.org" target="_blank" rel="noopener">telcoin.org</a>.
+                        </div>
+                    </details>
                 </div>
             </div>
         </header>

--- a/portfolio.html
+++ b/portfolio.html
@@ -49,7 +49,7 @@
     <div class="relative flex min-h-screen flex-col">
         <div id="top"></div>
         <header class="sticky top-0 z-50 border-b border-white/10 bg-ink-950/80 backdrop-blur-xs">
-            <div class="mx-auto w-full max-w-7xl px-4 py-3 lg:py-2.5">
+            <div class="mx-auto w-full max-w-7xl px-4 py-3 lg:py-3">
                 <div class="flex w-full flex-wrap items-center gap-3 lg:grid lg:grid-cols-[auto_minmax(0,1fr)_minmax(0,15rem)] lg:items-center lg:gap-4">
                     <a href="index.html" class="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-white/80 transition hover:bg-white/10 focus-ring" aria-label="Telcoin Wiki home">
                         <img src="logo.svg" alt="Telcoin Wiki" class="h-10 w-auto">
@@ -71,6 +71,17 @@
                             ☰
                         </button>
                     </div>
+                </div>
+                <div class="mt-3 w-full" data-community-banner-container>
+                    <details class="community-banner" open>
+                        <summary>
+                            <span>Community Repository</span>
+                            <span aria-hidden="true" class="banner-icon">▾</span>
+                        </summary>
+                        <div class="banner-body">
+                            This is an unofficial, community-created guide. For official information, visit <a class="link-ux" href="https://telcoin.org" target="_blank" rel="noopener">telcoin.org</a>.
+                        </div>
+                    </details>
                 </div>
             </div>
         </header>

--- a/styles/site.css
+++ b/styles/site.css
@@ -116,16 +116,20 @@ a:focus-visible {
   border-radius: 1.15rem;
   border: 1px solid rgba(255, 214, 142, 0.38);
   background: linear-gradient(135deg, rgba(255, 201, 106, 0.22), rgba(255, 170, 70, 0.14));
-  padding: 1rem 1.25rem 1.15rem;
+  padding: 0.75rem 1.1rem 0.85rem;
   box-shadow: 0 18px 42px rgba(6, 16, 50, 0.35);
   transition: border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+header [data-community-banner-container] {
+  margin-top: 0.5rem !important;
 }
 
 .community-banner summary {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.75rem;
   list-style: none;
   cursor: pointer;
   font-size: 0.72rem;
@@ -150,9 +154,9 @@ a:focus-visible {
 }
 
 .community-banner .banner-body {
-  margin-top: 0.85rem;
-  font-size: 0.85rem;
-  line-height: 1.6;
+  margin-top: 0.6rem;
+  font-size: 0.8rem;
+  line-height: 1.5;
   color: rgba(255, 244, 214, 0.9);
 }
 

--- a/styles/site.css
+++ b/styles/site.css
@@ -12,11 +12,13 @@ body {
   font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
   line-height: 1.6;
   color: #e9f1ff;
+  --twinkle-opacity-low: 0.28;
+  --twinkle-opacity-high: 0.42;
   background:
-    radial-gradient(1200px 540px at -10% -10%, rgba(77, 155, 255, 0.28), transparent 65%),
-    radial-gradient(920px 620px at 115% -5%, rgba(56, 210, 255, 0.18), transparent 60%),
-    radial-gradient(880px 820px at 46% 120%, rgba(11, 37, 92, 0.55), transparent 65%),
-    linear-gradient(180deg, #040a1d 0%, #082560 45%, #0b3f94 80%, #104fc6 100%);
+    radial-gradient(1200px 540px at -10% -10%, rgba(111, 187, 255, 0.32), transparent 65%),
+    radial-gradient(960px 620px at 115% -5%, rgba(72, 142, 255, 0.28), transparent 60%),
+    radial-gradient(900px 820px at 46% 120%, rgba(18, 52, 135, 0.6), transparent 65%),
+    linear-gradient(180deg, #2e7aff 0%, #1d4dad 45%, #0f2c72 78%, #07163f 100%);
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -30,8 +32,40 @@ body::before {
   position: fixed;
   inset: 0;
   pointer-events: none;
-  opacity: 0.04;
-  mix-blend-mode: overlay;
+  background-image:
+    radial-gradient(2px 2px at 12% 18%, rgba(182, 226, 255, 0.85), transparent 60%),
+    radial-gradient(1.5px 1.5px at 32% 68%, rgba(126, 204, 255, 0.75), transparent 55%),
+    radial-gradient(1.2px 1.2px at 62% 28%, rgba(210, 238, 255, 0.78), transparent 55%),
+    radial-gradient(1.8px 1.8px at 82% 78%, rgba(153, 209, 255, 0.72), transparent 55%),
+    radial-gradient(1px 1px at 10% 82%, rgba(185, 228, 255, 0.65), transparent 60%),
+    radial-gradient(1.1px 1.1px at 50% 50%, rgba(240, 250, 255, 0.82), transparent 60%);
+  background-size: 360px 360px, 460px 460px, 520px 520px, 580px 580px, 640px 640px, 720px 720px;
+  opacity: var(--twinkle-opacity-low);
+  mix-blend-mode: screen;
+  animation: twinkle 24s ease-in-out infinite;
+  will-change: opacity, transform;
+  z-index: 0;
+}
+
+@keyframes twinkle {
+  0%,
+  100% {
+    opacity: var(--twinkle-opacity-low);
+    transform: translate3d(0, 0, 0);
+  }
+  50% {
+    opacity: var(--twinkle-opacity-high);
+    transform: translate3d(0, -0.6vh, 0);
+  }
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.06;
+  mix-blend-mode: soft-light;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
   z-index: 0;
 }
@@ -48,16 +82,22 @@ html:not(.dark) {
 
 html:not(.dark) body {
   color: #0b1220;
+  --twinkle-opacity-low: 0.16;
+  --twinkle-opacity-high: 0.26;
   background:
-    radial-gradient(1200px 540px at -10% -10%, rgba(73, 190, 255, 0.22), transparent 65%),
-    radial-gradient(920px 620px at 115% -5%, rgba(60, 214, 195, 0.16), transparent 60%),
-    radial-gradient(880px 820px at 46% 120%, rgba(215, 235, 255, 0.75), transparent 65%),
-    linear-gradient(180deg, #eef5ff 0%, #d4e6ff 50%, #e4f3ff 100%);
+    radial-gradient(1200px 540px at -10% -10%, rgba(132, 194, 255, 0.28), transparent 65%),
+    radial-gradient(960px 620px at 115% -5%, rgba(166, 210, 255, 0.26), transparent 60%),
+    radial-gradient(900px 820px at 46% 120%, rgba(222, 235, 255, 0.78), transparent 65%),
+    linear-gradient(180deg, #f7fbff 0%, #dbe9ff 45%, #e9f3ff 100%);
 }
 
 html:not(.dark) body::before {
-  opacity: 0.08;
-  mix-blend-mode: normal;
+  mix-blend-mode: lighten;
+}
+
+html:not(.dark) body::after {
+  opacity: 0.04;
+  mix-blend-mode: multiply;
 }
 
 a {
@@ -68,6 +108,84 @@ a {
 a:hover,
 a:focus-visible {
   color: inherit;
+}
+
+.community-banner {
+  position: relative;
+  display: block;
+  border-radius: 1.15rem;
+  border: 1px solid rgba(255, 214, 142, 0.38);
+  background: linear-gradient(135deg, rgba(255, 201, 106, 0.22), rgba(255, 170, 70, 0.14));
+  padding: 1rem 1.25rem 1.15rem;
+  box-shadow: 0 18px 42px rgba(6, 16, 50, 0.35);
+  transition: border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.community-banner summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  list-style: none;
+  cursor: pointer;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: rgba(255, 235, 192, 0.95);
+}
+
+.community-banner summary::-webkit-details-marker {
+  display: none;
+}
+
+.community-banner .banner-icon {
+  font-size: 1rem;
+  color: rgba(255, 235, 192, 0.85);
+  transition: transform 0.3s ease;
+}
+
+.community-banner[open] .banner-icon {
+  transform: rotate(180deg);
+}
+
+.community-banner .banner-body {
+  margin-top: 0.85rem;
+  font-size: 0.85rem;
+  line-height: 1.6;
+  color: rgba(255, 244, 214, 0.9);
+}
+
+.community-banner .banner-body a {
+  color: rgba(124, 194, 255, 0.95);
+  text-decoration: underline;
+}
+
+.community-banner .banner-body a:hover,
+.community-banner .banner-body a:focus-visible {
+  color: rgba(156, 212, 255, 1);
+}
+
+html:not(.dark) .community-banner {
+  border-color: rgba(249, 196, 96, 0.5);
+  background: linear-gradient(135deg, rgba(255, 237, 186, 0.65), rgba(255, 214, 138, 0.35));
+  box-shadow: 0 16px 36px rgba(214, 169, 86, 0.22);
+}
+
+html:not(.dark) .community-banner summary {
+  color: rgba(109, 74, 12, 0.8);
+}
+
+html:not(.dark) .community-banner .banner-icon {
+  color: rgba(165, 112, 18, 0.72);
+}
+
+html:not(.dark) .community-banner .banner-body {
+  color: rgba(81, 56, 13, 0.82);
+}
+
+html:not(.dark) .community-banner .banner-body a {
+  color: #1c4da0;
 }
 
 img {


### PR DESCRIPTION
## Summary
- move the community repository notice into an always-open header dropdown across each page and update the hero subtitle copy
- retune the global gradients to start lighter and add a subtle starfield background that aligns with the Telcoin blue palette
- style the new banner for dark and light themes using the Telco-inspired color set

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d33cbd00e4833087ddaa4610343563