### PR TITLE
Add network status UI scaffolding components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,20 @@
+import type { FC } from 'react';
+import { LearnMore, PhaseOverview, RoadToMainnet, SecurityAudits } from './components';
+
+export const App: FC = () => {
+  return (
+    <div className="mx-auto flex max-w-5xl flex-col gap-10 p-4 sm:p-6 lg:p-10">
+      <header className="flex flex-col gap-2 text-slate-600 dark:text-slate-300">
+        <p className="text-sm uppercase tracking-[0.3em] text-slate-400 dark:text-slate-500">Telcoin Network Status</p>
+        <h1 className="text-3xl font-semibold text-slate-900 dark:text-slate-100">Live view of Devnet, Testnet, and Mainnet progress</h1>
+      </header>
+      <PhaseOverview />
+      <SecurityAudits />
+      <RoadToMainnet />
+      <LearnMore />
+    </div>
+  );
+};
+
+export default App;
+

--- a/src/components/LearnMore.tsx
+++ b/src/components/LearnMore.tsx
@@ -1,0 +1,62 @@
+import { useState, type FC } from 'react';
+import { statusData } from '../data/status';
+
+export const LearnMore: FC = () => {
+  const { learnMore } = statusData;
+  const [expanded, setExpanded] = useState<string | null>(learnMore.faqs[0]?.id ?? null);
+
+  const toggle = (id: string) => {
+    setExpanded((current) => (current === id ? null : id));
+  };
+
+  return (
+    <section className="rounded-3xl border border-slate-200/80 bg-white/80 p-8 shadow-sm shadow-slate-200/40 backdrop-blur dark:border-slate-700/60 dark:bg-slate-950/60 dark:shadow-black/10">
+      <header className="mb-6 flex items-center gap-3">
+        <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-slate-100 text-slate-500 dark:bg-slate-900 dark:text-slate-300">
+          <span className="text-lg">ℹ️</span>
+        </span>
+        <div>
+          <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Learn More</h2>
+          <p className="text-sm text-slate-500 dark:text-slate-400">Frequently asked questions about network phases.</p>
+        </div>
+      </header>
+      <div className="space-y-4">
+        {learnMore.faqs.map((faq) => {
+          const isOpen = expanded === faq.id;
+          return (
+            <div key={faq.id} className="overflow-hidden rounded-2xl border border-slate-200/70 bg-white/70 shadow-inner shadow-slate-200/40 dark:border-slate-700/60 dark:bg-slate-950/40">
+              <button
+                type="button"
+                onClick={() => toggle(faq.id)}
+                className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left text-sm font-medium text-slate-700 transition hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-900/60"
+              >
+                <span>{faq.question}</span>
+                <span className="text-lg text-slate-400 dark:text-slate-500">{isOpen ? '−' : '+'}</span>
+              </button>
+              {isOpen ? (
+                <div className="border-t border-slate-100 px-5 py-4 text-sm text-slate-600 dark:border-slate-800 dark:text-slate-300">
+                  {faq.answer}
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+      <footer className="mt-8 flex flex-wrap gap-3">
+        {learnMore.links.map((link) => (
+          <a
+            key={link.href}
+            href={link.href}
+            className="inline-flex items-center gap-2 rounded-full border border-slate-200/80 bg-white/60 px-4 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-300 hover:text-slate-900 dark:border-slate-700/60 dark:bg-slate-900/60 dark:text-slate-300 dark:hover:border-slate-600"
+          >
+            <span className="text-base">↗</span>
+            {link.label}
+          </a>
+        ))}
+      </footer>
+    </section>
+  );
+};
+
+export default LearnMore;
+

--- a/src/components/PhaseOverview.tsx
+++ b/src/components/PhaseOverview.tsx
@@ -1,0 +1,81 @@
+import type { FC } from 'react';
+import { statusData, type PhaseEntry, type ProgressState } from '../data/status';
+
+const statusColorMap: Record<ProgressState, string> = {
+  'in-progress': 'bg-amber-100 text-amber-700 dark:bg-amber-200/20 dark:text-amber-300',
+  upcoming: 'bg-slate-100 text-slate-600 dark:bg-slate-800/80 dark:text-slate-300',
+  complete: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-200/20 dark:text-emerald-300',
+};
+
+const statusDotMap: Record<ProgressState, string> = {
+  'in-progress': 'bg-amber-500',
+  upcoming: 'bg-slate-400',
+  complete: 'bg-emerald-500',
+};
+
+const PhaseCard: FC<{ phase: PhaseEntry }> = ({ phase }) => {
+  return (
+    <article className="flex flex-col gap-4 rounded-3xl border border-slate-200/80 bg-white/70 p-6 shadow-sm shadow-slate-200/40 backdrop-blur dark:border-slate-700/60 dark:bg-slate-900/80 dark:shadow-black/5">
+      <header className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{phase.name}</h3>
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">{phase.headline}</p>
+        </div>
+        <span className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium ${statusColorMap[phase.status]}`}>
+          <span className={`h-2 w-2 rounded-full ${statusDotMap[phase.status]}`}></span>
+          {phase.badgeLabel}
+        </span>
+      </header>
+      <p className="text-sm text-slate-600 dark:text-slate-300">{phase.summary}</p>
+      <ul className="mt-auto space-y-2 text-sm text-slate-600 dark:text-slate-300">
+        {phase.highlights.map((item) => (
+          <li key={item.label} className="flex items-start gap-2">
+            <span className="mt-1 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-slate-300 dark:bg-slate-600"></span>
+            <span>{item.label}</span>
+          </li>
+        ))}
+      </ul>
+    </article>
+  );
+};
+
+export const PhaseOverview: FC = () => {
+  const { phaseOverview } = statusData;
+
+  return (
+    <section className="flex flex-col gap-6 rounded-3xl border border-slate-200/80 bg-white/80 p-8 shadow-sm shadow-slate-200/40 backdrop-blur dark:border-slate-700/60 dark:bg-slate-950/60 dark:shadow-black/10">
+      <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.2em] text-slate-400 dark:text-slate-500">Live view</p>
+          <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Current Phase Overview</h2>
+        </div>
+        <div className="flex flex-col items-start gap-3 text-sm text-slate-500 dark:text-slate-400 md:items-end">
+          <div className="flex items-center gap-2">
+            <span className="inline-flex h-2 w-2 rounded-full bg-emerald-400"></span>
+            <span>Overall trajectory</span>
+          </div>
+          <div className="flex w-full max-w-xs items-center gap-3 md:w-60">
+            <div className="relative h-2 flex-1 rounded-full bg-slate-200 dark:bg-slate-700">
+              <span
+                className="absolute inset-y-0 left-0 rounded-full bg-emerald-500 transition-all"
+                style={{ width: `${Math.round(phaseOverview.overallTrajectory * 100)}%` }}
+              ></span>
+            </div>
+            <span className="text-xs font-medium text-slate-600 dark:text-slate-300">
+              {Math.round(phaseOverview.overallTrajectory * 100)}%
+            </span>
+          </div>
+          <span className="text-xs text-slate-400 dark:text-slate-500">Last updated {phaseOverview.lastUpdated}</span>
+        </div>
+      </header>
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {phaseOverview.phases.map((phase) => (
+          <PhaseCard key={phase.id} phase={phase} />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default PhaseOverview;
+

--- a/src/components/RoadToMainnet.tsx
+++ b/src/components/RoadToMainnet.tsx
@@ -1,0 +1,61 @@
+import type { FC } from 'react';
+import { statusData, type RoadmapMilestone } from '../data/status';
+
+const statusText: Record<RoadmapMilestone['status'], string> = {
+  'in-progress': 'text-amber-500',
+  upcoming: 'text-slate-400',
+  complete: 'text-emerald-500',
+  planned: 'text-slate-400',
+};
+
+const statusLabel: Record<RoadmapMilestone['status'], string> = {
+  'in-progress': 'In progress',
+  upcoming: 'Upcoming',
+  planned: 'Planned',
+  complete: 'Complete',
+};
+
+const indicatorBg: Record<RoadmapMilestone['status'], string> = {
+  'in-progress': 'bg-amber-400',
+  upcoming: 'bg-slate-300',
+  planned: 'bg-slate-300',
+  complete: 'bg-emerald-500',
+};
+
+export const RoadToMainnet: FC = () => {
+  const { roadmap } = statusData;
+
+  return (
+    <section className="rounded-3xl border border-slate-200/80 bg-white/80 p-8 shadow-sm shadow-slate-200/40 backdrop-blur dark:border-slate-700/60 dark:bg-slate-950/60 dark:shadow-black/10">
+      <header className="mb-6">
+        <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Road to Mainnet</h2>
+        <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+          Track the key milestones that close out the Mainnet launch checklist.
+        </p>
+      </header>
+      <ol className="relative space-y-6">
+        <span className="absolute left-4 top-0 hidden h-full w-px bg-slate-200 dark:bg-slate-800 md:block" aria-hidden="true"></span>
+        {roadmap.milestones.map((milestone) => (
+          <li key={milestone.id} className="relative flex flex-col gap-2 rounded-2xl border border-transparent bg-white/60 p-4 transition hover:border-slate-200 dark:bg-slate-950/30 dark:hover:border-slate-700 md:ml-6 md:p-5">
+            <span
+              className={`absolute left-0 top-5 hidden h-3 w-3 -translate-x-1/2 rounded-full ${indicatorBg[milestone.status]} md:block`}
+              aria-hidden="true"
+            ></span>
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <h3 className="text-lg font-medium text-slate-900 dark:text-slate-100">{milestone.title}</h3>
+              <span className={`text-xs font-medium uppercase tracking-wide ${statusText[milestone.status]}`}>
+                {statusLabel[milestone.status]}
+              </span>
+            </div>
+            {milestone.description ? (
+              <p className="text-sm text-slate-600 dark:text-slate-300">{milestone.description}</p>
+            ) : null}
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+};
+
+export default RoadToMainnet;
+

--- a/src/components/SecurityAudits.tsx
+++ b/src/components/SecurityAudits.tsx
@@ -1,0 +1,73 @@
+import type { FC } from 'react';
+import { statusData } from '../data/status';
+
+const severityAccent: Record<string, string> = {
+  High: 'text-rose-500',
+  Medium: 'text-amber-500',
+  Low: 'text-emerald-500',
+  Info: 'text-sky-500',
+};
+
+export const SecurityAudits: FC = () => {
+  const { securityAudits } = statusData;
+
+  return (
+    <section className="grid gap-8 rounded-3xl border border-slate-200/80 bg-white/80 p-8 shadow-sm shadow-slate-200/40 backdrop-blur dark:border-slate-700/60 dark:bg-slate-950/60 dark:shadow-black/10 md:grid-cols-[minmax(0,1fr)_minmax(280px,340px)]">
+      <div className="space-y-6">
+        <header>
+          <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Security &amp; Audits</h2>
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">Live audit coverage and remediation progress.</p>
+        </header>
+        <ul className="space-y-4 text-sm text-slate-600 dark:text-slate-300">
+          {securityAudits.highlights.map((highlight) => (
+            <li key={highlight} className="flex items-start gap-3">
+              <span className="mt-1 h-2 w-2 flex-shrink-0 rounded-full bg-slate-300 dark:bg-slate-700"></span>
+              <span>{highlight}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <aside className="flex flex-col gap-6 rounded-2xl border border-slate-200/80 bg-white/70 p-6 shadow-inner shadow-slate-200/40 dark:border-slate-700/60 dark:bg-slate-900/60">
+        <div className="flex flex-col gap-2">
+          <span className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400 dark:text-slate-500">{securityAudits.summary.label}</span>
+          <div className="text-2xl font-semibold text-slate-900 dark:text-slate-100">{securityAudits.summary.value}</div>
+          {securityAudits.summary.helperText ? (
+            <p className="text-xs text-slate-500 dark:text-slate-400">{securityAudits.summary.helperText}</p>
+          ) : null}
+        </div>
+        <div className="overflow-hidden rounded-xl border border-slate-200/70 dark:border-slate-700/50">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-slate-50 text-xs uppercase tracking-wide text-slate-500 dark:bg-slate-900/40 dark:text-slate-400">
+              <tr>
+                <th className="px-4 py-3 font-medium">Severity</th>
+                <th className="px-4 py-3 font-medium">Public-facing</th>
+                <th className="px-4 py-3 font-medium">After fixes</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+              {securityAudits.findings.map((row) => (
+                <tr key={row.severity} className="bg-white/60 text-slate-600 dark:bg-slate-950/40 dark:text-slate-300">
+                  <td className="px-4 py-3 font-medium">
+                    <span className={severityAccent[row.severity] ?? 'text-slate-500'}>{row.severity}</span>
+                  </td>
+                  <td className="px-4 py-3">{row.publicFacing}</td>
+                  <td className="px-4 py-3">{row.afterFixes}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <div className="rounded-xl border border-slate-200/70 bg-slate-50/80 p-4 text-sm text-slate-600 shadow-inner dark:border-slate-700/60 dark:bg-slate-900/60 dark:text-slate-300">
+          <div className="font-medium text-slate-900 dark:text-slate-100">{securityAudits.afterFixesSummary.label}</div>
+          <div className="text-lg font-semibold text-emerald-600 dark:text-emerald-400">{securityAudits.afterFixesSummary.value}</div>
+          {securityAudits.afterFixesSummary.helperText ? (
+            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{securityAudits.afterFixesSummary.helperText}</p>
+          ) : null}
+        </div>
+      </aside>
+    </section>
+  );
+};
+
+export default SecurityAudits;
+

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,5 @@
+export { PhaseOverview } from './PhaseOverview';
+export { SecurityAudits } from './SecurityAudits';
+export { RoadToMainnet } from './RoadToMainnet';
+export { LearnMore } from './LearnMore';
+

--- a/src/data/status.ts
+++ b/src/data/status.ts
@@ -1,0 +1,215 @@
+export type PhaseStatusKey = 'devnet' | 'publicTestnet' | 'mainnet';
+
+export type ProgressState = 'in-progress' | 'upcoming' | 'complete';
+
+export interface PhaseHighlight {
+  label: string;
+}
+
+export interface PhaseEntry {
+  id: PhaseStatusKey;
+  name: string;
+  headline: string;
+  summary: string;
+  status: ProgressState;
+  badgeLabel: string;
+  highlights: PhaseHighlight[];
+}
+
+export interface PhaseOverviewData {
+  lastUpdated: string;
+  overallTrajectory: number;
+  phases: PhaseEntry[];
+}
+
+export interface AuditCallout {
+  label: string;
+  value: string;
+  helperText?: string;
+}
+
+export interface AuditTableRow {
+  severity: string;
+  publicFacing: number;
+  afterFixes: number;
+}
+
+export interface SecurityAuditsData {
+  highlights: string[];
+  summary: AuditCallout;
+  findings: AuditTableRow[];
+  afterFixesSummary: AuditCallout;
+}
+
+export interface RoadmapMilestone {
+  id: string;
+  title: string;
+  status: ProgressState | 'planned';
+  description?: string;
+}
+
+export interface RoadmapData {
+  milestones: RoadmapMilestone[];
+}
+
+export interface FaqItem {
+  id: string;
+  question: string;
+  answer: string;
+}
+
+export interface LearnMoreLink {
+  label: string;
+  href: string;
+}
+
+export interface LearnMoreData {
+  faqs: FaqItem[];
+  links: LearnMoreLink[];
+}
+
+export interface StatusData {
+  phaseOverview: PhaseOverviewData;
+  securityAudits: SecurityAuditsData;
+  roadmap: RoadmapData;
+  learnMore: LearnMoreData;
+}
+
+export const statusData: StatusData = {
+  phaseOverview: {
+    lastUpdated: '23 Sept 2025, 19:00 UTC',
+    overallTrajectory: 0.25,
+    phases: [
+      {
+        id: 'devnet',
+        name: 'Devnet',
+        headline: 'Testing the final high-privacy shield systems before public release.',
+        summary:
+          'Devnet is delivering public-facing fixes in flight. Design work is wrapping up quickly to patch remaining combo bugs.',
+        status: 'in-progress',
+        badgeLabel: 'In progress',
+        highlights: [
+          { label: 'Addressing public-facing findings (3 high, 5 medium)' },
+          { label: 'Rerunning audit patches on every deploy to patch medium combos' },
+          { label: 'Design complete for coverage gap patch' },
+          { label: 'Extend peer coverage per patch' },
+        ],
+      },
+      {
+        id: 'publicTestnet',
+        name: 'Public Testnet',
+        headline: 'Testnet will onboard stable Devnet releases before enabling public validators.',
+        summary:
+          'Public Testnet will involve MMO-run validator nodes. Once stable, Devnet wins clear the path to open testing.',
+        status: 'upcoming',
+        badgeLabel: 'Upcoming',
+        highlights: [
+          { label: 'Finalize Devnet relaunch' },
+          { label: 'Rollout aligned with MMO nodes' },
+          { label: 'Security testing + audit fixes' },
+          { label: 'Open community soak testing' },
+        ],
+      },
+      {
+        id: 'mainnet',
+        name: 'Mainnet',
+        headline: 'Mainnet follows Testnet stability and final security hardening.',
+        summary:
+          'Alpha beta area to upgrade tracks like (finance improvements). Once security coverage is complete, production release begins.',
+        status: 'upcoming',
+        badgeLabel: 'Upcoming',
+        highlights: [
+          { label: 'Finalize production code' },
+          { label: 'Go/No-Go readiness review' },
+          { label: 'Compliance & regulatory reporting' },
+          { label: 'Confirm rollout sequencing' },
+        ],
+      },
+    ],
+  },
+  securityAudits: {
+    highlights: [
+      'Major architectural changes complete (one in progress).',
+      'Every patch this sprint added tests (caught 3 bugs missed in audit).',
+      'Another audit companion - enable insurance + 24/7 post-launch coverage.',
+    ],
+    summary: {
+      label: 'Priority Findings (public-facing)',
+      value: 'Devnet',
+      helperText: 'Live view of open issues discovered in latest audits.',
+    },
+    findings: [
+      { severity: 'High', publicFacing: 3, afterFixes: 0 },
+      { severity: 'Medium', publicFacing: 5, afterFixes: 2 },
+      { severity: 'Low', publicFacing: 4, afterFixes: 3 },
+      { severity: 'Info', publicFacing: 5, afterFixes: 4 },
+    ],
+    afterFixesSummary: {
+      label: 'After Priority Fixes (remaining)',
+      value: 'Low: 36',
+      helperText: 'Remaining backlog once all priority fixes ship to production.',
+    },
+  },
+  roadmap: {
+    milestones: [
+      {
+        id: 'fix-vulnerabilities',
+        title: 'Fix remaining vulnerabilities',
+        status: 'in-progress',
+        description: 'Patch backlog items uncovered during the latest audit cycle.',
+      },
+      {
+        id: 'relaunch-devnet',
+        title: 'Relaunch Devnet',
+        status: 'planned',
+        description: 'Stabilize shielded transactions and redeploy public Devnet with fixes.',
+      },
+      {
+        id: 'launch-testnet',
+        title: 'Launch Public Testnet',
+        status: 'planned',
+        description: 'Invite validators and the community to run the MMO-aligned network.',
+      },
+      {
+        id: 'final-audits',
+        title: 'Final audits & completion',
+        status: 'planned',
+        description: 'Complete final pass with audit partners and confirm green light.',
+      },
+      {
+        id: 'mainnet-launch',
+        title: 'Mainnet launch',
+        status: 'planned',
+        description: 'Production go-live once readiness reviews are complete.',
+      },
+    ],
+  },
+  learnMore: {
+    faqs: [
+      {
+        id: 'what-is-devnet',
+        question: 'What is Devnet?',
+        answer:
+          'Devnet is our private integration environment where protocol upgrades and security fixes incubate before they reach public testing.',
+      },
+      {
+        id: 'what-is-testnet',
+        question: 'What is Public Testnet?',
+        answer:
+          'Public Testnet enables community validator participation and lets us soak-test new releases in a high-fidelity environment.',
+      },
+      {
+        id: 'what-is-mainnet',
+        question: 'What is Mainnet?',
+        answer:
+          'Mainnet is the production-ready network with finalized compliance sign-off, formal security validation, and monitored operations.',
+      },
+    ],
+    links: [
+      { label: 'Governance Forum', href: 'https://forum.telcoin.com' },
+      { label: 'Technical Docs', href: 'https://docs.telcoin.com' },
+      { label: 'Audit Reports (post-publication)', href: 'https://telcoin.com/audits' },
+    ],
+  },
+};
+


### PR DESCRIPTION
## Summary
- add a shared status data module with mock progress information for network phases, security, roadmap, and FAQs
- scaffold Tailwind-styled React components for phase overview, security audits, roadmap timeline, and FAQ accordion
- compose an App layout that renders the new sections and wires them to the shared data source

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d47c5600cc833081687fc0664abf43