### PR TITLE
Add shared status data integration for remittance counts

### DIFF
--- a/data/faq.json
+++ b/data/faq.json
@@ -36,7 +36,7 @@
     {
         "id": "where-can-i-send-remittances",
         "question": "Where can I send remittances today?",
-        "answer": "<p>Telcoin currently supports remittance corridors across 20+ countries, focusing on fast and low-cost mobile money payouts. Live corridor availability and fees are listed inside the Telcoin Wallet and on the official remittance corridors page.</p>",
+        "answer": "<p>Telcoin currently supports remittance corridors across <span data-status-key=\"remittanceCorridors\" data-status-format=\"plus\">20+</span> countries, focusing on fast and low-cost mobile money payouts. Live corridor availability and fees are listed inside the Telcoin Wallet and on the official remittance corridors page.</p>",
         "tags": [
             "Remittances",
             "Wallet"

--- a/dist/faq.js
+++ b/dist/faq.js
@@ -259,6 +259,10 @@
       container.appendChild(article);
     });
 
+    if (window.TelcoinWiki && typeof window.TelcoinWiki.applyStatusText === 'function') {
+      window.TelcoinWiki.applyStatusText(container);
+    }
+
     handleDeepLink();
   }
 

--- a/dist/main.js
+++ b/dist/main.js
@@ -49,6 +49,10 @@
   };
 
   const searchInstances = [];
+  const statusNumberFormatter = new Intl.NumberFormat('en-US');
+  const TelcoinWiki = (window.TelcoinWiki = window.TelcoinWiki || {});
+  TelcoinWiki.applyStatusText = applyStatusText;
+
   const FAQ_CARD_TOGGLE_SELECTOR = '[data-faq-card-toggle]';
   const GETTING_STARTED_HOST_SELECTOR = '[data-getting-started]';
   const GETTING_STARTED_TOGGLE_SELECTOR = '[data-getting-started-toggle]';
@@ -59,7 +63,56 @@
     initSearch();
     initInlineFaqCards();
     initGettingStartedSection();
+    applyStatusText(document);
   });
+
+  function getStatusData() {
+    const data = window.__STATUS__;
+    if (!data || typeof data !== 'object') {
+      return null;
+    }
+    return data;
+  }
+
+  function applyStatusText(root) {
+    const data = getStatusData();
+    if (!data) {
+      return;
+    }
+    const scope = root && typeof root.querySelectorAll === 'function' ? root : document;
+    const targets = scope.querySelectorAll('[data-status-key]');
+    if (!targets.length) {
+      return;
+    }
+    targets.forEach((element) => {
+      const key = element.getAttribute('data-status-key');
+      if (!key || !(key in data)) {
+        return;
+      }
+      const value = data[key];
+      if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return;
+      }
+      const format = element.getAttribute('data-status-format') || 'number';
+      const formatted = formatStatusValue(value, format);
+      if (formatted !== null) {
+        element.textContent = formatted;
+      }
+    });
+  }
+
+  function formatStatusValue(value, format) {
+    if (!Number.isFinite(value)) {
+      return null;
+    }
+    switch (format) {
+      case 'plus':
+        return `${statusNumberFormatter.format(value)}+`;
+      case 'number':
+      default:
+        return statusNumberFormatter.format(value);
+    }
+  }
 
   function initLayout() {
     const currentPageId = document.body?.dataset?.page || 'home';

--- a/dist/status-data.js
+++ b/dist/status-data.js
@@ -1,0 +1,1 @@
+window.__STATUS__ = {"remittanceCorridors":20};

--- a/faq/index.html
+++ b/faq/index.html
@@ -39,6 +39,7 @@
   }
   </script>
   <script defer src="https://cdn.jsdelivr.net/npm/elasticlunr@0.9.6/elasticlunr.min.js" integrity="sha384-VY2k6pNnZX1hmzLwAlSP8nHbn8WCsuozN4/p2JjNyQaIJZL8SaJIs/VIVqVdPXge" crossorigin="anonymous"></script>
+  <script defer src="/dist/status-data.js"></script>
   <script defer src="/dist/main.js"></script>
   <script defer src="/dist/faq.js"></script>
 </head>

--- a/index.html
+++ b/index.html
@@ -405,6 +405,7 @@
   }
   </script>
   <script defer src="https://cdn.jsdelivr.net/npm/elasticlunr@0.9.6/elasticlunr.min.js" integrity="sha384-VY2k6pNnZX1hmzLwAlSP8nHbn8WCsuozN4/p2JjNyQaIJZL8SaJIs/VIVqVdPXge" crossorigin="anonymous"></script>
+  <script defer src="/dist/status-data.js"></script>
   <script defer src="/dist/main.js"></script>
 </head>
 <body data-page="home">
@@ -514,7 +515,7 @@
           <a class="card card--link" role="listitem" href="https://telco.in/remittances" target="_blank" rel="noopener">
             <p class="card__meta">Remittances</p>
             <h3 class="card__title">Active corridors &amp; fees</h3>
-            <p>See the 20+ supported send and receive markets, payout partners, and pricing straight from the official corridors page.</p>
+            <p>See the <span data-status-key="remittanceCorridors" data-status-format="plus">20+</span> supported send and receive markets, payout partners, and pricing straight from the official corridors page.</p>
             <span class="card__cta">View corridors →</span>
           </a>
         </div>

--- a/js/faq.js
+++ b/js/faq.js
@@ -259,6 +259,10 @@
       container.appendChild(article);
     });
 
+    if (window.TelcoinWiki && typeof window.TelcoinWiki.applyStatusText === 'function') {
+      window.TelcoinWiki.applyStatusText(container);
+    }
+
     handleDeepLink();
   }
 

--- a/js/main.js
+++ b/js/main.js
@@ -49,6 +49,10 @@
   };
 
   const searchInstances = [];
+  const statusNumberFormatter = new Intl.NumberFormat('en-US');
+  const TelcoinWiki = (window.TelcoinWiki = window.TelcoinWiki || {});
+  TelcoinWiki.applyStatusText = applyStatusText;
+
   const FAQ_CARD_TOGGLE_SELECTOR = '[data-faq-card-toggle]';
   const GETTING_STARTED_HOST_SELECTOR = '[data-getting-started]';
   const GETTING_STARTED_TOGGLE_SELECTOR = '[data-getting-started-toggle]';
@@ -59,7 +63,56 @@
     initSearch();
     initInlineFaqCards();
     initGettingStartedSection();
+    applyStatusText(document);
   });
+
+  function getStatusData() {
+    const data = window.__STATUS__;
+    if (!data || typeof data !== 'object') {
+      return null;
+    }
+    return data;
+  }
+
+  function applyStatusText(root) {
+    const data = getStatusData();
+    if (!data) {
+      return;
+    }
+    const scope = root && typeof root.querySelectorAll === 'function' ? root : document;
+    const targets = scope.querySelectorAll('[data-status-key]');
+    if (!targets.length) {
+      return;
+    }
+    targets.forEach((element) => {
+      const key = element.getAttribute('data-status-key');
+      if (!key || !(key in data)) {
+        return;
+      }
+      const value = data[key];
+      if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return;
+      }
+      const format = element.getAttribute('data-status-format') || 'number';
+      const formatted = formatStatusValue(value, format);
+      if (formatted !== null) {
+        element.textContent = formatted;
+      }
+    });
+  }
+
+  function formatStatusValue(value, format) {
+    if (!Number.isFinite(value)) {
+      return null;
+    }
+    switch (format) {
+      case 'plus':
+        return `${statusNumberFormatter.format(value)}+`;
+      case 'number':
+      default:
+        return statusNumberFormatter.format(value);
+    }
+  }
 
   function initLayout() {
     const currentPageId = document.body?.dataset?.page || 'home';

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "check:html": "html-validate '**/*.html'",
     "check:links": "linkinator . --recurse --silent --skip 'node_modules|dist'",
     "build:css": "csso styles/index.css --output dist/styles.css",
-    "build:js": "mkdir -p dist && terser js/main.js -o dist/main.js --compress --mangle && terser js/faq.js -o dist/faq.js --compress --mangle && terser js/pools-data.js -o dist/pools.js --compress --mangle",
+    "build:js": "mkdir -p dist && node scripts/build-status-data.js && terser js/main.js -o dist/main.js --compress --mangle && terser js/faq.js -o dist/faq.js --compress --mangle && terser js/pools-data.js -o dist/pools.js --compress --mangle",
     "build:img": "node scripts/optimize-images.js",
     "build": "npm run build:css && npm run build:js && npm run build:img"
   },

--- a/remittances.html
+++ b/remittances.html
@@ -39,6 +39,7 @@
   }
   </script>
   <script defer src="https://cdn.jsdelivr.net/npm/elasticlunr@0.9.6/elasticlunr.min.js" integrity="sha384-VY2k6pNnZX1hmzLwAlSP8nHbn8WCsuozN4/p2JjNyQaIJZL8SaJIs/VIVqVdPXge" crossorigin="anonymous"></script>
+  <script defer src="/dist/status-data.js"></script>
   <script defer src="/dist/main.js"></script>
 </head>
 <body data-page="remittances">
@@ -128,7 +129,7 @@
       <section id="remittance-overview" class="page-intro anchor-offset">
         <p class="page-intro__eyebrow">Remittances</p>
         <h1 class="page-intro__title">Send money with Telcoin</h1>
-        <p class="page-intro__lede">The Telcoin Wallet offers fast, low-cost remittances across more than 20 corridors. Use the official corridor directory to confirm supported routes, payout partners, and fees before you transfer.</p>
+        <p class="page-intro__lede">The Telcoin Wallet offers fast, low-cost remittances across more than <span data-status-key="remittanceCorridors">20</span> corridors. Use the official corridor directory to confirm supported routes, payout partners, and fees before you transfer.</p>
       </section>
 
       <section id="remittance-coverage" class="anchor-offset">

--- a/scripts/build-status-data.js
+++ b/scripts/build-status-data.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = path.resolve(__dirname, '..');
+const statusPath = path.join(rootDir, 'status.json');
+const outputPath = path.join(rootDir, 'dist', 'status-data.js');
+
+function readStatus() {
+  try {
+    const raw = fs.readFileSync(statusPath, 'utf8');
+    const data = JSON.parse(raw);
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+      throw new Error('status.json must contain an object.');
+    }
+    return data;
+  } catch (error) {
+    console.error('[build-status-data] Failed to read status.json:', error.message);
+    process.exit(1);
+  }
+}
+
+function writeBundle(data) {
+  const payload = `window.__STATUS__ = ${JSON.stringify(data)};\n`;
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, payload, 'utf8');
+}
+
+function main() {
+  const data = readStatus();
+  writeBundle(data);
+}
+
+main();

--- a/scripts/bump-status.ts
+++ b/scripts/bump-status.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+type StatusMap = Record<string, number>;
+
+type BumpResult = {
+  key: string;
+  previous: number;
+  next: number;
+};
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function loadStatus(filePath: string): StatusMap {
+  const raw = readFileSync(filePath, 'utf8');
+  const data = JSON.parse(raw) as unknown;
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    throw new Error('status.json must contain a top-level object.');
+  }
+
+  const map: StatusMap = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      throw new Error(`status.json field "${key}" must be a finite number.`);
+    }
+    map[key] = value;
+  }
+
+  return map;
+}
+
+function saveStatus(filePath: string, data: StatusMap): void {
+  const sorted = Object.keys(data)
+    .sort((a, b) => a.localeCompare(b))
+    .reduce<StatusMap>((acc, key) => {
+      acc[key] = data[key];
+      return acc;
+    }, {});
+
+  const payload = JSON.stringify(sorted, null, 2);
+  writeFileSync(filePath, `${payload}\n`, 'utf8');
+}
+
+function parseArgs(args: string[]): { key: string; amount: number } {
+  const [key, amountArg] = args;
+  if (!key) {
+    throw new Error('Usage: bump-status <field> [amount]');
+  }
+
+  const amount = amountArg ? Number(amountArg) : 1;
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new Error('Amount must be a positive number.');
+  }
+  if (!Number.isInteger(amount)) {
+    throw new Error('Amount must be an integer.');
+  }
+
+  return { key, amount };
+}
+
+function bumpStatus(data: StatusMap, key: string, amount: number): BumpResult {
+  if (!(key in data)) {
+    throw new Error(`Field "${key}" is not defined in status.json.`);
+  }
+
+  const previous = data[key];
+  const next = previous + amount;
+  if (!Number.isSafeInteger(next)) {
+    throw new Error(`Resulting value for "${key}" exceeds safe integer limits.`);
+  }
+
+  data[key] = next;
+  return { key, previous, next };
+}
+
+function main(): void {
+  try {
+    const { key, amount } = parseArgs(process.argv.slice(2));
+    const statusPath = resolve(__dirname, '..', 'status.json');
+    const data = loadStatus(statusPath);
+    const result = bumpStatus(data, key, amount);
+    saveStatus(statusPath, data);
+    console.log(`Updated ${result.key}: ${result.previous} → ${result.next}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(message);
+    process.exitCode = 1;
+  }
+}
+
+main();
+export {};

--- a/start-here.html
+++ b/start-here.html
@@ -39,6 +39,7 @@
   }
   </script>
   <script defer src="https://cdn.jsdelivr.net/npm/elasticlunr@0.9.6/elasticlunr.min.js" integrity="sha384-VY2k6pNnZX1hmzLwAlSP8nHbn8WCsuozN4/p2JjNyQaIJZL8SaJIs/VIVqVdPXge" crossorigin="anonymous"></script>
+  <script defer src="/dist/status-data.js"></script>
   <script defer src="/dist/main.js"></script>
 </head>
 <body data-page="start-here">
@@ -225,7 +226,7 @@
             </div>
             <div class="accordion__content faq-card__content" id="remittance-coverage-panel" role="region" aria-labelledby="remittance-coverage-toggle" hidden>
               <div class="faq-card__answer">
-                <p>Telcoin currently supports remittance corridors across 20+ countries, focusing on fast and low-cost mobile money payouts. Live corridor availability and fees are listed inside the Telcoin Wallet and on the official remittance corridors page.</p>
+                <p>Telcoin currently supports remittance corridors across <span data-status-key="remittanceCorridors" data-status-format="plus">20+</span> countries, focusing on fast and low-cost mobile money payouts. Live corridor availability and fees are listed inside the Telcoin Wallet and on the official remittance corridors page.</p>
               </div>
               <div class="faq-card__actions">
                 <a class="faq-card__cta" href="/remittances.html">View remittance coverage</a>

--- a/status.json
+++ b/status.json
@@ -1,0 +1,3 @@
+{
+  "remittanceCorridors": 20
+}

--- a/wallet.html
+++ b/wallet.html
@@ -39,6 +39,7 @@
   }
   </script>
   <script defer src="https://cdn.jsdelivr.net/npm/elasticlunr@0.9.6/elasticlunr.min.js" integrity="sha384-VY2k6pNnZX1hmzLwAlSP8nHbn8WCsuozN4/p2JjNyQaIJZL8SaJIs/VIVqVdPXge" crossorigin="anonymous"></script>
+  <script defer src="/dist/status-data.js"></script>
   <script defer src="/dist/main.js"></script>
 </head>
 <body data-page="wallet">
@@ -136,7 +137,7 @@
         <div class="card-grid card-grid--cols-2" role="list">
           <article class="card" role="listitem">
             <h3 class="card__title">Send and receive money</h3>
-            <p>Access 20+ corridors with mobile money, bank, and cash-out partners while seeing transparent fees before every transfer.</p>
+            <p>Access <span data-status-key="remittanceCorridors" data-status-format="plus">20+</span> corridors with mobile money, bank, and cash-out partners while seeing transparent fees before every transfer.</p>
             <p><a href="https://telco.in/remittances" target="_blank" rel="noopener">Review corridor coverage →</a></p>
           </article>
           <article class="card" role="listitem">


### PR DESCRIPTION
## Summary
- add a root-level status.json and a build step that emits dist/status-data.js for the UI
- expose a TypeScript bump-status utility for safely incrementing status counters
- update layout scripts and pages to source the remittance corridor count from the shared status data

## Testing
- npm run build *(fails: csso CLI is unavailable in the execution environment)*
- npm run build:js *(fails: terser CLI depends on commander, which cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d47c7147288330a19d8746087612a8