### PR TITLE
fix: restyle network architecture diagram

### DIFF
--- a/dist/styles.css
+++ b/dist/styles.css
@@ -1474,6 +1474,259 @@ tr:last-child td {
   box-shadow: none;
 }
 
+.architecture-diagram {
+  position: relative;
+  border-radius: clamp(1.25rem, 4vw, 2.5rem);
+  border: 1px solid rgba(78, 163, 255, 0.35);
+  background:
+    radial-gradient(120% 100% at 15% 0%, rgba(78, 163, 255, 0.16), transparent),
+    radial-gradient(120% 100% at 85% 0%, rgba(45, 212, 191, 0.16), transparent),
+    rgba(11, 20, 46, 0.92);
+  padding: clamp(var(--space-5), 4vw, var(--space-7));
+  box-shadow: 0 18px 48px rgba(3, 9, 26, 0.42);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.architecture-diagram::before,
+.architecture-diagram::after {
+  content: '';
+  position: absolute;
+  border-radius: 999px;
+  filter: blur(60px);
+  opacity: 0.45;
+  z-index: -1;
+}
+
+.architecture-diagram::before {
+  width: 42%;
+  height: 42%;
+  top: -18%;
+  left: 12%;
+  background: rgba(78, 163, 255, 0.4);
+}
+
+.architecture-diagram::after {
+  width: 48%;
+  height: 48%;
+  bottom: -22%;
+  right: 8%;
+  background: rgba(168, 85, 247, 0.38);
+}
+
+.architecture-diagram__header {
+  text-align: center;
+  margin-bottom: clamp(var(--space-5), 4vw, var(--space-7));
+}
+
+.architecture-diagram__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-1) var(--space-4);
+  border-radius: var(--radius-pill);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(78, 163, 255, 0.12);
+  color: rgba(222, 237, 255, 0.92);
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  margin-bottom: var(--space-3);
+}
+
+.architecture-diagram__title {
+  font-size: clamp(2.1rem, 4vw, 3.1rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--color-text);
+  margin: 0;
+}
+
+.architecture-diagram__summary {
+  margin: var(--space-3) auto 0;
+  max-width: 46rem;
+  color: var(--color-text-muted);
+}
+
+.architecture-diagram__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.4fr) minmax(0, 1fr);
+  gap: clamp(var(--space-4), 4vw, var(--space-7));
+}
+
+.architecture-diagram__rail {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(var(--space-4), 3vw, var(--space-6));
+}
+
+.architecture-diagram__core {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(var(--space-4), 3vw, var(--space-6));
+}
+
+.architecture-diagram__split {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(var(--space-4), 3vw, var(--space-5));
+}
+
+.architecture-diagram__footer {
+  margin-top: clamp(var(--space-6), 5vw, var(--space-8));
+  display: flex;
+  justify-content: center;
+}
+
+.architecture-node {
+  position: relative;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: linear-gradient(160deg, rgba(12, 22, 48, 0.92), rgba(21, 38, 74, 0.9));
+  padding: clamp(var(--space-4), 2.8vw, var(--space-5));
+  box-shadow: 0 10px 28px rgba(5, 13, 34, 0.4);
+  color: var(--color-text);
+  min-height: 9.5rem;
+  overflow: hidden;
+}
+
+.architecture-node::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 25% 20%, rgba(78, 163, 255, 0.18), transparent 65%);
+  opacity: 0.8;
+  z-index: -1;
+}
+
+.architecture-node--accent {
+  border-color: rgba(45, 212, 191, 0.38);
+  background: linear-gradient(165deg, rgba(12, 40, 52, 0.92), rgba(14, 28, 58, 0.85));
+}
+
+.architecture-node--highlight {
+  background: linear-gradient(165deg, rgba(31, 80, 148, 0.85), rgba(18, 34, 68, 0.92));
+  border-color: rgba(78, 163, 255, 0.48);
+}
+
+.architecture-node--soft {
+  background: linear-gradient(165deg, rgba(16, 46, 60, 0.85), rgba(15, 32, 66, 0.88));
+  border-color: rgba(78, 163, 255, 0.28);
+}
+
+.architecture-node--footer {
+  min-width: min(100%, 34rem);
+  text-align: center;
+  background: linear-gradient(165deg, rgba(18, 32, 68, 0.92), rgba(11, 24, 58, 0.92));
+  border-color: rgba(78, 163, 255, 0.42);
+}
+
+.architecture-node__title {
+  font-size: clamp(1.1rem, 2vw, 1.4rem);
+  margin-bottom: var(--space-2);
+}
+
+.architecture-node__body {
+  margin: 0;
+  color: var(--color-text-soft);
+}
+
+.architecture-node[data-connector='right']::after,
+.architecture-node[data-connector='left']::after,
+.architecture-node[data-connector='vertical']::after,
+.architecture-node[data-connector='down']::after {
+  content: '';
+  position: absolute;
+  background: linear-gradient(90deg, rgba(78, 163, 255, 0.55), rgba(45, 212, 191, 0.45));
+  pointer-events: none;
+}
+
+.architecture-node[data-connector='right']::after {
+  top: 50%;
+  right: -3.2rem;
+  width: 3.2rem;
+  height: 2px;
+  transform: translateY(-50%);
+}
+
+.architecture-node[data-connector='left']::after {
+  top: 50%;
+  left: -3.2rem;
+  width: 3.2rem;
+  height: 2px;
+  transform: translateY(-50%);
+}
+
+.architecture-node[data-connector='vertical']::after {
+  left: 50%;
+  bottom: -3rem;
+  width: 2px;
+  height: 3rem;
+  transform: translateX(-50%);
+}
+
+.architecture-node[data-connector='down']::after {
+  left: 50%;
+  bottom: -2.6rem;
+  width: 2px;
+  height: 2.6rem;
+  transform: translateX(-50%);
+}
+
+.architecture-diagram__rail--left .architecture-node:first-child::after,
+.architecture-diagram__rail--right .architecture-node:last-child::after {
+  background: linear-gradient(90deg, rgba(78, 163, 255, 0.45), rgba(45, 212, 191, 0.25));
+}
+
+.architecture-diagram__rail--right .architecture-node[data-connector='left']::after {
+  background: linear-gradient(90deg, rgba(45, 212, 191, 0.3), rgba(78, 163, 255, 0.5));
+}
+
+@media (max-width: 1100px) {
+  .architecture-diagram {
+    padding: clamp(var(--space-5), 6vw, var(--space-7));
+  }
+
+  .architecture-diagram__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .architecture-diagram__rail {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .architecture-diagram__rail .architecture-node {
+    flex: 1 1 14rem;
+  }
+
+  .architecture-diagram__split {
+    grid-template-columns: 1fr;
+  }
+
+  .architecture-node[data-connector='right']::after,
+  .architecture-node[data-connector='left']::after,
+  .architecture-node[data-connector='vertical']::after,
+  .architecture-node[data-connector='down']::after {
+    display: none;
+  }
+
+  .architecture-node--footer {
+    min-width: 100%;
+  }
+}
+
+@media (max-width: 640px) {
+  .architecture-diagram__title {
+    font-size: clamp(1.8rem, 6vw, 2.4rem);
+  }
+
+  .architecture-node {
+    min-height: auto;
+  }
+}
+
 .footer {
   margin-top: auto;
   background: rgba(6, 15, 36, 0.95);

--- a/network.html
+++ b/network.html
@@ -132,23 +132,94 @@
       </section>
 
       <section id="network-architecture" class="anchor-offset">
-        <h2>Architecture highlights</h2>
-        <div class="card-grid card-grid--cols-3" role="list">
-          <article class="card" role="listitem">
-            <h3 class="card__title">EVM smart contracts</h3>
-            <p>Developers can deploy Solidity contracts and integrate with tooling familiar to the broader Ethereum ecosystem.</p>
-            <p><a href="https://www.telcoinassociation.org/network" target="_blank" rel="noopener">Association technical overview →</a></p>
-          </article>
-          <article class="card" role="listitem">
-            <h3 class="card__title">Validator criteria</h3>
-            <p>Mobile network operators that meet Association-defined security and compliance standards can operate validators.</p>
-            <p><a href="https://www.telcoinassociation.org/network" target="_blank" rel="noopener">Validator requirements →</a></p>
-          </article>
-          <article class="card" role="listitem">
-            <h3 class="card__title">Settlement performance</h3>
-            <p>Transactions finalize in seconds, enabling instant settlement for Digital Cash, remittances, and TELx liquidity flows.</p>
-            <p><a href="https://www.telcoinnetwork.org" target="_blank" rel="noopener">Network landing →</a></p>
-          </article>
+        <h2 class="sr-only">Architecture highlights</h2>
+        <div class="architecture-diagram" role="group" aria-label="Telcoin Network Architecture diagram showing how users, stakers, developers, liquidity miners, validators, and treasury flows connect across the Telcoin ecosystem">
+          <div class="architecture-diagram__header">
+            <span class="architecture-diagram__badge">Telcoin Association</span>
+            <p class="architecture-diagram__title" role="heading" aria-level="3">Telcoin Network Architecture</p>
+            <p class="architecture-diagram__summary">How ecosystem participants, liquidity programs, and governance combine across the Telcoin Network.</p>
+          </div>
+          <div class="architecture-diagram__grid">
+            <div class="architecture-diagram__rail architecture-diagram__rail--left" aria-label="Community roles">
+              <div class="architecture-node architecture-node--accent" data-connector="right">
+                <h3 class="architecture-node__title">Users</h3>
+                <p class="architecture-node__body">Transact with Digital Cash, send remittances, and pay TEL gas fees across the network.</p>
+              </div>
+              <div class="architecture-node" data-connector="right">
+                <h3 class="architecture-node__title">Stakers</h3>
+                <p class="architecture-node__body">Stake TEL, provide network security assurances, and share in fee flows from compliant services.</p>
+              </div>
+            </div>
+            <div class="architecture-diagram__core" aria-label="Network systems">
+              <div class="architecture-node architecture-node--highlight" data-connector="vertical">
+                <h3 class="architecture-node__title">Telcoin Application Network</h3>
+                <p class="architecture-node__body">Exchange, settle TELx activity, and route TEL-backed incentives for compliant services.</p>
+              </div>
+              <div class="architecture-diagram__split">
+                <div class="architecture-node architecture-node--soft" data-connector="down">
+                  <h3 class="architecture-node__title">TELx</h3>
+                  <p class="architecture-node__body">Provide liquidity, earn TEL rewards, and access instant settlement between compliant pools.</p>
+                </div>
+                <div class="architecture-node architecture-node--soft" data-connector="down">
+                  <h3 class="architecture-node__title">TEL Treasury</h3>
+                  <p class="architecture-node__body">Issue TEL for incentives, fund staking programs, and recycle a portion of network gas fees.</p>
+                </div>
+              </div>
+              <div class="architecture-node" data-connector="vertical">
+                <h3 class="architecture-node__title">Telcoin Network</h3>
+                <p class="architecture-node__body">Carrier-secured validators confirm transactions, enforce compliance, and anchor TEL gas economics.</p>
+              </div>
+              <div class="architecture-diagram__split">
+                <div class="architecture-node" data-connector="down">
+                  <h3 class="architecture-node__title">Telcoin Platform</h3>
+                  <p class="architecture-node__body">Wallet, remittance rails, and Digital Cash services deliver user experiences on top of the network.</p>
+                </div>
+                <div class="architecture-node" data-connector="down">
+                  <h3 class="architecture-node__title">Validators</h3>
+                  <p class="architecture-node__body">GSMA-member operators stake TEL, run infrastructure, and maintain uptime for compliant deployments.</p>
+                </div>
+              </div>
+            </div>
+            <div class="architecture-diagram__rail architecture-diagram__rail--right" aria-label="Builder roles">
+              <div class="architecture-node architecture-node--accent" data-connector="left">
+                <h3 class="architecture-node__title">Developers</h3>
+                <p class="architecture-node__body">Deploy EVM smart contracts, integrate tooling, and pay TEL gas and exchange fees.</p>
+              </div>
+              <div class="architecture-node" data-connector="left">
+                <h3 class="architecture-node__title">Liquidity Miners</h3>
+                <p class="architecture-node__body">Stake TEL, seed compliant pools, and earn a share of TELx exchange incentives.</p>
+              </div>
+              <div class="architecture-node" data-connector="left">
+                <h3 class="architecture-node__title">Users</h3>
+                <p class="architecture-node__body">Access Digital Cash balances, spend in the Telcoin Wallet, and settle remittances instantly.</p>
+              </div>
+            </div>
+          </div>
+          <div class="architecture-diagram__footer">
+            <div class="architecture-node architecture-node--footer">
+              <h3 class="architecture-node__title">Governance System</h3>
+              <p class="architecture-node__body">Telcoin Association policy frameworks and council oversight align incentives across network participants.</p>
+            </div>
+          </div>
+        </div>
+        <div class="sr-only">
+          <div role="list">
+            <article role="listitem">
+              <h3>EVM smart contracts</h3>
+              <p>Developers can deploy Solidity contracts and integrate with tooling familiar to the broader Ethereum ecosystem.</p>
+              <p><a href="https://www.telcoinassociation.org/network" target="_blank" rel="noopener">Association technical overview →</a></p>
+            </article>
+            <article role="listitem">
+              <h3>Validator criteria</h3>
+              <p>Mobile network operators that meet Association-defined security and compliance standards can operate validators.</p>
+              <p><a href="https://www.telcoinassociation.org/network" target="_blank" rel="noopener">Validator requirements →</a></p>
+            </article>
+            <article role="listitem">
+              <h3>Settlement performance</h3>
+              <p>Transactions finalize in seconds, enabling instant settlement for Digital Cash, remittances, and TELx liquidity flows.</p>
+              <p><a href="https://www.telcoinnetwork.org" target="_blank" rel="noopener">Network landing →</a></p>
+            </article>
+          </div>
         </div>
       </section>
 

--- a/styles/site.css
+++ b/styles/site.css
@@ -1416,6 +1416,259 @@ tr:last-child td {
   box-shadow: none;
 }
 
+.architecture-diagram {
+  position: relative;
+  border-radius: clamp(1.25rem, 4vw, 2.5rem);
+  border: 1px solid rgba(78, 163, 255, 0.35);
+  background:
+    radial-gradient(120% 100% at 15% 0%, rgba(78, 163, 255, 0.16), transparent),
+    radial-gradient(120% 100% at 85% 0%, rgba(45, 212, 191, 0.16), transparent),
+    rgba(11, 20, 46, 0.92);
+  padding: clamp(var(--space-5), 4vw, var(--space-7));
+  box-shadow: 0 18px 48px rgba(3, 9, 26, 0.42);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.architecture-diagram::before,
+.architecture-diagram::after {
+  content: '';
+  position: absolute;
+  border-radius: 999px;
+  filter: blur(60px);
+  opacity: 0.45;
+  z-index: -1;
+}
+
+.architecture-diagram::before {
+  width: 42%;
+  height: 42%;
+  top: -18%;
+  left: 12%;
+  background: rgba(78, 163, 255, 0.4);
+}
+
+.architecture-diagram::after {
+  width: 48%;
+  height: 48%;
+  bottom: -22%;
+  right: 8%;
+  background: rgba(168, 85, 247, 0.38);
+}
+
+.architecture-diagram__header {
+  text-align: center;
+  margin-bottom: clamp(var(--space-5), 4vw, var(--space-7));
+}
+
+.architecture-diagram__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-1) var(--space-4);
+  border-radius: var(--radius-pill);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(78, 163, 255, 0.12);
+  color: rgba(222, 237, 255, 0.92);
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  margin-bottom: var(--space-3);
+}
+
+.architecture-diagram__title {
+  font-size: clamp(2.1rem, 4vw, 3.1rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--color-text);
+  margin: 0;
+}
+
+.architecture-diagram__summary {
+  margin: var(--space-3) auto 0;
+  max-width: 46rem;
+  color: var(--color-text-muted);
+}
+
+.architecture-diagram__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.4fr) minmax(0, 1fr);
+  gap: clamp(var(--space-4), 4vw, var(--space-7));
+}
+
+.architecture-diagram__rail {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(var(--space-4), 3vw, var(--space-6));
+}
+
+.architecture-diagram__core {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(var(--space-4), 3vw, var(--space-6));
+}
+
+.architecture-diagram__split {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(var(--space-4), 3vw, var(--space-5));
+}
+
+.architecture-diagram__footer {
+  margin-top: clamp(var(--space-6), 5vw, var(--space-8));
+  display: flex;
+  justify-content: center;
+}
+
+.architecture-node {
+  position: relative;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: linear-gradient(160deg, rgba(12, 22, 48, 0.92), rgba(21, 38, 74, 0.9));
+  padding: clamp(var(--space-4), 2.8vw, var(--space-5));
+  box-shadow: 0 10px 28px rgba(5, 13, 34, 0.4);
+  color: var(--color-text);
+  min-height: 9.5rem;
+  overflow: hidden;
+}
+
+.architecture-node::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 25% 20%, rgba(78, 163, 255, 0.18), transparent 65%);
+  opacity: 0.8;
+  z-index: -1;
+}
+
+.architecture-node--accent {
+  border-color: rgba(45, 212, 191, 0.38);
+  background: linear-gradient(165deg, rgba(12, 40, 52, 0.92), rgba(14, 28, 58, 0.85));
+}
+
+.architecture-node--highlight {
+  background: linear-gradient(165deg, rgba(31, 80, 148, 0.85), rgba(18, 34, 68, 0.92));
+  border-color: rgba(78, 163, 255, 0.48);
+}
+
+.architecture-node--soft {
+  background: linear-gradient(165deg, rgba(16, 46, 60, 0.85), rgba(15, 32, 66, 0.88));
+  border-color: rgba(78, 163, 255, 0.28);
+}
+
+.architecture-node--footer {
+  min-width: min(100%, 34rem);
+  text-align: center;
+  background: linear-gradient(165deg, rgba(18, 32, 68, 0.92), rgba(11, 24, 58, 0.92));
+  border-color: rgba(78, 163, 255, 0.42);
+}
+
+.architecture-node__title {
+  font-size: clamp(1.1rem, 2vw, 1.4rem);
+  margin-bottom: var(--space-2);
+}
+
+.architecture-node__body {
+  margin: 0;
+  color: var(--color-text-soft);
+}
+
+.architecture-node[data-connector='right']::after,
+.architecture-node[data-connector='left']::after,
+.architecture-node[data-connector='vertical']::after,
+.architecture-node[data-connector='down']::after {
+  content: '';
+  position: absolute;
+  background: linear-gradient(90deg, rgba(78, 163, 255, 0.55), rgba(45, 212, 191, 0.45));
+  pointer-events: none;
+}
+
+.architecture-node[data-connector='right']::after {
+  top: 50%;
+  right: -3.2rem;
+  width: 3.2rem;
+  height: 2px;
+  transform: translateY(-50%);
+}
+
+.architecture-node[data-connector='left']::after {
+  top: 50%;
+  left: -3.2rem;
+  width: 3.2rem;
+  height: 2px;
+  transform: translateY(-50%);
+}
+
+.architecture-node[data-connector='vertical']::after {
+  left: 50%;
+  bottom: -3rem;
+  width: 2px;
+  height: 3rem;
+  transform: translateX(-50%);
+}
+
+.architecture-node[data-connector='down']::after {
+  left: 50%;
+  bottom: -2.6rem;
+  width: 2px;
+  height: 2.6rem;
+  transform: translateX(-50%);
+}
+
+.architecture-diagram__rail--left .architecture-node:first-child::after,
+.architecture-diagram__rail--right .architecture-node:last-child::after {
+  background: linear-gradient(90deg, rgba(78, 163, 255, 0.45), rgba(45, 212, 191, 0.25));
+}
+
+.architecture-diagram__rail--right .architecture-node[data-connector='left']::after {
+  background: linear-gradient(90deg, rgba(45, 212, 191, 0.3), rgba(78, 163, 255, 0.5));
+}
+
+@media (max-width: 1100px) {
+  .architecture-diagram {
+    padding: clamp(var(--space-5), 6vw, var(--space-7));
+  }
+
+  .architecture-diagram__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .architecture-diagram__rail {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .architecture-diagram__rail .architecture-node {
+    flex: 1 1 14rem;
+  }
+
+  .architecture-diagram__split {
+    grid-template-columns: 1fr;
+  }
+
+  .architecture-node[data-connector='right']::after,
+  .architecture-node[data-connector='left']::after,
+  .architecture-node[data-connector='vertical']::after,
+  .architecture-node[data-connector='down']::after {
+    display: none;
+  }
+
+  .architecture-node--footer {
+    min-width: 100%;
+  }
+}
+
+@media (max-width: 640px) {
+  .architecture-diagram__title {
+    font-size: clamp(1.8rem, 6vw, 2.4rem);
+  }
+
+  .architecture-node {
+    min-height: auto;
+  }
+}
+
 .footer {
   margin-top: auto;
   background: rgba(6, 15, 36, 0.95);


### PR DESCRIPTION
## Summary
Implemented a network architecture diagram on the Telcoin Network page and layered supporting styles so the layout mirrors the association reference artwork while keeping the original copy accessible.

## Screenshots
![Network architecture layout](browser:/invocations/mysaezgw/artifacts/artifacts/network-architecture.png)

## Test Plan
- npm ci
- npm run dev
- npm run build
- npm run validate:status

------
https://chatgpt.com/codex/tasks/task_e_68d568e158ec83309d3f59766b3784cb