### PR TITLE
Remove elasticlunr CDN dependency and add native search

### DIFF
--- a/404.html
+++ b/404.html
@@ -39,7 +39,6 @@
     ]
   }
   </script>
-  <script defer src="https://cdn.jsdelivr.net/npm/elasticlunr@0.9.6/elasticlunr.min.js" integrity="sha384-VY2k6pNnZX1hmzLwAlSP8nHbn8WCsuozN4/p2JjNyQaIJZL8SaJIs/VIVqVdPXge" crossorigin="anonymous"></script>
   <script defer src="/dist/main.js"></script>
 </head>
 <body data-page="404">

--- a/about.html
+++ b/about.html
@@ -38,7 +38,6 @@
     ]
   }
   </script>
-  <script defer src="https://cdn.jsdelivr.net/npm/elasticlunr@0.9.6/elasticlunr.min.js" integrity="sha384-VY2k6pNnZX1hmzLwAlSP8nHbn8WCsuozN4/p2JjNyQaIJZL8SaJIs/VIVqVdPXge" crossorigin="anonymous"></script>
   <script defer src="/dist/main.js"></script>
 </head>
 <body data-page="about">

--- a/builders.html
+++ b/builders.html
@@ -38,7 +38,6 @@
     ]
   }
   </script>
-  <script defer src="https://cdn.jsdelivr.net/npm/elasticlunr@0.9.6/elasticlunr.min.js" integrity="sha384-VY2k6pNnZX1hmzLwAlSP8nHbn8WCsuozN4/p2JjNyQaIJZL8SaJIs/VIVqVdPXge" crossorigin="anonymous"></script>
   <script defer src="/dist/main.js"></script>
 </head>
 <body data-page="builders">

--- a/deep-dive.html
+++ b/deep-dive.html
@@ -38,7 +38,6 @@
     ]
   }
   </script>
-  <script defer src="https://cdn.jsdelivr.net/npm/elasticlunr@0.9.6/elasticlunr.min.js" integrity="sha384-VY2k6pNnZX1hmzLwAlSP8nHbn8WCsuozN4/p2JjNyQaIJZL8SaJIs/VIVqVdPXge" crossorigin="anonymous"></script>
   <script defer src="/dist/main.js"></script>
 </head>
 <body data-page="deep-dive">

--- a/digital-cash.html
+++ b/digital-cash.html
@@ -38,7 +38,6 @@
     ]
   }
   </script>
-  <script defer src="https://cdn.jsdelivr.net/npm/elasticlunr@0.9.6/elasticlunr.min.js" integrity="sha384-VY2k6pNnZX1hmzLwAlSP8nHbn8WCsuozN4/p2JjNyQaIJZL8SaJIs/VIVqVdPXge" crossorigin="anonymous"></script>
   <script defer src="/dist/main.js"></script>
 </head>
 <body data-page="digital-cash">

--- a/faq/index.html
+++ b/faq/index.html
@@ -38,7 +38,6 @@
     ]
   }
   </script>
-  <script defer src="https://cdn.jsdelivr.net/npm/elasticlunr@0.9.6/elasticlunr.min.js" integrity="sha384-VY2k6pNnZX1hmzLwAlSP8nHbn8WCsuozN4/p2JjNyQaIJZL8SaJIs/VIVqVdPXge" crossorigin="anonymous"></script>
   <script defer src="/dist/main.js"></script>
   <script defer src="/dist/faq.js"></script>
 </head>

--- a/governance.html
+++ b/governance.html
@@ -38,7 +38,6 @@
     ]
   }
   </script>
-  <script defer src="https://cdn.jsdelivr.net/npm/elasticlunr@0.9.6/elasticlunr.min.js" integrity="sha384-VY2k6pNnZX1hmzLwAlSP8nHbn8WCsuozN4/p2JjNyQaIJZL8SaJIs/VIVqVdPXge" crossorigin="anonymous"></script>
   <script defer src="/dist/main.js"></script>
 </head>
 <body data-page="governance">

--- a/index.html
+++ b/index.html
@@ -429,7 +429,6 @@
     ]
   }
   </script>
-  <script defer src="https://cdn.jsdelivr.net/npm/elasticlunr@0.9.6/elasticlunr.min.js" integrity="sha384-VY2k6pNnZX1hmzLwAlSP8nHbn8WCsuozN4/p2JjNyQaIJZL8SaJIs/VIVqVdPXge" crossorigin="anonymous"></script>
   <script defer src="/dist/main.js"></script>
 </head>
 <body data-page="home">

--- a/links.html
+++ b/links.html
@@ -38,7 +38,6 @@
     ]
   }
   </script>
-  <script defer src="https://cdn.jsdelivr.net/npm/elasticlunr@0.9.6/elasticlunr.min.js" integrity="sha384-VY2k6pNnZX1hmzLwAlSP8nHbn8WCsuozN4/p2JjNyQaIJZL8SaJIs/VIVqVdPXge" crossorigin="anonymous"></script>
   <script defer src="/dist/main.js"></script>
 </head>
 <body data-page="links">

--- a/network.html
+++ b/network.html
@@ -38,7 +38,6 @@
     ]
   }
   </script>
-  <script defer src="https://cdn.jsdelivr.net/npm/elasticlunr@0.9.6/elasticlunr.min.js" integrity="sha384-VY2k6pNnZX1hmzLwAlSP8nHbn8WCsuozN4/p2JjNyQaIJZL8SaJIs/VIVqVdPXge" crossorigin="anonymous"></script>
   <script defer src="/dist/main.js"></script>
 </head>
 <body data-page="network">

--- a/pools.html
+++ b/pools.html
@@ -38,7 +38,6 @@
     ]
   }
   </script>
-  <script defer src="https://cdn.jsdelivr.net/npm/elasticlunr@0.9.6/elasticlunr.min.js" integrity="sha384-VY2k6pNnZX1hmzLwAlSP8nHbn8WCsuozN4/p2JjNyQaIJZL8SaJIs/VIVqVdPXge" crossorigin="anonymous"></script>
   <script defer src="/dist/main.js"></script>
   <script defer src="/dist/pools.js"></script>
 </head>

--- a/portfolio.html
+++ b/portfolio.html
@@ -38,7 +38,6 @@
     ]
   }
   </script>
-  <script defer src="https://cdn.jsdelivr.net/npm/elasticlunr@0.9.6/elasticlunr.min.js" integrity="sha384-VY2k6pNnZX1hmzLwAlSP8nHbn8WCsuozN4/p2JjNyQaIJZL8SaJIs/VIVqVdPXge" crossorigin="anonymous"></script>
   <script defer src="/dist/main.js"></script>
 </head>
 <body data-page="portfolio">

--- a/remittances.html
+++ b/remittances.html
@@ -38,7 +38,6 @@
     ]
   }
   </script>
-  <script defer src="https://cdn.jsdelivr.net/npm/elasticlunr@0.9.6/elasticlunr.min.js" integrity="sha384-VY2k6pNnZX1hmzLwAlSP8nHbn8WCsuozN4/p2JjNyQaIJZL8SaJIs/VIVqVdPXge" crossorigin="anonymous"></script>
   <script defer src="/dist/main.js"></script>
 </head>
 <body data-page="remittances">

--- a/start-here.html
+++ b/start-here.html
@@ -38,7 +38,6 @@
     ]
   }
   </script>
-  <script defer src="https://cdn.jsdelivr.net/npm/elasticlunr@0.9.6/elasticlunr.min.js" integrity="sha384-VY2k6pNnZX1hmzLwAlSP8nHbn8WCsuozN4/p2JjNyQaIJZL8SaJIs/VIVqVdPXge" crossorigin="anonymous"></script>
   <script defer src="/dist/main.js"></script>
 </head>
 <body data-page="start-here">

--- a/tel-token.html
+++ b/tel-token.html
@@ -38,7 +38,6 @@
     ]
   }
   </script>
-  <script defer src="https://cdn.jsdelivr.net/npm/elasticlunr@0.9.6/elasticlunr.min.js" integrity="sha384-VY2k6pNnZX1hmzLwAlSP8nHbn8WCsuozN4/p2JjNyQaIJZL8SaJIs/VIVqVdPXge" crossorigin="anonymous"></script>
   <script defer src="/dist/main.js"></script>
 </head>
 <body data-page="tel-token">

--- a/telx.html
+++ b/telx.html
@@ -38,7 +38,6 @@
     ]
   }
   </script>
-  <script defer src="https://cdn.jsdelivr.net/npm/elasticlunr@0.9.6/elasticlunr.min.js" integrity="sha384-VY2k6pNnZX1hmzLwAlSP8nHbn8WCsuozN4/p2JjNyQaIJZL8SaJIs/VIVqVdPXge" crossorigin="anonymous"></script>
   <script defer src="/dist/main.js"></script>
 </head>
 <body data-page="telx">

--- a/wallet.html
+++ b/wallet.html
@@ -38,7 +38,6 @@
     ]
   }
   </script>
-  <script defer src="https://cdn.jsdelivr.net/npm/elasticlunr@0.9.6/elasticlunr.min.js" integrity="sha384-VY2k6pNnZX1hmzLwAlSP8nHbn8WCsuozN4/p2JjNyQaIJZL8SaJIs/VIVqVdPXge" crossorigin="anonymous"></script>
   <script defer src="/dist/main.js"></script>
 </head>
 <body data-page="wallet">


### PR DESCRIPTION
## Summary
- replace the elasticlunr-backed indexing in the global header search with a local scoring implementation so no CDN script is required
- rework the FAQ filter/search logic to use the new lightweight indexer and operate without elasticlunr
- drop the elasticlunr CDN script tag from all pages now that the site bundles its own search logic

## Testing
- npm install *(fails: npm registry access is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c8c9024c8330b25f427e8d0df89d