### PR TITLE
chore(theme): adopt roadmap cards and chips

### DIFF
--- a/404.html
+++ b/404.html
@@ -22,9 +22,21 @@
   <meta name="twitter:description" content="Sorry, we can’t find that Telcoin Wiki page. Head back to Start Here or search the FAQ for trusted resources.">
   <meta name="twitter:image" content="https://telcoinwiki.com/assets/Telcoinwiki.png">
   <meta name="twitter:site" content="@telcoin">
-  <link rel="icon" type="image/svg+xml" href="/logo.svg">
+  <link rel="stylesheet" href="/src/styles/tokens.css">
   <link rel="preload" href="/dist/styles.css" as="style">
   <link rel="stylesheet" href="/dist/styles.css">
+  <link id="app-favicon" rel="icon" href="https://telcoin.org/favicon.ico" />
+  <script>
+    (function () {
+      var link = document.getElementById('app-favicon');
+      if (!link) return;
+      var img = new Image();
+      img.onerror = function () {
+        link.href = 'https://telcoin.network/favicon.ico';
+      };
+      img.src = link.href + '?v=1';
+    })();
+  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -46,13 +58,13 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
   <header class="site-header" data-header>
     <div class="site-header__inner">
-      <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
+      <a class="site-logo" data-home-link href="/index.html" aria-label="Telcoin Wiki home">
         <img src="/logo.svg" alt="Telcoin Wiki" width="40" height="40" fetchpriority="high">
         <span>Telcoin Wiki</span>
       </a>
       <button type="button" class="sidebar-toggle" data-sidebar-toggle aria-expanded="false" aria-controls="site-sidebar">Menu</button>
       <nav class="top-nav" aria-label="Primary">
-        <ul class="top-nav__list" data-nav>
+        <ul class="top-nav__list tc-tabbar" data-nav>
           <li><a class="top-nav__link" href="/start-here.html">Start Here</a></li>
           <li><a class="top-nav__link" href="/faq/">FAQ</a></li>
           <li><a class="top-nav__link" href="/wallet.html">Wallet</a></li>
@@ -66,17 +78,20 @@
           <li><a class="top-nav__link" href="/links.html">Links</a></li>
         </ul>
       </nav>
-      <div class="header-search" role="search">
-        <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
-        <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
-        <div class="search-panel" data-search-results hidden aria-label="Search suggestions"></div>
+      <div class="site-header__actions">
+        <div class="last-updated" data-last-updated></div>
+        <div class="header-search" role="search">
+          <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
+          <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
+          <div class="search-panel tc-card" data-search-results hidden aria-label="Search suggestions"></div>
+        </div>
       </div>
     </div>
   </header>
   <div class="sidebar-overlay" data-sidebar-overlay></div>
   <div class="site-shell">
     <aside id="site-sidebar" class="sidebar" data-sidebar>
-      <div class="sidebar__inner">
+      <div class="sidebar__inner tc-card">
         <p class="sidebar__heading">Knowledge base</p>
         <nav class="sidebar__nav" aria-label="Knowledge base">
           <ul class="sidebar__list" data-sidebar-list>
@@ -117,10 +132,10 @@
         </nav>
       </div>
     </aside>
-    <main id="main-content" class="site-main" tabindex="-1">
+    <main id="main-content" class="site-main tc-card" tabindex="-1">
       <nav class="breadcrumbs" aria-label="Breadcrumb" data-breadcrumbs></nav>
 
-      <section id="not-found-hero" class="page-intro anchor-offset">
+      <section id="not-found-hero" class="page-intro anchor-offset tc-card">
         <p class="page-intro__eyebrow">404</p>
         <h1 class="page-intro__title">We couldn’t find that page</h1>
         <p class="page-intro__lede">The Telcoin Wiki entry you requested may have moved or never existed. Use the quick links below to restart your search.</p>

--- a/about.html
+++ b/about.html
@@ -21,9 +21,21 @@
   <meta name="twitter:description" content="Learn why the Telcoin Wiki exists, how to contribute, and the disclaimers that keep this resource clearly unofficial.">
   <meta name="twitter:image" content="https://telcoinwiki.com/assets/Telcoinwiki.png">
   <meta name="twitter:site" content="@telcoin">
-  <link rel="icon" type="image/svg+xml" href="/logo.svg">
+  <link rel="stylesheet" href="/src/styles/tokens.css">
   <link rel="preload" href="/dist/styles.css" as="style">
   <link rel="stylesheet" href="/dist/styles.css">
+  <link id="app-favicon" rel="icon" href="https://telcoin.org/favicon.ico" />
+  <script>
+    (function () {
+      var link = document.getElementById('app-favicon');
+      if (!link) return;
+      var img = new Image();
+      img.onerror = function () {
+        link.href = 'https://telcoin.network/favicon.ico';
+      };
+      img.src = link.href + '?v=1';
+    })();
+  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -45,13 +57,13 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
   <header class="site-header" data-header>
     <div class="site-header__inner">
-      <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
+      <a class="site-logo" data-home-link href="/index.html" aria-label="Telcoin Wiki home">
         <img src="/logo.svg" alt="Telcoin Wiki" width="40" height="40" fetchpriority="high">
         <span>Telcoin Wiki</span>
       </a>
       <button type="button" class="sidebar-toggle" data-sidebar-toggle aria-expanded="false" aria-controls="site-sidebar">Menu</button>
       <nav class="top-nav" aria-label="Primary">
-        <ul class="top-nav__list" data-nav>
+        <ul class="top-nav__list tc-tabbar" data-nav>
           <li><a class="top-nav__link" href="/start-here.html">Start Here</a></li>
           <li><a class="top-nav__link" href="/faq/">FAQ</a></li>
           <li><a class="top-nav__link" href="/wallet.html">Wallet</a></li>
@@ -65,17 +77,20 @@
           <li><a class="top-nav__link" href="/links.html">Links</a></li>
         </ul>
       </nav>
-      <div class="header-search" role="search">
-        <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
-        <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
-        <div class="search-panel" data-search-results hidden aria-label="Search suggestions"></div>
+      <div class="site-header__actions">
+        <div class="last-updated" data-last-updated></div>
+        <div class="header-search" role="search">
+          <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
+          <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
+          <div class="search-panel tc-card" data-search-results hidden aria-label="Search suggestions"></div>
+        </div>
       </div>
     </div>
   </header>
   <div class="sidebar-overlay" data-sidebar-overlay></div>
   <div class="site-shell">
     <aside id="site-sidebar" class="sidebar" data-sidebar>
-      <div class="sidebar__inner">
+      <div class="sidebar__inner tc-card">
         <p class="sidebar__heading">Knowledge base</p>
         <nav class="sidebar__nav" aria-label="Knowledge base">
           <ul class="sidebar__list" data-sidebar-list>
@@ -116,10 +131,10 @@
         </nav>
       </div>
     </aside>
-    <main id="main-content" class="site-main" tabindex="-1">
+    <main id="main-content" class="site-main tc-card" tabindex="-1">
       <nav class="breadcrumbs" aria-label="Breadcrumb" data-breadcrumbs></nav>
 
-      <section id="about-mission" class="page-intro anchor-offset">
+      <section id="about-mission" class="page-intro anchor-offset tc-card">
         <p class="page-intro__eyebrow">About</p>
         <h1 class="page-intro__title">Why this wiki exists</h1>
         <p class="page-intro__lede">Telcoin Wiki is a community project that collects concise answers and official links so newcomers can find trustworthy information without wading through social media threads.</p>

--- a/builders.html
+++ b/builders.html
@@ -21,9 +21,21 @@
   <meta name="twitter:description" content="Find Telcoin builder resources including TELx dashboards, portfolio explorers, and contribution guidelines.">
   <meta name="twitter:image" content="https://telcoinwiki.com/assets/Telcoinwiki.png">
   <meta name="twitter:site" content="@telcoin">
-  <link rel="icon" type="image/svg+xml" href="/logo.svg">
+  <link rel="stylesheet" href="/src/styles/tokens.css">
   <link rel="preload" href="/dist/styles.css" as="style">
   <link rel="stylesheet" href="/dist/styles.css">
+  <link id="app-favicon" rel="icon" href="https://telcoin.org/favicon.ico" />
+  <script>
+    (function () {
+      var link = document.getElementById('app-favicon');
+      if (!link) return;
+      var img = new Image();
+      img.onerror = function () {
+        link.href = 'https://telcoin.network/favicon.ico';
+      };
+      img.src = link.href + '?v=1';
+    })();
+  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -45,13 +57,13 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
   <header class="site-header" data-header>
     <div class="site-header__inner">
-      <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
+      <a class="site-logo" data-home-link href="/index.html" aria-label="Telcoin Wiki home">
         <img src="/logo.svg" alt="Telcoin Wiki" width="40" height="40" fetchpriority="high">
         <span>Telcoin Wiki</span>
       </a>
       <button type="button" class="sidebar-toggle" data-sidebar-toggle aria-expanded="false" aria-controls="site-sidebar">Menu</button>
       <nav class="top-nav" aria-label="Primary">
-        <ul class="top-nav__list" data-nav>
+        <ul class="top-nav__list tc-tabbar" data-nav>
           <li><a class="top-nav__link" href="/start-here.html">Start Here</a></li>
           <li><a class="top-nav__link" href="/faq/">FAQ</a></li>
           <li><a class="top-nav__link" href="/wallet.html">Wallet</a></li>
@@ -65,17 +77,20 @@
           <li><a class="top-nav__link" href="/links.html">Links</a></li>
         </ul>
       </nav>
-      <div class="header-search" role="search">
-        <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
-        <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
-        <div class="search-panel" data-search-results hidden aria-label="Search suggestions"></div>
+      <div class="site-header__actions">
+        <div class="last-updated" data-last-updated></div>
+        <div class="header-search" role="search">
+          <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
+          <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
+          <div class="search-panel tc-card" data-search-results hidden aria-label="Search suggestions"></div>
+        </div>
       </div>
     </div>
   </header>
   <div class="sidebar-overlay" data-sidebar-overlay></div>
   <div class="site-shell">
     <aside id="site-sidebar" class="sidebar" data-sidebar>
-      <div class="sidebar__inner">
+      <div class="sidebar__inner tc-card">
         <p class="sidebar__heading">Knowledge base</p>
         <nav class="sidebar__nav" aria-label="Knowledge base">
           <ul class="sidebar__list" data-sidebar-list>
@@ -122,10 +137,10 @@
         </nav>
       </div>
     </aside>
-    <main id="main-content" class="site-main" tabindex="-1">
+    <main id="main-content" class="site-main tc-card" tabindex="-1">
       <nav class="breadcrumbs" aria-label="Breadcrumb" data-breadcrumbs></nav>
 
-      <section id="builders-overview" class="page-intro anchor-offset">
+      <section id="builders-overview" class="page-intro anchor-offset tc-card">
         <p class="page-intro__eyebrow">Builders</p>
         <h1 class="page-intro__title">Resources for Telcoin contributors</h1>
         <p class="page-intro__lede">Whether you monitor TELx pools, experiment with dashboards, or contribute research, this page surfaces the core tools and official touchpoints for building with Telcoin.</p>

--- a/deep-dive.html
+++ b/deep-dive.html
@@ -21,9 +21,21 @@
   <meta name="twitter:description" content="Explore how the Telcoin Association, Telcoin Network, TEL token, and TELx liquidity layer work together with links to official resources.">
   <meta name="twitter:image" content="https://telcoinwiki.com/assets/Telcoinwiki.png">
   <meta name="twitter:site" content="@telcoin">
-  <link rel="icon" type="image/svg+xml" href="/logo.svg">
+  <link rel="stylesheet" href="/src/styles/tokens.css">
   <link rel="preload" href="/dist/styles.css" as="style">
   <link rel="stylesheet" href="/dist/styles.css">
+  <link id="app-favicon" rel="icon" href="https://telcoin.org/favicon.ico" />
+  <script>
+    (function () {
+      var link = document.getElementById('app-favicon');
+      if (!link) return;
+      var img = new Image();
+      img.onerror = function () {
+        link.href = 'https://telcoin.network/favicon.ico';
+      };
+      img.src = link.href + '?v=1';
+    })();
+  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -45,13 +57,13 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
   <header class="site-header" data-header>
     <div class="site-header__inner">
-      <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
+      <a class="site-logo" data-home-link href="/index.html" aria-label="Telcoin Wiki home">
         <img src="/logo.svg" alt="Telcoin Wiki" width="40" height="40" fetchpriority="high">
         <span>Telcoin Wiki</span>
       </a>
       <button type="button" class="sidebar-toggle" data-sidebar-toggle aria-expanded="false" aria-controls="site-sidebar">Menu</button>
       <nav class="top-nav" aria-label="Primary">
-        <ul class="top-nav__list" data-nav>
+        <ul class="top-nav__list tc-tabbar" data-nav>
           <li><a class="top-nav__link" href="/start-here.html">Start Here</a></li>
           <li><a class="top-nav__link" href="/faq/">FAQ</a></li>
           <li><a class="top-nav__link" href="/wallet.html">Wallet</a></li>
@@ -65,17 +77,20 @@
           <li><a class="top-nav__link" href="/links.html">Links</a></li>
         </ul>
       </nav>
-      <div class="header-search" role="search">
-        <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
-        <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
-        <div class="search-panel" data-search-results hidden aria-label="Search suggestions"></div>
+      <div class="site-header__actions">
+        <div class="last-updated" data-last-updated></div>
+        <div class="header-search" role="search">
+          <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
+          <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
+          <div class="search-panel tc-card" data-search-results hidden aria-label="Search suggestions"></div>
+        </div>
       </div>
     </div>
   </header>
   <div class="sidebar-overlay" data-sidebar-overlay></div>
   <div class="site-shell">
     <aside id="site-sidebar" class="sidebar" data-sidebar>
-      <div class="sidebar__inner">
+      <div class="sidebar__inner tc-card">
         <p class="sidebar__heading">Knowledge base</p>
         <nav class="sidebar__nav" aria-label="Knowledge base">
           <ul class="sidebar__list" data-sidebar-list>
@@ -121,10 +136,10 @@
         </nav>
       </div>
     </aside>
-    <main id="main-content" class="site-main" tabindex="-1">
+    <main id="main-content" class="site-main tc-card" tabindex="-1">
       <nav class="breadcrumbs" aria-label="Breadcrumb" data-breadcrumbs></nav>
 
-      <section id="deep-dive-overview" class="page-intro anchor-offset">
+      <section id="deep-dive-overview" class="page-intro anchor-offset tc-card">
         <p class="page-intro__eyebrow">Deep Dive</p>
         <h1 class="page-intro__title">How Telcoin’s pieces fit together</h1>
         <p class="page-intro__lede">Use this primer to understand the relationship between the Telcoin Association, Telcoin Network, TEL token, and TELx liquidity layer. Each card links to the official resource for in-depth exploration.</p>

--- a/digital-cash.html
+++ b/digital-cash.html
@@ -21,9 +21,21 @@
   <meta name="twitter:description" content="Explore Telcoin Digital Cash currencies, how they settle on the Telcoin Network, and where to confirm availability and compliance updates.">
   <meta name="twitter:image" content="https://telcoinwiki.com/assets/Telcoinwiki.png">
   <meta name="twitter:site" content="@telcoin">
-  <link rel="icon" type="image/svg+xml" href="/logo.svg">
+  <link rel="stylesheet" href="/src/styles/tokens.css">
   <link rel="preload" href="/dist/styles.css" as="style">
   <link rel="stylesheet" href="/dist/styles.css">
+  <link id="app-favicon" rel="icon" href="https://telcoin.org/favicon.ico" />
+  <script>
+    (function () {
+      var link = document.getElementById('app-favicon');
+      if (!link) return;
+      var img = new Image();
+      img.onerror = function () {
+        link.href = 'https://telcoin.network/favicon.ico';
+      };
+      img.src = link.href + '?v=1';
+    })();
+  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -45,13 +57,13 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
   <header class="site-header" data-header>
     <div class="site-header__inner">
-      <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
+      <a class="site-logo" data-home-link href="/index.html" aria-label="Telcoin Wiki home">
         <img src="/logo.svg" alt="Telcoin Wiki" width="40" height="40" fetchpriority="high">
         <span>Telcoin Wiki</span>
       </a>
       <button type="button" class="sidebar-toggle" data-sidebar-toggle aria-expanded="false" aria-controls="site-sidebar">Menu</button>
       <nav class="top-nav" aria-label="Primary">
-        <ul class="top-nav__list" data-nav>
+        <ul class="top-nav__list tc-tabbar" data-nav>
           <li><a class="top-nav__link" href="/start-here.html">Start Here</a></li>
           <li><a class="top-nav__link" href="/faq/">FAQ</a></li>
           <li><a class="top-nav__link" href="/wallet.html">Wallet</a></li>
@@ -65,17 +77,20 @@
           <li><a class="top-nav__link" href="/links.html">Links</a></li>
         </ul>
       </nav>
-      <div class="header-search" role="search">
-        <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
-        <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
-        <div class="search-panel" data-search-results hidden aria-label="Search suggestions"></div>
+      <div class="site-header__actions">
+        <div class="last-updated" data-last-updated></div>
+        <div class="header-search" role="search">
+          <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
+          <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
+          <div class="search-panel tc-card" data-search-results hidden aria-label="Search suggestions"></div>
+        </div>
       </div>
     </div>
   </header>
   <div class="sidebar-overlay" data-sidebar-overlay></div>
   <div class="site-shell">
     <aside id="site-sidebar" class="sidebar" data-sidebar>
-      <div class="sidebar__inner">
+      <div class="sidebar__inner tc-card">
         <p class="sidebar__heading">Knowledge base</p>
         <nav class="sidebar__nav" aria-label="Knowledge base">
           <ul class="sidebar__list" data-sidebar-list>
@@ -122,10 +137,10 @@
         </nav>
       </div>
     </aside>
-    <main id="main-content" class="site-main" tabindex="-1">
+    <main id="main-content" class="site-main tc-card" tabindex="-1">
       <nav class="breadcrumbs" aria-label="Breadcrumb" data-breadcrumbs></nav>
 
-      <section id="digital-cash-overview" class="page-intro anchor-offset">
+      <section id="digital-cash-overview" class="page-intro anchor-offset tc-card">
         <p class="page-intro__eyebrow">Digital Cash</p>
         <h1 class="page-intro__title">Instant-settlement fiat on the Telcoin Network</h1>
         <p class="page-intro__lede">Digital Cash brings fiat-backed currencies like eUSD, eCAD, and ePHP directly into the Telcoin Wallet. Each asset is designed to settle in seconds on the Telcoin Network while preserving the compliance expectations of its underlying fiat.</p>

--- a/dist/pools.js
+++ b/dist/pools.js
@@ -845,15 +845,15 @@
 
     function createStatusChip(status) {
         const span = document.createElement('span');
-        span.classList.add('chip');
+        span.classList.add('tc-chip');
         const label = status && status.trim ? status.trim() : 'Unknown';
         const normalized = label.toLowerCase();
         if (normalized.indexOf('active') !== -1 || normalized.indexOf('live') !== -1 || normalized.indexOf('enabled') !== -1) {
-            span.classList.add('chip-active');
+            span.classList.add('chip-active','is-active');
         } else if (normalized.indexOf('deprecated') !== -1 || normalized.indexOf('sunset') !== -1 || normalized.indexOf('inactive') !== -1 || normalized.indexOf('ending') !== -1) {
-            span.classList.add('chip-deprecated');
+            span.classList.add('chip-deprecated','is-deprecated');
         } else if (normalized.indexOf('archived') !== -1 || normalized.indexOf('ended') !== -1 || normalized.indexOf('retired') !== -1) {
-            span.classList.add('chip-archived');
+            span.classList.add('chip-archived','is-archived');
         }
         span.title = label;
         span.textContent = label;

--- a/dist/styles.css
+++ b/dist/styles.css
@@ -152,9 +152,9 @@ pre {
 }
 
 pre {
-  background: var(--color-surface-soft);
+  background: var(--color-surface);
   border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-md);
   padding: var(--space-4);
   overflow-x: auto;
   color: var(--color-text);
@@ -274,6 +274,17 @@ pre {
   gap: var(--space-3);
   margin: 0;
   padding: 0;
+}
+
+.tc-tabbar {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  padding: var(--space-1);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-subtle);
+  box-shadow: var(--shadow-sm);
 }
 
 .top-nav__link {
@@ -410,11 +421,11 @@ pre {
   top: calc(var(--header-height) + var(--space-4));
   max-height: calc(100vh - var(--header-height) - var(--space-6));
   overflow-y: auto;
-  background: rgba(10, 20, 44, 0.82);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
   padding: var(--space-4);
-  box-shadow: var(--shadow-sm);
+}
+
+.sidebar__inner.tc-card {
+  border-radius: var(--radius-lg);
 }
 
 .sidebar__heading {
@@ -511,12 +522,12 @@ pre {
 }
 
 .page-intro {
-  background: rgba(10, 20, 44, 0.72);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-xl);
   padding: var(--space-6) var(--space-5);
-  box-shadow: var(--shadow-md);
   margin-bottom: var(--space-6);
+}
+
+.page-intro.tc-card {
+  border-radius: var(--radius-xl);
 }
 
 .page-intro__eyebrow {
@@ -1378,7 +1389,7 @@ tr:last-child td {
 }
 
 .status-chip,
-.chip {
+.tc-chip {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1398,7 +1409,8 @@ tr:last-child td {
 }
 
 .chip--active,
-.chip-active {
+.chip-active,
+.tc-chip.is-active {
   background: linear-gradient(135deg, rgba(45, 212, 191, 0.28), rgba(78, 163, 255, 0.24));
   border-color: rgba(45, 212, 191, 0.38);
   color: #d9fff8;
@@ -1406,7 +1418,8 @@ tr:last-child td {
 }
 
 .chip--archived,
-.chip-archived {
+.chip-archived,
+.tc-chip.is-archived {
   background: linear-gradient(135deg, rgba(78, 163, 255, 0.28), rgba(31, 109, 255, 0.34));
   border-color: rgba(78, 163, 255, 0.45);
   color: rgba(224, 238, 255, 0.94);
@@ -1414,7 +1427,8 @@ tr:last-child td {
 }
 
 .chip--deprecated,
-.chip-deprecated {
+.chip-deprecated,
+.tc-chip.is-deprecated {
   background: linear-gradient(135deg, rgba(250, 204, 21, 0.32), rgba(168, 85, 247, 0.2));
   border-color: rgba(250, 204, 21, 0.38);
   color: #fff9cc;

--- a/faq/index.html
+++ b/faq/index.html
@@ -21,9 +21,21 @@
   <meta name="twitter:description" content="Browse Telcoin FAQs with tag filters and direct links to official Wallet, Digital Cash, TEL, Network, and governance resources.">
   <meta name="twitter:image" content="https://telcoinwiki.com/assets/Telcoinwiki.png">
   <meta name="twitter:site" content="@telcoin">
-  <link rel="icon" type="image/svg+xml" href="/logo.svg">
+  <link rel="stylesheet" href="/src/styles/tokens.css">
   <link rel="preload" href="/dist/styles.css" as="style">
   <link rel="stylesheet" href="/dist/styles.css">
+  <link id="app-favicon" rel="icon" href="https://telcoin.org/favicon.ico" />
+  <script>
+    (function () {
+      var link = document.getElementById('app-favicon');
+      if (!link) return;
+      var img = new Image();
+      img.onerror = function () {
+        link.href = 'https://telcoin.network/favicon.ico';
+      };
+      img.src = link.href + '?v=1';
+    })();
+  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -47,13 +59,13 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
   <header class="site-header" data-header>
     <div class="site-header__inner">
-      <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
+      <a class="site-logo" data-home-link href="/index.html" aria-label="Telcoin Wiki home">
         <img src="/logo.svg" alt="Telcoin Wiki" width="40" height="40" fetchpriority="high">
         <span>Telcoin Wiki</span>
       </a>
       <button type="button" class="sidebar-toggle" data-sidebar-toggle aria-expanded="false" aria-controls="site-sidebar">Menu</button>
       <nav class="top-nav" aria-label="Primary">
-        <ul class="top-nav__list" data-nav>
+        <ul class="top-nav__list tc-tabbar" data-nav>
           <li><a class="top-nav__link" href="/start-here.html">Start Here</a></li>
           <li><a class="top-nav__link is-active" href="/faq/" aria-current="page">FAQ</a></li>
           <li><a class="top-nav__link" href="/wallet.html">Wallet</a></li>
@@ -67,17 +79,20 @@
           <li><a class="top-nav__link" href="/links.html">Links</a></li>
         </ul>
       </nav>
-      <div class="header-search" role="search">
-        <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
-        <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
-        <div class="search-panel" data-search-results hidden aria-label="Search suggestions"></div>
+      <div class="site-header__actions">
+        <div class="last-updated" data-last-updated></div>
+        <div class="header-search" role="search">
+          <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
+          <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
+          <div class="search-panel tc-card" data-search-results hidden aria-label="Search suggestions"></div>
+        </div>
       </div>
     </div>
   </header>
   <div class="sidebar-overlay" data-sidebar-overlay></div>
   <div class="site-shell">
     <aside id="site-sidebar" class="sidebar" data-sidebar>
-      <div class="sidebar__inner">
+      <div class="sidebar__inner tc-card">
         <p class="sidebar__heading">Knowledge base</p>
         <nav class="sidebar__nav" aria-label="Knowledge base">
           <ul class="sidebar__list" data-sidebar-list>
@@ -123,10 +138,10 @@
         </nav>
       </div>
     </aside>
-    <main id="main-content" class="site-main" tabindex="-1">
+    <main id="main-content" class="site-main tc-card" tabindex="-1">
       <nav class="breadcrumbs" aria-label="Breadcrumb" data-breadcrumbs></nav>
 
-      <section id="faq-hero" class="page-intro anchor-offset">
+      <section id="faq-hero" class="page-intro anchor-offset tc-card">
         <p class="page-intro__eyebrow">FAQ</p>
         <h1 class="page-intro__title">Filterable Telcoin FAQ</h1>
         <p class="page-intro__lede">Search by keyword or filter by topic to find trusted answers. Every entry links back to Telcoin Association or Telcoin product resources for verification.</p>

--- a/governance.html
+++ b/governance.html
@@ -21,9 +21,21 @@
   <meta name="twitter:description" content="Understand the Telcoin Association, community councils, and how proposals move from idea to implementation.">
   <meta name="twitter:image" content="https://telcoinwiki.com/assets/Telcoinwiki.png">
   <meta name="twitter:site" content="@telcoin">
-  <link rel="icon" type="image/svg+xml" href="/logo.svg">
+  <link rel="stylesheet" href="/src/styles/tokens.css">
   <link rel="preload" href="/dist/styles.css" as="style">
   <link rel="stylesheet" href="/dist/styles.css">
+  <link id="app-favicon" rel="icon" href="https://telcoin.org/favicon.ico" />
+  <script>
+    (function () {
+      var link = document.getElementById('app-favicon');
+      if (!link) return;
+      var img = new Image();
+      img.onerror = function () {
+        link.href = 'https://telcoin.network/favicon.ico';
+      };
+      img.src = link.href + '?v=1';
+    })();
+  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -45,13 +57,13 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
   <header class="site-header" data-header>
     <div class="site-header__inner">
-      <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
+      <a class="site-logo" data-home-link href="/index.html" aria-label="Telcoin Wiki home">
         <img src="/logo.svg" alt="Telcoin Wiki" width="40" height="40" fetchpriority="high">
         <span>Telcoin Wiki</span>
       </a>
       <button type="button" class="sidebar-toggle" data-sidebar-toggle aria-expanded="false" aria-controls="site-sidebar">Menu</button>
       <nav class="top-nav" aria-label="Primary">
-        <ul class="top-nav__list" data-nav>
+        <ul class="top-nav__list tc-tabbar" data-nav>
           <li><a class="top-nav__link" href="/start-here.html">Start Here</a></li>
           <li><a class="top-nav__link" href="/faq/">FAQ</a></li>
           <li><a class="top-nav__link" href="/wallet.html">Wallet</a></li>
@@ -65,17 +77,20 @@
           <li><a class="top-nav__link" href="/links.html">Links</a></li>
         </ul>
       </nav>
-      <div class="header-search" role="search">
-        <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
-        <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
-        <div class="search-panel" data-search-results hidden aria-label="Search suggestions"></div>
+      <div class="site-header__actions">
+        <div class="last-updated" data-last-updated></div>
+        <div class="header-search" role="search">
+          <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
+          <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
+          <div class="search-panel tc-card" data-search-results hidden aria-label="Search suggestions"></div>
+        </div>
       </div>
     </div>
   </header>
   <div class="sidebar-overlay" data-sidebar-overlay></div>
   <div class="site-shell">
     <aside id="site-sidebar" class="sidebar" data-sidebar>
-      <div class="sidebar__inner">
+      <div class="sidebar__inner tc-card">
         <p class="sidebar__heading">Knowledge base</p>
         <nav class="sidebar__nav" aria-label="Knowledge base">
           <ul class="sidebar__list" data-sidebar-list>
@@ -122,10 +137,10 @@
         </nav>
       </div>
     </aside>
-    <main id="main-content" class="site-main" tabindex="-1">
+    <main id="main-content" class="site-main tc-card" tabindex="-1">
       <nav class="breadcrumbs" aria-label="Breadcrumb" data-breadcrumbs></nav>
 
-      <section id="governance-overview" class="page-intro anchor-offset">
+      <section id="governance-overview" class="page-intro anchor-offset tc-card">
         <p class="page-intro__eyebrow">Governance &amp; Association</p>
         <h1 class="page-intro__title">Who stewards Telcoin?</h1>
         <p class="page-intro__lede">The Telcoin Association, a Swiss Verein, leads Telcoin Network governance, validator onboarding, and issuance policies for TEL and Digital Cash. Community councils partner with the Association to review and advance proposals.</p>

--- a/index.html
+++ b/index.html
@@ -21,9 +21,21 @@
   <meta name="twitter:description" content="Unofficial Telcoin knowledge base with quick answers, onboarding guides, and trusted links to official Telcoin resources.">
   <meta name="twitter:image" content="https://telcoinwiki.com/assets/Telcoinwiki.png">
   <meta name="twitter:site" content="@telcoin">
-  <link rel="icon" type="image/svg+xml" href="/logo.svg">
+  <link rel="stylesheet" href="/src/styles/tokens.css">
   <link rel="preload" href="/dist/styles.css" as="style">
   <link rel="stylesheet" href="/dist/styles.css">
+  <link id="app-favicon" rel="icon" href="https://telcoin.org/favicon.ico" />
+  <script>
+    (function () {
+      var link = document.getElementById('app-favicon');
+      if (!link) return;
+      var img = new Image();
+      img.onerror = function () {
+        link.href = 'https://telcoin.network/favicon.ico';
+      };
+      img.src = link.href + '?v=1';
+    })();
+  </script>
   <style>
     /* Critical styles extracted from styles/critical.css */
     :root {
@@ -31,25 +43,28 @@
       --font-family-base: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
       --font-family-mono: "JetBrains Mono", "SFMono-Regular", Menlo, Consolas, monospace;
       --line-height-base: 1.6;
-      --color-bg: #050a1b;
-      --color-surface: #0e1934;
-      --color-surface-alt: #162449;
-      --color-surface-soft: #1f2f57;
-      --color-border: rgba(92, 130, 200, 0.45);
-      --color-border-subtle: rgba(92, 130, 200, 0.2);
-      --color-text: #f4f7ff;
-      --color-text-muted: rgba(244, 247, 255, 0.7);
-      --color-text-soft: rgba(244, 247, 255, 0.55);
-      --color-text-inverse: #07132b;
-      --color-primary: #4ea3ff;
-      --color-primary-strong: #1f6dff;
-      --color-primary-soft: rgba(78, 163, 255, 0.16);
-      --color-secondary: #2dd4bf;
-      --color-secondary-soft: rgba(45, 212, 191, 0.16);
-      --color-highlight: #a855f7;
+    
+      --color-bg: var(--tc-bg);
+      --color-surface: var(--tc-surface);
+      --color-surface-alt: var(--tc-surface-2);
+      --color-surface-soft: rgba(255, 255, 255, 0.12);
+      --color-border: var(--tc-border-strong);
+      --color-border-subtle: var(--tc-border);
+      --color-text: var(--tc-ink);
+      --color-text-muted: var(--tc-ink-muted);
+      --color-text-soft: var(--tc-ink-subtle);
+      --color-text-inverse: #050f2d;
+    
+      --color-primary: var(--tc-primary);
+      --color-primary-strong: var(--tc-primary-700);
+      --color-primary-soft: rgba(64, 102, 222, 0.22);
+      --color-secondary: var(--tc-accent);
+      --color-secondary-soft: rgba(69, 188, 241, 0.18);
+      --color-highlight: var(--tc-primary-300);
       --color-warning: #facc15;
       --color-warning-soft: rgba(250, 204, 21, 0.16);
-      --color-info-soft: rgba(78, 163, 255, 0.12);
+      --color-info-soft: rgba(69, 188, 241, 0.18);
+    
       --space-1: 0.25rem;
       --space-2: 0.5rem;
       --space-3: 0.75rem;
@@ -59,67 +74,68 @@
       --space-7: 2.5rem;
       --space-8: 3rem;
       --space-9: 4rem;
-      --radius-xs: 0.375rem;
-      --radius-sm: 0.75rem;
-      --radius-md: 1rem;
-      --radius-lg: 1.5rem;
-      --shadow-sm: 0 4px 16px rgba(7, 17, 40, 0.4);
+    
+      --radius-xs: 0.5rem;
+      --radius-sm: var(--tc-radius);
+      --radius-md: var(--tc-radius-lg);
+      --radius-lg: 1.75rem;
+    
+      --shadow-sm: var(--tc-shadow);
       --max-width-content: 72rem;
       --max-width-wide: 90rem;
       --sidebar-width: clamp(16rem, 18vw, 20rem);
       --header-height: 4.25rem;
       --transition-base: 0.25s ease;
     }
-
+    
+    
     *,
     *::before,
     *::after {
       box-sizing: border-box;
     }
-
+    
     html {
       scroll-behavior: smooth;
     }
-
+    
     body {
       margin: 0;
       font-family: var(--font-family-base);
       line-height: var(--line-height-base);
       color: var(--color-text);
       background:
-        radial-gradient(1200px 520px at -10% -15%, rgba(78, 163, 255, 0.28), transparent 70%),
-        radial-gradient(900px 720px at 120% -15%, rgba(45, 212, 191, 0.14), transparent 65%),
-        radial-gradient(640px 840px at 40% 120%, rgba(168, 85, 247, 0.18), transparent 70%),
-        linear-gradient(180deg, var(--color-bg) 0%, #091431 42%, #0c1f45 78%, #0f2a58 100%);
+        radial-gradient(1200px 800px at 10% -10%, rgba(69, 188, 241, 0.15), transparent 65%),
+        linear-gradient(180deg, #10255e 0%, var(--color-bg) 60%);
       min-height: 100vh;
     }
-
+    
     main {
       display: block;
     }
-
+    
     a {
-      color: var(--color-primary);
+      color: var(--color-secondary);
       text-decoration: none;
       transition: color var(--transition-base);
     }
-
+    
     a:hover,
     a:focus-visible {
       text-decoration: underline;
     }
-
+    
     img {
       max-width: 100%;
       height: auto;
       border-radius: var(--radius-sm);
     }
-
+    
     p {
       margin: 0 0 var(--space-4);
       color: var(--color-text-muted);
     }
-
+    
     h1,
     h2,
     h3,
@@ -131,127 +147,171 @@
       color: var(--color-text);
       margin: 0 0 var(--space-3);
     }
-
+    
     h1 {
       font-size: clamp(2.2rem, 4vw, 3.2rem);
     }
-
+    
     h2 {
       font-size: clamp(1.6rem, 2.6vw, 2.4rem);
     }
-
+    
     h3 {
       font-size: clamp(1.25rem, 2vw, 1.6rem);
     }
-
+    
     ul,
     ol {
       margin: 0 0 var(--space-4);
       padding-left: var(--space-5);
       color: var(--color-text-muted);
     }
-
+    
     .skip-link {
       position: absolute;
       top: -40px;
       left: var(--space-3);
       padding: var(--space-2) var(--space-3);
       background: var(--color-primary);
-      color: var(--color-text-inverse);
+      color: #fff;
       border-radius: var(--radius-sm);
       z-index: 200;
       transition: top var(--transition-base);
     }
-
+    
     .skip-link:focus {
       top: var(--space-3);
     }
-
+    
     .site-header {
       position: sticky;
       top: 0;
       z-index: 120;
-      background: rgba(8, 17, 44, 0.9);
+      background: rgba(14, 27, 63, 0.88);
       backdrop-filter: blur(18px);
-      border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+      border-bottom: 1px solid var(--color-border-subtle);
       box-shadow: var(--shadow-sm);
     }
-
+    
     .site-header__inner {
       max-width: var(--max-width-wide);
       margin: 0 auto;
       padding: var(--space-2) var(--space-4);
-      display: grid;
-      grid-template-columns: auto minmax(0, 1fr) auto;
+      display: flex;
+      flex-wrap: wrap;
       align-items: center;
       gap: var(--space-3);
     }
-
+    
     .site-logo {
       display: inline-flex;
       align-items: center;
       gap: var(--space-2);
-      font-weight: 600;
+      padding: var(--space-1) var(--space-2);
+      border-radius: var(--radius-sm);
       color: var(--color-text);
+      font-weight: 600;
+      transition: background var(--transition-base), transform var(--transition-base);
     }
-
+    
+    .site-logo:hover,
+    .site-logo:focus-visible {
+      background: var(--color-surface-alt);
+      text-decoration: none;
+      transform: translateY(-1px);
+    }
+    
     .site-logo span {
       font-size: 1rem;
     }
-
+    
     .sidebar-toggle {
-      display: none;
-      padding: var(--space-2) var(--space-3);
-      border-radius: var(--radius-sm);
-      border: 1px solid rgba(255, 255, 255, 0.12);
-      background: var(--color-surface);
-      color: var(--color-text);
-    }
-
-    .top-nav {
-      justify-self: end;
-    }
-
-    .top-nav__list {
-      display: flex;
+      display: inline-flex;
       align-items: center;
-      gap: var(--space-3);
-      list-style: none;
-      margin: 0;
-      padding: 0;
-    }
-
-    .top-nav__link {
-      color: var(--color-text-muted);
+      gap: var(--space-2);
+      margin-left: auto;
+      padding: var(--space-2) var(--space-3);
+      border-radius: var(--radius-pill);
+      border: 1px solid var(--color-border-subtle);
+      background: var(--color-surface-alt);
+      color: var(--color-text);
       font-size: 0.95rem;
     }
-
-    .top-nav__link.is-active {
-      color: var(--color-text);
-      font-weight: 600;
+    
+    .top-nav {
+      display: none;
+      flex: 1 1 auto;
     }
-
-    .header-search {
-      display: flex;
-      align-items: stretch;
-      position: relative;
-    }
-
-    .search-input {
-      width: 100%;
-      max-width: 16rem;
+    
+    .top-nav__list {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--space-2);
+      list-style: none;
+      margin: 0;
+      padding: var(--space-1);
+      border-radius: var(--radius-md);
       background: var(--color-surface);
       border: 1px solid var(--color-border-subtle);
-      border-radius: var(--radius-sm);
+    }
+    
+    .top-nav__link {
+      display: inline-flex;
+      align-items: center;
       padding: var(--space-2) var(--space-3);
+      border-radius: var(--radius-sm);
+      color: var(--color-text-muted);
+      font-size: 0.95rem;
+      transition: background var(--transition-base), color var(--transition-base);
+    }
+    
+    .top-nav__link:hover,
+    .top-nav__link:focus-visible {
+      color: var(--color-text);
+      text-decoration: none;
+      background: var(--color-surface-alt);
+    }
+    
+    .top-nav__link.is-active {
+      color: var(--color-text);
+      background: var(--color-surface-alt);
+    }
+    
+    .site-header__actions {
+      display: flex;
+      flex: 1 0 100%;
+      align-items: center;
+      gap: var(--space-3);
+      justify-content: space-between;
+      flex-wrap: wrap;
+    }
+    
+    .last-updated {
+      font-size: 0.75rem;
+      color: var(--color-text-soft);
+    }
+    
+    .header-search {
+      position: relative;
+      flex: 1 1 auto;
+      display: flex;
+      align-items: center;
+    }
+    
+    .search-input {
+      width: 100%;
+      padding: var(--space-2) var(--space-4);
+      border-radius: var(--radius-pill);
+      border: 1px solid var(--color-border-subtle);
+      background: rgba(17, 31, 68, 0.92);
       color: var(--color-text);
     }
-
+    
     .search-panel {
       position: absolute;
       top: calc(100% + var(--space-2));
       right: 0;
-      min-width: min(28rem, 90vw);
+      width: clamp(18rem, 32vw, 26rem);
       background: var(--color-surface);
       border: 1px solid var(--color-border-subtle);
       box-shadow: var(--shadow-sm);
@@ -260,7 +320,7 @@
       display: grid;
       gap: var(--space-3);
     }
-
+    
     .site-shell {
       max-width: var(--max-width-wide);
       margin: 0 auto;
@@ -268,22 +328,24 @@
       grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
       gap: var(--space-6);
       padding: var(--space-6) var(--space-4);
+      align-items: start;
     }
-
+    
     .sidebar {
       position: sticky;
       top: calc(var(--header-height) + var(--space-4));
       align-self: start;
     }
-
+    
     .sidebar__inner {
       background: var(--color-surface);
       border: 1px solid var(--color-border-subtle);
       border-radius: var(--radius-md);
       padding: var(--space-4);
       box-shadow: var(--shadow-sm);
+      backdrop-filter: blur(24px);
     }
-
+    
     .sidebar__heading {
       margin: 0 0 var(--space-3);
       font-size: 0.9rem;
@@ -291,7 +353,7 @@
       text-transform: uppercase;
       color: var(--color-text-soft);
     }
-
+    
     .sidebar__list,
     .sidebar__sublist {
       list-style: none;
@@ -300,24 +362,25 @@
       display: grid;
       gap: var(--space-2);
     }
-
+    
     .sidebar__link {
       color: var(--color-text-muted);
     }
-
+    
     .sidebar__link.is-active {
       color: var(--color-text);
       font-weight: 600;
     }
-
+    
     .site-main {
-      background: rgba(15, 27, 60, 0.65);
+      background: var(--color-surface);
       border: 1px solid var(--color-border-subtle);
       border-radius: var(--radius-lg);
       padding: var(--space-6);
       box-shadow: var(--shadow-sm);
+      backdrop-filter: blur(24px);
     }
-
+    
     .breadcrumbs {
       display: flex;
       align-items: center;
@@ -326,13 +389,13 @@
       margin-bottom: var(--space-4);
       color: var(--color-text-soft);
     }
-
+    
     .page-intro {
       display: grid;
       gap: var(--space-3);
       margin-bottom: var(--space-6);
     }
-
+    
     .page-intro__eyebrow {
       font-size: 0.85rem;
       font-weight: 600;
@@ -341,35 +404,25 @@
       color: var(--color-secondary);
       margin: 0;
     }
-
+    
     .page-intro__lede {
       font-size: 1.1rem;
     }
-
+    
     .notice {
       border-radius: var(--radius-md);
       padding: var(--space-4);
-      background: var(--color-info-soft);
+      background: var(--color-surface-alt);
+      border: 1px solid var(--color-border-subtle);
       color: var(--color-text);
+      box-shadow: var(--shadow-xs);
     }
-
+    
     @media (max-width: 1024px) {
-      .site-header__inner {
-        grid-template-columns: 1fr auto;
-      }
-
-      .top-nav {
-        display: none;
-      }
-
-      .sidebar-toggle {
-        display: inline-flex;
-      }
-
       .site-shell {
         grid-template-columns: 1fr;
       }
-
+    
       .sidebar {
         position: fixed;
         top: var(--header-height);
@@ -380,13 +433,47 @@
         transition: transform var(--transition-base);
         z-index: 90;
       }
-
+    
       .sidebar.is-open {
         transform: translateX(0);
       }
-
+    
+      .site-header__actions {
+        gap: var(--space-2);
+      }
+    
       .site-main {
         padding: var(--space-5);
+      }
+    }
+    
+    @media (min-width: 960px) {
+      .site-header__inner {
+        flex-wrap: nowrap;
+      }
+    
+      .sidebar-toggle {
+        display: none;
+      }
+    
+      .top-nav {
+        display: flex;
+        margin-left: var(--space-3);
+      }
+    
+      .site-header__actions {
+        flex: 0 0 auto;
+        justify-content: flex-end;
+        gap: var(--space-4);
+        margin-left: auto;
+      }
+    
+      .last-updated {
+        font-size: 0.8rem;
+      }
+    
+      .header-search {
+        max-width: 24rem;
       }
     }
   </style>
@@ -412,13 +499,13 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
   <header class="site-header" data-header>
     <div class="site-header__inner">
-      <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
+      <a class="site-logo" data-home-link href="/index.html" aria-label="Telcoin Wiki home">
         <img src="/logo.svg" alt="Telcoin Wiki" width="40" height="40" fetchpriority="high">
         <span>Telcoin Wiki</span>
       </a>
       <button type="button" class="sidebar-toggle" data-sidebar-toggle aria-expanded="false" aria-controls="site-sidebar">Menu</button>
       <nav class="top-nav" aria-label="Primary">
-        <ul class="top-nav__list" data-nav>
+        <ul class="top-nav__list tc-tabbar" data-nav>
           <li><a class="top-nav__link" href="/start-here.html">Start Here</a></li>
           <li><a class="top-nav__link" href="/faq/">FAQ</a></li>
           <li><a class="top-nav__link" href="/wallet.html">Wallet</a></li>
@@ -432,17 +519,20 @@
           <li><a class="top-nav__link" href="/links.html">Links</a></li>
         </ul>
       </nav>
-      <div class="header-search" role="search">
-        <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
-        <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
-        <div class="search-panel" data-search-results hidden aria-label="Search suggestions"></div>
+      <div class="site-header__actions">
+        <div class="last-updated" data-last-updated></div>
+        <div class="header-search" role="search">
+          <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
+          <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
+          <div class="search-panel tc-card" data-search-results hidden aria-label="Search suggestions"></div>
+        </div>
       </div>
     </div>
   </header>
   <div class="sidebar-overlay" data-sidebar-overlay></div>
   <div class="site-shell">
     <aside id="site-sidebar" class="sidebar" data-sidebar>
-      <div class="sidebar__inner">
+      <div class="sidebar__inner tc-card">
         <p class="sidebar__heading">Knowledge base</p>
         <nav class="sidebar__nav" aria-label="Knowledge base">
           <ul class="sidebar__list" data-sidebar-list>
@@ -483,10 +573,10 @@
         </nav>
       </div>
     </aside>
-    <main id="main-content" class="site-main" tabindex="-1">
+    <main id="main-content" class="site-main tc-card" tabindex="-1">
       <nav class="breadcrumbs" aria-label="Breadcrumb" data-breadcrumbs></nav>
 
-      <section id="home-hero" class="page-intro anchor-offset">
+      <section id="home-hero" class="page-intro anchor-offset tc-card">
         <p class="page-intro__eyebrow">Community Q&amp;A for Telcoin</p>
         <h1 class="page-intro__title">Understand the Telcoin platform in minutes</h1>
         <p class="page-intro__lede">This unofficial wiki curates verified answers, onboarding checklists, and direct links to Telcoin Association and Telcoin company resources so newcomers can get started with confidence.</p>

--- a/js/main.js
+++ b/js/main.js
@@ -63,8 +63,57 @@
     initSearch();
     initInlineFaqCards();
     initGettingStartedSection();
+    renderLastUpdated();
+    setupHomeLinks();
     applyStatusText(document);
   });
+
+  function formatLastUpdated(date) {
+    if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+      return '';
+    }
+    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    const day = date.getDate();
+    const suffix = day % 10 === 1 && day % 100 !== 11
+      ? 'st'
+      : day % 10 === 2 && day % 100 !== 12
+        ? 'nd'
+        : day % 10 === 3 && day % 100 !== 13
+          ? 'rd'
+          : 'th';
+    return `${months[date.getMonth()]} ${day}${suffix}, ${date.getFullYear()}`;
+  }
+
+  function renderLastUpdated() {
+    const target = document.querySelector('[data-last-updated]');
+    if (!target) {
+      return;
+    }
+    const modified = new Date(document.lastModified || Date.now());
+    const formatted = formatLastUpdated(modified);
+    if (!formatted) {
+      return;
+    }
+    target.textContent = `Last Updated ${formatted}`;
+  }
+
+  function setupHomeLinks() {
+    const links = document.querySelectorAll('[data-home-link]');
+    if (!links.length) {
+      return;
+    }
+    links.forEach((link) => {
+      link.addEventListener('click', (event) => {
+        if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0) {
+          return;
+        }
+        event.preventDefault();
+        const base = window.location.pathname + window.location.search;
+        history.replaceState(null, '', base);
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      });
+    });
+  }
 
   function getStatusData() {
     const data = window.__STATUS__;

--- a/js/pools-data.js
+++ b/js/pools-data.js
@@ -845,15 +845,15 @@
 
     function createStatusChip(status) {
         const span = document.createElement('span');
-        span.classList.add('chip');
+        span.classList.add('tc-chip');
         const label = status && status.trim ? status.trim() : 'Unknown';
         const normalized = label.toLowerCase();
         if (normalized.indexOf('active') !== -1 || normalized.indexOf('live') !== -1 || normalized.indexOf('enabled') !== -1) {
-            span.classList.add('chip-active');
+            span.classList.add('chip-active', 'is-active');
         } else if (normalized.indexOf('deprecated') !== -1 || normalized.indexOf('sunset') !== -1 || normalized.indexOf('inactive') !== -1 || normalized.indexOf('ending') !== -1) {
-            span.classList.add('chip-deprecated');
+            span.classList.add('chip-deprecated', 'is-deprecated');
         } else if (normalized.indexOf('archived') !== -1 || normalized.indexOf('ended') !== -1 || normalized.indexOf('retired') !== -1) {
-            span.classList.add('chip-archived');
+            span.classList.add('chip-archived', 'is-archived');
         }
         span.title = label;
         span.textContent = label;

--- a/links.html
+++ b/links.html
@@ -21,9 +21,21 @@
   <meta name="twitter:description" content="Trusted Telcoin links for Wallet, Digital Cash, Remittances, Association docs, Network updates, legal notices, and social channels.">
   <meta name="twitter:image" content="https://telcoinwiki.com/assets/Telcoinwiki.png">
   <meta name="twitter:site" content="@telcoin">
-  <link rel="icon" type="image/svg+xml" href="/logo.svg">
+  <link rel="stylesheet" href="/src/styles/tokens.css">
   <link rel="preload" href="/dist/styles.css" as="style">
   <link rel="stylesheet" href="/dist/styles.css">
+  <link id="app-favicon" rel="icon" href="https://telcoin.org/favicon.ico" />
+  <script>
+    (function () {
+      var link = document.getElementById('app-favicon');
+      if (!link) return;
+      var img = new Image();
+      img.onerror = function () {
+        link.href = 'https://telcoin.network/favicon.ico';
+      };
+      img.src = link.href + '?v=1';
+    })();
+  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -45,13 +57,13 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
   <header class="site-header" data-header>
     <div class="site-header__inner">
-      <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
+      <a class="site-logo" data-home-link href="/index.html" aria-label="Telcoin Wiki home">
         <img src="/logo.svg" alt="Telcoin Wiki" width="40" height="40" fetchpriority="high">
         <span>Telcoin Wiki</span>
       </a>
       <button type="button" class="sidebar-toggle" data-sidebar-toggle aria-expanded="false" aria-controls="site-sidebar">Menu</button>
       <nav class="top-nav" aria-label="Primary">
-        <ul class="top-nav__list" data-nav>
+        <ul class="top-nav__list tc-tabbar" data-nav>
           <li><a class="top-nav__link" href="/start-here.html">Start Here</a></li>
           <li><a class="top-nav__link" href="/faq/">FAQ</a></li>
           <li><a class="top-nav__link" href="/wallet.html">Wallet</a></li>
@@ -65,17 +77,20 @@
           <li><a class="top-nav__link is-active" href="/links.html" aria-current="page">Links</a></li>
         </ul>
       </nav>
-      <div class="header-search" role="search">
-        <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
-        <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
-        <div class="search-panel" data-search-results hidden aria-label="Search suggestions"></div>
+      <div class="site-header__actions">
+        <div class="last-updated" data-last-updated></div>
+        <div class="header-search" role="search">
+          <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
+          <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
+          <div class="search-panel tc-card" data-search-results hidden aria-label="Search suggestions"></div>
+        </div>
       </div>
     </div>
   </header>
   <div class="sidebar-overlay" data-sidebar-overlay></div>
   <div class="site-shell">
     <aside id="site-sidebar" class="sidebar" data-sidebar>
-      <div class="sidebar__inner">
+      <div class="sidebar__inner tc-card">
         <p class="sidebar__heading">Knowledge base</p>
         <nav class="sidebar__nav" aria-label="Knowledge base">
           <ul class="sidebar__list" data-sidebar-list>
@@ -122,10 +137,10 @@
         </nav>
       </div>
     </aside>
-    <main id="main-content" class="site-main" tabindex="-1">
+    <main id="main-content" class="site-main tc-card" tabindex="-1">
       <nav class="breadcrumbs" aria-label="Breadcrumb" data-breadcrumbs></nav>
 
-      <section id="links-overview" class="page-intro anchor-offset">
+      <section id="links-overview" class="page-intro anchor-offset tc-card">
         <p class="page-intro__eyebrow">Official links</p>
         <h1 class="page-intro__title">Verified Telcoin destinations</h1>
         <p class="page-intro__lede">Bookmark these official Telcoin channels for product information, governance updates, status notifications, legal notices, and security alerts.</p>

--- a/network.html
+++ b/network.html
@@ -21,9 +21,21 @@
   <meta name="twitter:description" content="Review the Telcoin Network’s EVM design, validator requirements, and how the Association governs upgrades.">
   <meta name="twitter:image" content="https://telcoinwiki.com/assets/Telcoinwiki.png">
   <meta name="twitter:site" content="@telcoin">
-  <link rel="icon" type="image/svg+xml" href="/logo.svg">
+  <link rel="stylesheet" href="/src/styles/tokens.css">
   <link rel="preload" href="/dist/styles.css" as="style">
   <link rel="stylesheet" href="/dist/styles.css">
+  <link id="app-favicon" rel="icon" href="https://telcoin.org/favicon.ico" />
+  <script>
+    (function () {
+      var link = document.getElementById('app-favicon');
+      if (!link) return;
+      var img = new Image();
+      img.onerror = function () {
+        link.href = 'https://telcoin.network/favicon.ico';
+      };
+      img.src = link.href + '?v=1';
+    })();
+  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -45,13 +57,13 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
   <header class="site-header" data-header>
     <div class="site-header__inner">
-      <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
+      <a class="site-logo" data-home-link href="/index.html" aria-label="Telcoin Wiki home">
         <img src="/logo.svg" alt="Telcoin Wiki" width="40" height="40" fetchpriority="high">
         <span>Telcoin Wiki</span>
       </a>
       <button type="button" class="sidebar-toggle" data-sidebar-toggle aria-expanded="false" aria-controls="site-sidebar">Menu</button>
       <nav class="top-nav" aria-label="Primary">
-        <ul class="top-nav__list" data-nav>
+        <ul class="top-nav__list tc-tabbar" data-nav>
           <li><a class="top-nav__link" href="/start-here.html">Start Here</a></li>
           <li><a class="top-nav__link" href="/faq/">FAQ</a></li>
           <li><a class="top-nav__link" href="/wallet.html">Wallet</a></li>
@@ -65,17 +77,20 @@
           <li><a class="top-nav__link" href="/links.html">Links</a></li>
         </ul>
       </nav>
-      <div class="header-search" role="search">
-        <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
-        <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
-        <div class="search-panel" data-search-results hidden aria-label="Search suggestions"></div>
+      <div class="site-header__actions">
+        <div class="last-updated" data-last-updated></div>
+        <div class="header-search" role="search">
+          <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
+          <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
+          <div class="search-panel tc-card" data-search-results hidden aria-label="Search suggestions"></div>
+        </div>
       </div>
     </div>
   </header>
   <div class="sidebar-overlay" data-sidebar-overlay></div>
   <div class="site-shell">
     <aside id="site-sidebar" class="sidebar" data-sidebar>
-      <div class="sidebar__inner">
+      <div class="sidebar__inner tc-card">
         <p class="sidebar__heading">Knowledge base</p>
         <nav class="sidebar__nav" aria-label="Knowledge base">
           <ul class="sidebar__list" data-sidebar-list>
@@ -122,10 +137,10 @@
         </nav>
       </div>
     </aside>
-    <main id="main-content" class="site-main" tabindex="-1">
+    <main id="main-content" class="site-main tc-card" tabindex="-1">
       <nav class="breadcrumbs" aria-label="Breadcrumb" data-breadcrumbs></nav>
 
-      <section id="network-overview" class="page-intro anchor-offset">
+      <section id="network-overview" class="page-intro anchor-offset tc-card">
         <p class="page-intro__eyebrow">Telcoin Network</p>
         <h1 class="page-intro__title">Carrier-secured, EVM compatible</h1>
         <p class="page-intro__lede">The Telcoin Network is an EVM chain whose validators are GSMA-member mobile network operators. It connects remittances, Digital Cash, TEL staking, and TELx liquidity under a compliance-first governance model.</p>

--- a/pools.html
+++ b/pools.html
@@ -21,9 +21,21 @@
   <meta name="twitter:description" content="Snapshot of TELx liquidity pools with status chips, TVL, staking balances, 24h volume, fees, and reward programs.">
   <meta name="twitter:image" content="https://telcoinwiki.com/assets/Telcoinwiki.png">
   <meta name="twitter:site" content="@telcoin">
-  <link rel="icon" type="image/svg+xml" href="/logo.svg">
+  <link rel="stylesheet" href="/src/styles/tokens.css">
   <link rel="preload" href="/dist/styles.css" as="style">
   <link rel="stylesheet" href="/dist/styles.css">
+  <link id="app-favicon" rel="icon" href="https://telcoin.org/favicon.ico" />
+  <script>
+    (function () {
+      var link = document.getElementById('app-favicon');
+      if (!link) return;
+      var img = new Image();
+      img.onerror = function () {
+        link.href = 'https://telcoin.network/favicon.ico';
+      };
+      img.src = link.href + '?v=1';
+    })();
+  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -46,13 +58,13 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
   <header class="site-header" data-header>
     <div class="site-header__inner">
-      <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
+      <a class="site-logo" data-home-link href="/index.html" aria-label="Telcoin Wiki home">
         <img src="/logo.svg" alt="Telcoin Wiki" width="40" height="40" fetchpriority="high">
         <span>Telcoin Wiki</span>
       </a>
       <button type="button" class="sidebar-toggle" data-sidebar-toggle aria-expanded="false" aria-controls="site-sidebar">Menu</button>
       <nav class="top-nav" aria-label="Primary">
-        <ul class="top-nav__list" data-nav>
+        <ul class="top-nav__list tc-tabbar" data-nav>
           <li><a class="top-nav__link" href="/start-here.html">Start Here</a></li>
           <li><a class="top-nav__link" href="/faq/">FAQ</a></li>
           <li><a class="top-nav__link" href="/wallet.html">Wallet</a></li>
@@ -66,17 +78,20 @@
           <li><a class="top-nav__link" href="/links.html">Links</a></li>
         </ul>
       </nav>
-      <div class="header-search" role="search">
-        <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
-        <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
-        <div class="search-panel" data-search-results hidden aria-label="Search suggestions"></div>
+      <div class="site-header__actions">
+        <div class="last-updated" data-last-updated></div>
+        <div class="header-search" role="search">
+          <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
+          <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
+          <div class="search-panel tc-card" data-search-results hidden aria-label="Search suggestions"></div>
+        </div>
       </div>
     </div>
   </header>
   <div class="sidebar-overlay" data-sidebar-overlay></div>
   <div class="site-shell">
     <aside id="site-sidebar" class="sidebar" data-sidebar>
-      <div class="sidebar__inner">
+      <div class="sidebar__inner tc-card">
         <p class="sidebar__heading">Knowledge base</p>
         <nav class="sidebar__nav" aria-label="Knowledge base">
           <ul class="sidebar__list" data-sidebar-list>
@@ -122,10 +137,10 @@
         </nav>
       </div>
     </aside>
-    <main id="main-content" class="site-main" tabindex="-1">
+    <main id="main-content" class="site-main tc-card" tabindex="-1">
       <nav class="breadcrumbs" aria-label="Breadcrumb" data-breadcrumbs></nav>
 
-      <section id="pools-overview" class="page-intro anchor-offset">
+      <section id="pools-overview" class="page-intro anchor-offset tc-card">
         <p class="page-intro__eyebrow">TELx Pools</p>
         <h1 class="page-intro__title">Pools overview</h1>
         <p class="page-intro__lede">Monitor the health of Telcoin’s on-chain liquidity. Status chips reflect governance-defined lifecycle stages; metrics refresh alongside community updates.</p>

--- a/portfolio.html
+++ b/portfolio.html
@@ -21,9 +21,21 @@
   <meta name="twitter:description" content="Track simulated TELx rewards, LPT stakes, and deprecated pool notices in a TELx-inspired portfolio dashboard.">
   <meta name="twitter:image" content="https://telcoinwiki.com/assets/Telcoinwiki.png">
   <meta name="twitter:site" content="@telcoin">
-  <link rel="icon" type="image/svg+xml" href="/logo.svg">
+  <link rel="stylesheet" href="/src/styles/tokens.css">
   <link rel="preload" href="/dist/styles.css" as="style">
   <link rel="stylesheet" href="/dist/styles.css">
+  <link id="app-favicon" rel="icon" href="https://telcoin.org/favicon.ico" />
+  <script>
+    (function () {
+      var link = document.getElementById('app-favicon');
+      if (!link) return;
+      var img = new Image();
+      img.onerror = function () {
+        link.href = 'https://telcoin.network/favicon.ico';
+      };
+      img.src = link.href + '?v=1';
+    })();
+  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -45,13 +57,13 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
   <header class="site-header" data-header>
     <div class="site-header__inner">
-      <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
+      <a class="site-logo" data-home-link href="/index.html" aria-label="Telcoin Wiki home">
         <img src="/logo.svg" alt="Telcoin Wiki" width="40" height="40" fetchpriority="high">
         <span>Telcoin Wiki</span>
       </a>
       <button type="button" class="sidebar-toggle" data-sidebar-toggle aria-expanded="false" aria-controls="site-sidebar">Menu</button>
       <nav class="top-nav" aria-label="Primary">
-        <ul class="top-nav__list" data-nav>
+        <ul class="top-nav__list tc-tabbar" data-nav>
           <li><a class="top-nav__link" href="/start-here.html">Start Here</a></li>
           <li><a class="top-nav__link" href="/faq/">FAQ</a></li>
           <li><a class="top-nav__link" href="/wallet.html">Wallet</a></li>
@@ -65,17 +77,20 @@
           <li><a class="top-nav__link" href="/links.html">Links</a></li>
         </ul>
       </nav>
-      <div class="header-search" role="search">
-        <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
-        <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
-        <div class="search-panel" data-search-results hidden aria-label="Search suggestions"></div>
+      <div class="site-header__actions">
+        <div class="last-updated" data-last-updated></div>
+        <div class="header-search" role="search">
+          <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
+          <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
+          <div class="search-panel tc-card" data-search-results hidden aria-label="Search suggestions"></div>
+        </div>
       </div>
     </div>
   </header>
   <div class="sidebar-overlay" data-sidebar-overlay></div>
   <div class="site-shell">
     <aside id="site-sidebar" class="sidebar" data-sidebar>
-      <div class="sidebar__inner">
+      <div class="sidebar__inner tc-card">
         <p class="sidebar__heading">Knowledge base</p>
         <nav class="sidebar__nav" aria-label="Knowledge base">
           <ul class="sidebar__list" data-sidebar-list>
@@ -122,10 +137,10 @@
         </nav>
       </div>
     </aside>
-    <main id="main-content" class="site-main" tabindex="-1">
+    <main id="main-content" class="site-main tc-card" tabindex="-1">
       <nav class="breadcrumbs" aria-label="Breadcrumb" data-breadcrumbs></nav>
 
-      <section id="portfolio-overview" class="page-intro anchor-offset">
+      <section id="portfolio-overview" class="page-intro anchor-offset tc-card">
         <p class="page-intro__eyebrow">TELx Portfolio</p>
         <h1 class="page-intro__title">Your TELx positions</h1>
         <p class="page-intro__lede">A design-time view of TEL claimable rewards and liquidity provider tokens. Use it to imagine how TELx wallets surface positions with glass panels, friendly chips, and clear callouts.</p>
@@ -156,7 +171,7 @@
                 <p class="entry-list__label">TEL / USDC</p>
                 <p class="entry-list__value">1,248 TEL</p>
               </div>
-              <span class="chip chip-active">Active</span>
+              <span class="tc-chip is-active">Active</span>
             </div>
             <p class="entry-list__meta">Next unlock: 03:12 UTC • Reward stream via TEL issuance</p>
           </li>
@@ -166,7 +181,7 @@
                 <p class="entry-list__label">TEL / WETH</p>
                 <p class="entry-list__value">482 TEL</p>
               </div>
-              <span class="chip chip-active">Active</span>
+              <span class="tc-chip is-active">Active</span>
             </div>
             <p class="entry-list__meta">Fees accrued in last 24h: $212</p>
           </li>
@@ -176,7 +191,7 @@
                 <p class="entry-list__label">TEL / eUSD</p>
                 <p class="entry-list__value">176 TEL</p>
               </div>
-              <span class="chip chip-deprecated">Deprecated</span>
+              <span class="tc-chip is-deprecated">Deprecated</span>
             </div>
             <p class="entry-list__meta">Claim before 15 Sep • incentives ending soon</p>
           </li>
@@ -196,7 +211,7 @@
                 <p class="entry-list__label">TEL / USDC</p>
                 <p class="entry-list__value">12.8 LPT</p>
               </div>
-              <span class="chip chip-active">Active</span>
+              <span class="tc-chip is-active">Active</span>
             </div>
             <p class="entry-list__meta">Share of pool: 0.82% • Staked since 12 Jul 2025</p>
           </li>
@@ -206,7 +221,7 @@
                 <p class="entry-list__label">TEL / MATIC</p>
                 <p class="entry-list__value">6.4 LPT</p>
               </div>
-              <span class="chip chip-active">Active</span>
+              <span class="tc-chip is-active">Active</span>
             </div>
             <p class="entry-list__meta">Rewards streaming: 98 TEL / day</p>
           </li>
@@ -216,7 +231,7 @@
                 <p class="entry-list__label">TEL / eCAD</p>
                 <p class="entry-list__value">3.1 LPT</p>
               </div>
-              <span class="chip chip-archived">Archived</span>
+              <span class="tc-chip is-archived">Archived</span>
             </div>
             <p class="entry-list__meta">Consider migrating to TEL / USDC for active incentives</p>
           </li>

--- a/remittances.html
+++ b/remittances.html
@@ -21,9 +21,21 @@
   <meta name="twitter:description" content="Check live Telcoin remittance coverage, how pricing works, and where to confirm service status before you send.">
   <meta name="twitter:image" content="https://telcoinwiki.com/assets/Telcoinwiki.png">
   <meta name="twitter:site" content="@telcoin">
-  <link rel="icon" type="image/svg+xml" href="/logo.svg">
+  <link rel="stylesheet" href="/src/styles/tokens.css">
   <link rel="preload" href="/dist/styles.css" as="style">
   <link rel="stylesheet" href="/dist/styles.css">
+  <link id="app-favicon" rel="icon" href="https://telcoin.org/favicon.ico" />
+  <script>
+    (function () {
+      var link = document.getElementById('app-favicon');
+      if (!link) return;
+      var img = new Image();
+      img.onerror = function () {
+        link.href = 'https://telcoin.network/favicon.ico';
+      };
+      img.src = link.href + '?v=1';
+    })();
+  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -46,13 +58,13 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
   <header class="site-header" data-header>
     <div class="site-header__inner">
-      <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
+      <a class="site-logo" data-home-link href="/index.html" aria-label="Telcoin Wiki home">
         <img src="/logo.svg" alt="Telcoin Wiki" width="40" height="40" fetchpriority="high">
         <span>Telcoin Wiki</span>
       </a>
       <button type="button" class="sidebar-toggle" data-sidebar-toggle aria-expanded="false" aria-controls="site-sidebar">Menu</button>
       <nav class="top-nav" aria-label="Primary">
-        <ul class="top-nav__list" data-nav>
+        <ul class="top-nav__list tc-tabbar" data-nav>
           <li><a class="top-nav__link" href="/start-here.html">Start Here</a></li>
           <li><a class="top-nav__link" href="/faq/">FAQ</a></li>
           <li><a class="top-nav__link" href="/wallet.html">Wallet</a></li>
@@ -66,17 +78,20 @@
           <li><a class="top-nav__link" href="/links.html">Links</a></li>
         </ul>
       </nav>
-      <div class="header-search" role="search">
-        <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
-        <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
-        <div class="search-panel" data-search-results hidden aria-label="Search suggestions"></div>
+      <div class="site-header__actions">
+        <div class="last-updated" data-last-updated></div>
+        <div class="header-search" role="search">
+          <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
+          <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
+          <div class="search-panel tc-card" data-search-results hidden aria-label="Search suggestions"></div>
+        </div>
       </div>
     </div>
   </header>
   <div class="sidebar-overlay" data-sidebar-overlay></div>
   <div class="site-shell">
     <aside id="site-sidebar" class="sidebar" data-sidebar>
-      <div class="sidebar__inner">
+      <div class="sidebar__inner tc-card">
         <p class="sidebar__heading">Knowledge base</p>
         <nav class="sidebar__nav" aria-label="Knowledge base">
           <ul class="sidebar__list" data-sidebar-list>
@@ -123,10 +138,10 @@
         </nav>
       </div>
     </aside>
-    <main id="main-content" class="site-main" tabindex="-1">
+    <main id="main-content" class="site-main tc-card" tabindex="-1">
       <nav class="breadcrumbs" aria-label="Breadcrumb" data-breadcrumbs></nav>
 
-      <section id="remittance-overview" class="page-intro anchor-offset">
+      <section id="remittance-overview" class="page-intro anchor-offset tc-card">
         <p class="page-intro__eyebrow">Remittances</p>
         <h1 class="page-intro__title">Send money with Telcoin</h1>
         <p class="page-intro__lede">The Telcoin Wallet offers fast, low-cost remittances across more than <span data-status-key="remittanceCorridors">20</span> corridors. Use the official corridor directory to confirm supported routes, payout partners, and fees before you transfer.</p>

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,85 @@
+:root {
+  /* Telcoin palette */
+  --tc-primary: #4066DE;
+  --tc-primary-50: #E4ECF7;
+  --tc-primary-300: #7F86D2;
+  --tc-primary-500: #4066DE;
+  --tc-primary-700: #2C2C7A;
+  --tc-accent: #45BCF1;
+
+  --tc-ink: rgba(255, 255, 255, 0.92);
+  --tc-ink-muted: rgba(255, 255, 255, 0.8);
+  --tc-ink-subtle: rgba(255, 255, 255, 0.65);
+
+  --tc-bg: #0f1a3a;
+  --tc-surface: rgba(255, 255, 255, 0.05);
+  --tc-surface-2: rgba(255, 255, 255, 0.08);
+  --tc-border: rgba(255, 255, 255, 0.1);
+  --tc-border-strong: rgba(255, 255, 255, 0.18);
+
+  --tc-radius: 1rem;
+  --tc-radius-lg: 1.25rem;
+  --tc-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+}
+
+.tc-card {
+  border: 1px solid var(--tc-border);
+  background: var(--tc-surface);
+  border-radius: var(--tc-radius-lg);
+  box-shadow: var(--tc-shadow);
+  backdrop-filter: blur(24px);
+  color: var(--tc-ink);
+}
+
+.tc-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--tc-radius);
+  border: 1px solid var(--tc-border);
+  background: var(--tc-surface);
+  color: var(--tc-ink);
+  font-weight: 600;
+  font-size: 0.875rem;
+}
+
+.tc-chip.is-active {
+  background: rgba(69, 188, 241, 0.18);
+  border-color: rgba(69, 188, 241, 0.4);
+  color: var(--tc-accent);
+}
+
+.tc-chip.is-archived {
+  background: rgba(64, 102, 222, 0.2);
+  border-color: rgba(64, 102, 222, 0.45);
+  color: var(--tc-ink-muted);
+}
+
+.tc-chip.is-deprecated {
+  background: rgba(250, 204, 21, 0.2);
+  border-color: rgba(250, 204, 21, 0.45);
+  color: #facc15;
+}
+
+.tc-tabbar {
+  display: inline-flex;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  border-radius: var(--tc-radius-lg);
+  background: var(--tc-surface);
+}
+
+.tc-tabbar button[aria-pressed="true"] {
+  background: var(--tc-surface-2);
+  color: var(--tc-ink);
+  border-radius: 0.75rem;
+}
+
+.tc-link {
+  color: var(--tc-accent);
+}
+
+.tc-link:hover {
+  text-decoration: underline;
+}

--- a/start-here.html
+++ b/start-here.html
@@ -21,9 +21,21 @@
   <meta name="twitter:description" content="Start with the top Telcoin questions and link directly to official Wallet, Digital Cash, Remittance, TEL, and governance resources.">
   <meta name="twitter:image" content="https://telcoinwiki.com/assets/Telcoinwiki.png">
   <meta name="twitter:site" content="@telcoin">
-  <link rel="icon" type="image/svg+xml" href="/logo.svg">
+  <link rel="stylesheet" href="/src/styles/tokens.css">
   <link rel="preload" href="/dist/styles.css" as="style">
   <link rel="stylesheet" href="/dist/styles.css">
+  <link id="app-favicon" rel="icon" href="https://telcoin.org/favicon.ico" />
+  <script>
+    (function () {
+      var link = document.getElementById('app-favicon');
+      if (!link) return;
+      var img = new Image();
+      img.onerror = function () {
+        link.href = 'https://telcoin.network/favicon.ico';
+      };
+      img.src = link.href + '?v=1';
+    })();
+  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -46,13 +58,13 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
   <header class="site-header" data-header>
     <div class="site-header__inner">
-      <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
+      <a class="site-logo" data-home-link href="/index.html" aria-label="Telcoin Wiki home">
         <img src="/logo.svg" alt="Telcoin Wiki" width="40" height="40" fetchpriority="high">
         <span>Telcoin Wiki</span>
       </a>
       <button type="button" class="sidebar-toggle" data-sidebar-toggle aria-expanded="false" aria-controls="site-sidebar">Menu</button>
       <nav class="top-nav" aria-label="Primary">
-        <ul class="top-nav__list" data-nav>
+        <ul class="top-nav__list tc-tabbar" data-nav>
           <li><a class="top-nav__link is-active" href="/start-here.html" aria-current="page">Start Here</a></li>
           <li><a class="top-nav__link" href="/faq/">FAQ</a></li>
           <li><a class="top-nav__link" href="/wallet.html">Wallet</a></li>
@@ -66,17 +78,20 @@
           <li><a class="top-nav__link" href="/links.html">Links</a></li>
         </ul>
       </nav>
-      <div class="header-search" role="search">
-        <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
-        <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
-        <div class="search-panel" data-search-results hidden aria-label="Search suggestions"></div>
+      <div class="site-header__actions">
+        <div class="last-updated" data-last-updated></div>
+        <div class="header-search" role="search">
+          <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
+          <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
+          <div class="search-panel tc-card" data-search-results hidden aria-label="Search suggestions"></div>
+        </div>
       </div>
     </div>
   </header>
   <div class="sidebar-overlay" data-sidebar-overlay></div>
   <div class="site-shell">
     <aside id="site-sidebar" class="sidebar" data-sidebar>
-      <div class="sidebar__inner">
+      <div class="sidebar__inner tc-card">
         <p class="sidebar__heading">Knowledge base</p>
         <nav class="sidebar__nav" aria-label="Knowledge base">
           <ul class="sidebar__list" data-sidebar-list>
@@ -122,10 +137,10 @@
         </nav>
       </div>
     </aside>
-    <main id="main-content" class="site-main" tabindex="-1">
+    <main id="main-content" class="site-main tc-card" tabindex="-1">
       <nav class="breadcrumbs" aria-label="Breadcrumb" data-breadcrumbs></nav>
 
-      <section id="start-intro" class="page-intro anchor-offset">
+      <section id="start-intro" class="page-intro anchor-offset tc-card">
         <p class="page-intro__eyebrow">Start here</p>
         <h1 class="page-intro__title">Your Telcoin onboarding checklist</h1>
         <p class="page-intro__lede">Use these quick answers to ground yourself in the Telcoin Wallet, Digital Cash, remittance coverage, TEL utility, and the governance structure that keeps everything compliant.</p>

--- a/styles/critical.css
+++ b/styles/critical.css
@@ -4,26 +4,26 @@
   --font-family-mono: "JetBrains Mono", "SFMono-Regular", Menlo, Consolas, monospace;
   --line-height-base: 1.6;
 
-  --color-bg: #050a1b;
-  --color-surface: #0e1934;
-  --color-surface-alt: #162449;
-  --color-surface-soft: #1f2f57;
-  --color-border: rgba(92, 130, 200, 0.45);
-  --color-border-subtle: rgba(92, 130, 200, 0.2);
-  --color-text: #f4f7ff;
-  --color-text-muted: rgba(244, 247, 255, 0.7);
-  --color-text-soft: rgba(244, 247, 255, 0.55);
-  --color-text-inverse: #07132b;
+  --color-bg: var(--tc-bg);
+  --color-surface: var(--tc-surface);
+  --color-surface-alt: var(--tc-surface-2);
+  --color-surface-soft: rgba(255, 255, 255, 0.12);
+  --color-border: var(--tc-border-strong);
+  --color-border-subtle: var(--tc-border);
+  --color-text: var(--tc-ink);
+  --color-text-muted: var(--tc-ink-muted);
+  --color-text-soft: var(--tc-ink-subtle);
+  --color-text-inverse: #050f2d;
 
-  --color-primary: #4ea3ff;
-  --color-primary-strong: #1f6dff;
-  --color-primary-soft: rgba(78, 163, 255, 0.16);
-  --color-secondary: #2dd4bf;
-  --color-secondary-soft: rgba(45, 212, 191, 0.16);
-  --color-highlight: #a855f7;
+  --color-primary: var(--tc-primary);
+  --color-primary-strong: var(--tc-primary-700);
+  --color-primary-soft: rgba(64, 102, 222, 0.22);
+  --color-secondary: var(--tc-accent);
+  --color-secondary-soft: rgba(69, 188, 241, 0.18);
+  --color-highlight: var(--tc-primary-300);
   --color-warning: #facc15;
   --color-warning-soft: rgba(250, 204, 21, 0.16);
-  --color-info-soft: rgba(78, 163, 255, 0.12);
+  --color-info-soft: rgba(69, 188, 241, 0.18);
 
   --space-1: 0.25rem;
   --space-2: 0.5rem;
@@ -35,12 +35,12 @@
   --space-8: 3rem;
   --space-9: 4rem;
 
-  --radius-xs: 0.375rem;
-  --radius-sm: 0.75rem;
-  --radius-md: 1rem;
-  --radius-lg: 1.5rem;
+  --radius-xs: 0.5rem;
+  --radius-sm: var(--tc-radius);
+  --radius-md: var(--tc-radius-lg);
+  --radius-lg: 1.75rem;
 
-  --shadow-sm: 0 4px 16px rgba(7, 17, 40, 0.4);
+  --shadow-sm: var(--tc-shadow);
   --max-width-content: 72rem;
   --max-width-wide: 90rem;
   --sidebar-width: clamp(16rem, 18vw, 20rem);
@@ -65,10 +65,8 @@ body {
   line-height: var(--line-height-base);
   color: var(--color-text);
   background:
-    radial-gradient(1200px 520px at -10% -15%, rgba(78, 163, 255, 0.28), transparent 70%),
-    radial-gradient(900px 720px at 120% -15%, rgba(45, 212, 191, 0.14), transparent 65%),
-    radial-gradient(640px 840px at 40% 120%, rgba(168, 85, 247, 0.18), transparent 70%),
-    linear-gradient(180deg, var(--color-bg) 0%, #091431 42%, #0c1f45 78%, #0f2a58 100%);
+    radial-gradient(1200px 800px at 10% -10%, rgba(69, 188, 241, 0.15), transparent 65%),
+    linear-gradient(180deg, #10255e 0%, var(--color-bg) 60%);
   min-height: 100vh;
 }
 
@@ -77,7 +75,7 @@ main {
 }
 
 a {
-  color: var(--color-primary);
+  color: var(--color-secondary);
   text-decoration: none;
   transition: color var(--transition-base);
 }
@@ -135,7 +133,7 @@ ol {
   left: var(--space-3);
   padding: var(--space-2) var(--space-3);
   background: var(--color-primary);
-  color: var(--color-text-inverse);
+  color: #fff;
   border-radius: var(--radius-sm);
   z-index: 200;
   transition: top var(--transition-base);
@@ -149,9 +147,9 @@ ol {
   position: sticky;
   top: 0;
   z-index: 120;
-  background: rgba(8, 17, 44, 0.9);
+  background: rgba(14, 27, 63, 0.88);
   backdrop-filter: blur(18px);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  border-bottom: 1px solid var(--color-border-subtle);
   box-shadow: var(--shadow-sm);
 }
 
@@ -159,8 +157,8 @@ ol {
   max-width: var(--max-width-wide);
   margin: 0 auto;
   padding: var(--space-2) var(--space-4);
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: var(--space-3);
 }
@@ -169,8 +167,18 @@ ol {
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
-  font-weight: 600;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
   color: var(--color-text);
+  font-weight: 600;
+  transition: background var(--transition-base), transform var(--transition-base);
+}
+
+.site-logo:hover,
+.site-logo:focus-visible {
+  background: var(--color-surface-alt);
+  text-decoration: none;
+  transform: translateY(-1px);
 }
 
 .site-logo span {
@@ -178,50 +186,96 @@ ol {
 }
 
 .sidebar-toggle {
-  display: none;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-left: auto;
   padding: var(--space-2) var(--space-3);
-  border-radius: var(--radius-sm);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: var(--color-surface);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-surface-alt);
   color: var(--color-text);
+  font-size: 0.95rem;
 }
 
 .top-nav {
-  justify-self: end;
+  display: none;
+  flex: 1 1 auto;
 }
 
 .top-nav__list {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: var(--space-3);
+  gap: var(--space-2);
   list-style: none;
   margin: 0;
   padding: 0;
 }
 
+.tc-tabbar {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-subtle);
+  box-shadow: var(--shadow-sm);
+}
+
+.tc-tabbar .top-nav__link {
+  border-radius: var(--radius-sm);
+}
+
 .top-nav__link {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
   color: var(--color-text-muted);
   font-size: 0.95rem;
+  transition: background var(--transition-base), color var(--transition-base);
+}
+
+.top-nav__link:hover,
+.top-nav__link:focus-visible {
+  color: var(--color-text);
+  text-decoration: none;
+  background: var(--color-surface-alt);
 }
 
 .top-nav__link.is-active {
   color: var(--color-text);
-  font-weight: 600;
+  background: var(--color-surface-alt);
+}
+
+.site-header__actions {
+  display: flex;
+  flex: 1 0 100%;
+  align-items: center;
+  gap: var(--space-3);
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.last-updated {
+  font-size: 0.75rem;
+  color: var(--color-text-soft);
 }
 
 .header-search {
-  display: flex;
-  align-items: stretch;
   position: relative;
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
 }
 
 .search-input {
   width: 100%;
-  max-width: 16rem;
-  background: var(--color-surface);
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-pill);
   border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-sm);
-  padding: var(--space-2) var(--space-3);
+  background: rgba(17, 31, 68, 0.92);
   color: var(--color-text);
 }
 
@@ -229,7 +283,7 @@ ol {
   position: absolute;
   top: calc(100% + var(--space-2));
   right: 0;
-  min-width: min(28rem, 90vw);
+  width: clamp(18rem, 32vw, 26rem);
   background: var(--color-surface);
   border: 1px solid var(--color-border-subtle);
   box-shadow: var(--shadow-sm);
@@ -242,10 +296,10 @@ ol {
 .site-shell {
   max-width: var(--max-width-wide);
   margin: 0 auto;
-  display: grid;
-  grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
-  gap: var(--space-6);
-  padding: var(--space-6) var(--space-4);
+  display: flex;
+  gap: var(--space-5);
+  padding: var(--space-6) var(--space-4) var(--space-8);
+  align-items: flex-start;
 }
 
 .sidebar {
@@ -255,11 +309,11 @@ ol {
 }
 
 .sidebar__inner {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-md);
   padding: var(--space-4);
-  box-shadow: var(--shadow-sm);
+}
+
+.sidebar__inner.tc-card {
+  border-radius: var(--radius-md);
 }
 
 .sidebar__heading {
@@ -289,11 +343,11 @@ ol {
 }
 
 .site-main {
-  background: rgba(15, 27, 60, 0.65);
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-lg);
   padding: var(--space-6);
-  box-shadow: var(--shadow-sm);
+}
+
+.site-main.tc-card {
+  border-radius: var(--radius-lg);
 }
 
 .breadcrumbs {
@@ -308,7 +362,12 @@ ol {
 .page-intro {
   display: grid;
   gap: var(--space-3);
+  padding: var(--space-6) var(--space-5);
   margin-bottom: var(--space-6);
+}
+
+.page-intro.tc-card {
+  border-radius: var(--radius-xl);
 }
 
 .page-intro__eyebrow {
@@ -327,43 +386,69 @@ ol {
 .notice {
   border-radius: var(--radius-md);
   padding: var(--space-4);
-  background: var(--color-info-soft);
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border-subtle);
   color: var(--color-text);
+  box-shadow: var(--shadow-xs);
 }
 
 @media (max-width: 1024px) {
-  .site-header__inner {
-    grid-template-columns: 1fr auto;
-  }
-
-  .top-nav {
-    display: none;
-  }
-
-  .sidebar-toggle {
-    display: inline-flex;
-  }
-
   .site-shell {
-    grid-template-columns: 1fr;
+    flex-direction: column;
+    padding-top: var(--space-5);
   }
 
   .sidebar {
     position: fixed;
-    top: var(--header-height);
-    left: 0;
-    bottom: 0;
-    width: min(80vw, 18rem);
-    transform: translateX(-120%);
-    transition: transform var(--transition-base);
+    inset: calc(var(--header-height) + var(--space-2)) var(--space-3) var(--space-3) var(--space-3);
+    transform: translateY(1rem);
+    opacity: 0;
+    pointer-events: none;
+    transition: transform var(--transition-base), opacity var(--transition-base);
     z-index: 90;
   }
 
   .sidebar.is-open {
-    transform: translateX(0);
+    transform: translateY(0);
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .site-header__actions {
+    gap: var(--space-2);
   }
 
   .site-main {
     padding: var(--space-5);
+  }
+}
+
+@media (min-width: 960px) {
+  .site-header__inner {
+    flex-wrap: nowrap;
+  }
+
+  .sidebar-toggle {
+    display: none;
+  }
+
+  .top-nav {
+    display: flex;
+    margin-left: var(--space-3);
+  }
+
+  .site-header__actions {
+    flex: 0 0 auto;
+    justify-content: flex-end;
+    gap: var(--space-4);
+    margin-left: auto;
+  }
+
+  .last-updated {
+    font-size: 0.8rem;
+  }
+
+  .header-search {
+    max-width: 24rem;
   }
 }

--- a/styles/site.css
+++ b/styles/site.css
@@ -16,10 +16,8 @@ body {
   line-height: var(--line-height-base);
   color: var(--color-text);
   background:
-    radial-gradient(1200px 520px at -10% -15%, rgba(78, 163, 255, 0.28), transparent 70%),
-    radial-gradient(900px 720px at 120% -15%, rgba(45, 212, 191, 0.14), transparent 65%),
-    radial-gradient(640px 840px at 40% 120%, rgba(168, 85, 247, 0.18), transparent 70%),
-    linear-gradient(180deg, var(--color-bg) 0%, #091431 42%, #0c1f45 78%, #0f2a58 100%);
+    radial-gradient(1200px 800px at 10% -10%, rgba(69, 188, 241, 0.15), transparent 65%),
+    linear-gradient(180deg, #10255e 0%, var(--color-bg) 60%);
   min-height: 100vh;
 }
 
@@ -28,7 +26,7 @@ main {
 }
 
 a {
-  color: var(--color-primary);
+  color: var(--color-secondary);
   text-decoration: none;
   transition: color var(--transition-base);
 }
@@ -94,9 +92,9 @@ pre {
 }
 
 pre {
-  background: var(--color-surface-soft);
+  background: var(--color-surface);
   border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-md);
   padding: var(--space-4);
   overflow-x: auto;
   color: var(--color-text);
@@ -109,7 +107,7 @@ pre {
   left: var(--space-3);
   padding: var(--space-2) var(--space-3);
   background: var(--color-primary);
-  color: var(--color-text-inverse);
+  color: #fff;
   border-radius: var(--radius-sm);
   z-index: 200;
   transition: top var(--transition-base);
@@ -139,9 +137,9 @@ pre {
   position: sticky;
   top: 0;
   z-index: 120;
-  background: rgba(8, 17, 44, 0.9);
+  background: rgba(14, 27, 63, 0.88);
   backdrop-filter: blur(18px);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  border-bottom: 1px solid var(--color-border-subtle);
   box-shadow: var(--shadow-sm);
 }
 
@@ -149,8 +147,8 @@ pre {
   max-width: var(--max-width-wide);
   margin: 0 auto;
   padding: var(--space-2) var(--space-4);
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: var(--space-3);
 }
@@ -159,8 +157,10 @@ pre {
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
-  padding: var(--space-2);
+  padding: var(--space-1) var(--space-2);
   border-radius: var(--radius-sm);
+  color: var(--color-text);
+  font-weight: 600;
   transition: background var(--transition-base), transform var(--transition-base);
 }
 
@@ -173,13 +173,14 @@ pre {
 .site-logo span {
   font-size: 1.05rem;
   font-weight: 600;
-  color: var(--color-text);
+  color: inherit;
 }
 
 .site-logo:focus-visible,
 .site-logo:hover {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--color-surface-alt);
   transform: translateY(-1px);
+  text-decoration: none;
 }
 
 .sidebar-toggle {
@@ -187,8 +188,8 @@ pre {
   align-items: center;
   gap: var(--space-2);
   border-radius: var(--radius-pill);
-  border: 1px solid var(--color-border);
-  background: rgba(15, 28, 58, 0.85);
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-surface-alt);
   color: var(--color-text);
   padding: var(--space-2) var(--space-3);
   font-size: 0.95rem;
@@ -199,7 +200,7 @@ pre {
 
 .sidebar-toggle:hover,
 .sidebar-toggle:focus-visible {
-  background: rgba(30, 50, 100, 0.95);
+  background: var(--color-surface);
   transform: translateY(-1px);
 }
 
@@ -207,56 +208,79 @@ pre {
   display: none;
   align-items: center;
   justify-content: center;
+  flex: 1 1 auto;
 }
 
 .top-nav__list {
   list-style: none;
-  display: flex;
+  display: inline-flex;
   flex-wrap: wrap;
-  gap: var(--space-3);
+  gap: var(--space-2);
   margin: 0;
   padding: 0;
+}
+
+.tc-tabbar {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  padding: var(--space-1);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-subtle);
+  box-shadow: var(--shadow-sm);
 }
 
 .top-nav__link {
   display: inline-flex;
   align-items: center;
   padding: var(--space-2) var(--space-3);
-  border-radius: var(--radius-pill);
+  border-radius: var(--radius-sm);
   font-size: 0.95rem;
   font-weight: 500;
   color: var(--color-text-muted);
-  border: 1px solid transparent;
-  transition: background var(--transition-base), color var(--transition-base), border-color var(--transition-base);
+  transition: background var(--transition-base), color var(--transition-base);
 }
 
 .top-nav__link:hover,
 .top-nav__link:focus-visible {
   color: var(--color-text);
-  border-color: rgba(255, 255, 255, 0.16);
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--color-surface-alt);
   text-decoration: none;
 }
 
 .top-nav__link.is-active {
   color: var(--color-text);
-  border-color: rgba(255, 255, 255, 0.26);
-  background: rgba(255, 255, 255, 0.12);
+  background: var(--color-surface-alt);
+}
+
+.site-header__actions {
+  display: flex;
+  flex: 1 0 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.last-updated {
+  font-size: 0.75rem;
+  color: var(--color-text-soft);
 }
 
 .header-search {
   position: relative;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  flex: 1 1 auto;
 }
 
 .search-input {
-  width: min(100%, 22rem);
+  width: 100%;
   padding: var(--space-2) var(--space-4);
   border-radius: var(--radius-pill);
-  border: 1px solid var(--color-border);
-  background: rgba(10, 21, 45, 0.92);
+  border: 1px solid var(--color-border-subtle);
+  background: rgba(17, 31, 68, 0.92);
   color: var(--color-text);
   font-size: 0.95rem;
   transition: border-color var(--transition-base), background var(--transition-base);
@@ -270,7 +294,7 @@ pre {
   outline: none;
   border-color: var(--color-primary);
   box-shadow: 0 0 0 3px var(--color-primary-soft);
-  background: rgba(12, 28, 64, 0.98);
+  background: rgba(24, 42, 88, 0.98);
 }
 
 .search-panel {
@@ -280,10 +304,10 @@ pre {
   width: clamp(18rem, 32vw, 26rem);
   max-height: 26rem;
   overflow-y: auto;
-  background: var(--color-surface-alt);
-  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-subtle);
   border-radius: var(--radius-md);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--shadow-sm);
   padding: var(--space-2);
   display: none;
   z-index: 140;
@@ -319,7 +343,7 @@ pre {
 }
 
 .search-result mark {
-  background: rgba(78, 163, 255, 0.35);
+  background: rgba(69, 188, 241, 0.25);
   color: var(--color-text);
   border-radius: var(--radius-xs);
   padding: 0 var(--space-1);
@@ -328,8 +352,8 @@ pre {
 .search-result:hover,
 .search-result:focus-visible {
   text-decoration: none;
-  background: rgba(255, 255, 255, 0.06);
-  border-color: rgba(255, 255, 255, 0.08);
+  background: var(--color-surface-alt);
+  border-color: var(--color-border-subtle);
   color: var(--color-text);
 }
 
@@ -340,6 +364,7 @@ pre {
   max-width: var(--max-width-wide);
   margin: 0 auto;
   padding: var(--space-6) var(--space-4) var(--space-8);
+  align-items: flex-start;
 }
 
 .sidebar {
@@ -352,11 +377,11 @@ pre {
   top: calc(var(--header-height) + var(--space-4));
   max-height: calc(100vh - var(--header-height) - var(--space-6));
   overflow-y: auto;
-  background: rgba(10, 20, 44, 0.82);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
   padding: var(--space-4);
-  box-shadow: var(--shadow-sm);
+}
+
+.sidebar__inner.tc-card {
+  border-radius: var(--radius-lg);
 }
 
 .sidebar__heading {
@@ -392,21 +417,21 @@ pre {
 .sidebar__link:hover,
 .sidebar__link:focus-visible {
   color: var(--color-text);
-  border-color: rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.06);
+  border-color: var(--color-border-subtle);
+  background: var(--color-surface-alt);
   text-decoration: none;
 }
 
 .sidebar__link.is-active {
   color: var(--color-text);
-  border-color: rgba(255, 255, 255, 0.18);
-  background: rgba(255, 255, 255, 0.1);
+  border-color: var(--color-border);
+  background: var(--color-surface-alt);
 }
 
 .sidebar__sublist {
   margin-top: var(--space-2);
   padding-left: var(--space-3);
-  border-left: 2px solid rgba(255, 255, 255, 0.08);
+  border-left: 2px solid var(--color-border-subtle);
 }
 
 .sidebar__subitem + .sidebar__subitem {
@@ -425,7 +450,7 @@ pre {
 .sidebar__sublink:hover,
 .sidebar__sublink:focus-visible {
   color: var(--color-text);
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--color-surface-alt);
   text-decoration: none;
 }
 
@@ -453,19 +478,19 @@ pre {
 }
 
 .page-intro {
-  background: rgba(10, 20, 44, 0.72);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-xl);
   padding: var(--space-6) var(--space-5);
-  box-shadow: var(--shadow-md);
   margin-bottom: var(--space-6);
+}
+
+.page-intro.tc-card {
+  border-radius: var(--radius-xl);
 }
 
 .page-intro__eyebrow {
   font-size: 0.75rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: var(--color-text-soft);
+  color: var(--color-secondary);
   margin-bottom: var(--space-3);
 }
 
@@ -497,15 +522,35 @@ pre {
 
   .top-nav {
     display: flex;
+    margin-left: var(--space-3);
   }
 
   .sidebar-toggle {
     display: none;
   }
+
+  .site-header__inner {
+    flex-wrap: nowrap;
+  }
+
+  .site-header__actions {
+    flex: 0 0 auto;
+    justify-content: flex-end;
+    gap: var(--space-4);
+    margin-left: auto;
+  }
+
+  .last-updated {
+    font-size: 0.8rem;
+  }
+
+  .header-search {
+    max-width: 24rem;
+  }
 }
 
 .card {
-  background: rgba(10, 21, 45, 0.72);
+  background: var(--color-surface);
   border: 1px solid var(--color-border-subtle);
   border-radius: var(--radius-lg);
   padding: var(--space-4);
@@ -521,7 +566,7 @@ pre {
 .card--link:hover,
 .card--link:focus-visible {
   transform: translateY(-4px);
-  border-color: rgba(255, 255, 255, 0.16);
+  border-color: var(--color-border);
   box-shadow: var(--shadow-md);
   text-decoration: none;
 }
@@ -548,8 +593,9 @@ pre {
 .getting-started {
   border-radius: var(--radius-lg);
   border: 1px solid var(--color-border-subtle);
-  background: rgba(10, 21, 45, 0.72);
+  background: var(--color-surface);
   box-shadow: var(--shadow-xs);
+  backdrop-filter: blur(24px);
 }
 
 .getting-started__toggle {
@@ -585,6 +631,7 @@ pre {
   background: var(--color-primary-soft);
   position: relative;
   transition: background var(--transition-base);
+  box-shadow: inset 0 0 0 1px var(--color-border-subtle);
 }
 
 .getting-started__toggle-icon::before,
@@ -606,7 +653,7 @@ pre {
 }
 
 .getting-started.is-open .getting-started__toggle-icon {
-  background: rgba(78, 163, 255, 0.32);
+  background: rgba(64, 102, 222, 0.32);
 }
 
 .getting-started.is-open .getting-started__toggle-icon::after {
@@ -630,6 +677,10 @@ pre {
 .getting-started-card {
   display: flex;
   flex-direction: column;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-xs);
   transition: transform var(--transition-base), box-shadow var(--transition-base), border-color var(--transition-base);
 }
 
@@ -637,7 +688,7 @@ pre {
 .getting-started-card:focus-within,
 .getting-started-card.is-open {
   transform: translateY(-4px);
-  border-color: rgba(255, 255, 255, 0.16);
+  border-color: var(--color-border);
   box-shadow: var(--shadow-md);
 }
 
@@ -726,13 +777,13 @@ pre {
   border-radius: var(--radius-lg);
   padding: var(--space-4);
   border: 1px solid var(--color-border-subtle);
-  background: rgba(12, 28, 64, 0.72);
+  background: var(--color-surface);
   box-shadow: var(--shadow-xs);
   margin-bottom: var(--space-4);
 }
 
 .notice--info {
-  border-color: rgba(78, 163, 255, 0.45);
+  border-color: rgba(64, 102, 222, 0.35);
   background: var(--color-info-soft);
 }
 
@@ -756,8 +807,8 @@ pre {
   border-radius: var(--radius-pill);
   padding: var(--space-1) var(--space-3);
   font-size: 0.85rem;
-  border: 1px solid transparent;
-  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-surface);
   color: var(--color-text-muted);
   transition: background var(--transition-base), border-color var(--transition-base), color var(--transition-base);
 }
@@ -765,13 +816,13 @@ pre {
 .tag-pill:hover,
 .tag-pill:focus-visible {
   text-decoration: none;
-  background: rgba(255, 255, 255, 0.12);
+  background: var(--color-surface-alt);
   color: var(--color-text);
 }
 
 .tag-pill.is-active {
-  background: rgba(78, 163, 255, 0.18);
-  border-color: rgba(78, 163, 255, 0.4);
+  background: var(--color-surface-alt);
+  border-color: var(--color-border);
   color: var(--color-text);
 }
 
@@ -799,8 +850,8 @@ pre {
   width: 100%;
   padding: var(--space-2) var(--space-4);
   border-radius: var(--radius-pill);
-  border: 1px solid var(--color-border);
-  background: rgba(10, 21, 45, 0.76);
+  border: 1px solid var(--color-border-subtle);
+  background: rgba(17, 31, 68, 0.88);
   color: var(--color-text);
 }
 
@@ -816,9 +867,9 @@ pre {
 }
 
 .accordion {
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--color-border-subtle);
   border-radius: var(--radius-lg);
-  background: rgba(10, 21, 45, 0.72);
+  background: var(--color-surface);
   box-shadow: var(--shadow-xs);
 }
 
@@ -839,7 +890,7 @@ pre {
 
 .accordion__summary:hover,
 .accordion__summary:focus-visible {
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--color-surface-alt);
 }
 
 .accordion__icon {
@@ -850,7 +901,8 @@ pre {
   width: 1.75rem;
   height: 1.75rem;
   border-radius: 50%;
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-surface);
   font-size: 0.9rem;
   transition: transform var(--transition-base);
 }
@@ -946,8 +998,8 @@ pre {
 .source-box {
   margin-top: var(--space-6);
   border-radius: var(--radius-lg);
-  border: 1px solid rgba(78, 163, 255, 0.35);
-  background: rgba(78, 163, 255, 0.12);
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-surface);
   padding: var(--space-4);
   box-shadow: var(--shadow-xs);
 }
@@ -980,9 +1032,9 @@ pre {
   gap: var(--space-1);
   padding: var(--space-1) var(--space-3);
   border-radius: var(--radius-pill);
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  background: rgba(10, 20, 44, 0.65);
-  color: var(--color-text);
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-surface);
+  color: var(--color-text-muted);
   font-size: 0.88rem;
   transition: background var(--transition-base), border-color var(--transition-base);
 }
@@ -990,8 +1042,9 @@ pre {
 .source-box__link:hover,
 .source-box__link:focus-visible {
   text-decoration: none;
-  background: rgba(255, 255, 255, 0.16);
-  border-color: rgba(255, 255, 255, 0.28);
+  background: var(--color-surface-alt);
+  border-color: var(--color-border);
+  color: var(--color-text);
 }
 
 .results-list {
@@ -1015,15 +1068,15 @@ pre {
 .results-list__link:hover,
 .results-list__link:focus-visible {
   text-decoration: none;
-  border-color: rgba(255, 255, 255, 0.14);
-  background: rgba(255, 255, 255, 0.06);
+  border-color: var(--color-border-subtle);
+  background: var(--color-surface-alt);
   color: var(--color-text);
 }
 
 .context-box {
   border-radius: var(--radius-lg);
-  border: 1px dashed rgba(78, 163, 255, 0.45);
-  background: rgba(78, 163, 255, 0.1);
+  border: 1px dashed rgba(69, 188, 241, 0.45);
+  background: rgba(69, 188, 241, 0.12);
   padding: var(--space-4);
   margin-bottom: var(--space-4);
 }
@@ -1118,8 +1171,9 @@ pre {
   width: 100%;
   overflow-x: auto;
   border-radius: var(--radius-lg);
-  border: 1px solid var(--color-border);
-  background: rgba(10, 21, 45, 0.72);
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-xs);
 }
 
 table {
@@ -1133,7 +1187,7 @@ td {
   padding: var(--space-3);
   text-align: left;
   font-size: 0.95rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid var(--color-border-subtle);
   color: var(--color-text-muted);
 }
 
@@ -1142,7 +1196,7 @@ th {
   text-transform: uppercase;
   letter-spacing: 0.14em;
   color: var(--color-text);
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--color-surface-alt);
 }
 
 tr:last-child td {
@@ -1202,7 +1256,7 @@ tr:last-child td {
   position: relative;
   height: 0.4rem;
   border-radius: var(--radius-pill);
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--color-surface-alt);
   overflow: hidden;
   opacity: 0;
   transition: opacity 0.6s var(--transition-smooth);
@@ -1220,7 +1274,7 @@ tr:last-child td {
   position: absolute;
   inset: 0;
   width: 0%;
-  background: linear-gradient(90deg, rgba(45, 212, 191, 0.7), rgba(78, 163, 255, 0.85));
+  background: linear-gradient(90deg, rgba(69, 188, 241, 0.7), rgba(64, 102, 222, 0.85));
   border-radius: inherit;
   transform-origin: left center;
 }
@@ -1257,7 +1311,7 @@ tr:last-child td {
   display: block;
   height: 0.75rem;
   border-radius: var(--radius-pill);
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--color-surface-alt);
   position: relative;
   overflow: hidden;
 }
@@ -1270,7 +1324,7 @@ tr:last-child td {
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.25), transparent);
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.22), transparent);
   transform: translateX(-100%);
   animation: skeletonSweep 1.8s ease-in-out infinite;
 }
@@ -1320,47 +1374,47 @@ tr:last-child td {
 }
 
 .status-chip,
-.chip {
+.tc-chip {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: var(--space-1);
-  padding: var(--space-1) var(--space-3);
-  border-radius: var(--radius-pill);
-  font-size: 0.8rem;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.85rem;
   font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  text-transform: none;
   color: var(--color-text);
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-subtle);
+  box-shadow: var(--shadow-xs);
   transition: background var(--transition-base), color var(--transition-base), border-color var(--transition-base),
     box-shadow var(--transition-base);
 }
 
 .chip--active,
-.chip-active {
-  background: linear-gradient(135deg, rgba(45, 212, 191, 0.28), rgba(78, 163, 255, 0.24));
-  border-color: rgba(45, 212, 191, 0.38);
-  color: #d9fff8;
-  box-shadow: inset 0 1px 0 rgba(45, 212, 191, 0.26);
+.chip-active,
+.tc-chip.is-active {
+  background: rgba(69, 188, 241, 0.18);
+  border-color: rgba(69, 188, 241, 0.4);
+  color: var(--color-text);
 }
 
 .chip--archived,
-.chip-archived {
-  background: linear-gradient(135deg, rgba(78, 163, 255, 0.28), rgba(31, 109, 255, 0.34));
-  border-color: rgba(78, 163, 255, 0.45);
-  color: rgba(224, 238, 255, 0.94);
-  box-shadow: inset 0 1px 0 rgba(78, 163, 255, 0.24);
+.chip-archived,
+.tc-chip.is-archived {
+  background: rgba(64, 102, 222, 0.2);
+  border-color: rgba(64, 102, 222, 0.45);
+  color: var(--color-text);
 }
 
 .chip--deprecated,
-.chip-deprecated {
-  background: linear-gradient(135deg, rgba(250, 204, 21, 0.32), rgba(168, 85, 247, 0.2));
-  border-color: rgba(250, 204, 21, 0.38);
-  color: #fff9cc;
-  box-shadow: inset 0 1px 0 rgba(250, 204, 21, 0.28);
+.chip-deprecated,
+.tc-chip.is-deprecated {
+  background: rgba(250, 204, 21, 0.2);
+  border-color: rgba(250, 204, 21, 0.45);
+  color: var(--color-warning);
 }
 
 .btn,
@@ -1371,7 +1425,7 @@ tr:last-child td {
   justify-content: center;
   gap: var(--space-2);
   padding: var(--space-2) var(--space-4);
-  border-radius: var(--radius-pill);
+  border-radius: var(--radius-sm);
   border: 1px solid transparent;
   font-size: 0.95rem;
   font-weight: 600;
@@ -1381,26 +1435,28 @@ tr:last-child td {
 
 .btn-primary {
   background: var(--color-primary);
-  color: var(--color-text-inverse);
+  color: #fff;
   box-shadow: var(--shadow-sm);
 }
 
 .btn-primary:hover,
 .btn-primary:focus-visible {
   transform: translateY(-1px);
+  background: var(--color-primary-strong);
   box-shadow: var(--shadow-md);
 }
 
 .btn-secondary {
-  background: transparent;
-  border-color: rgba(255, 255, 255, 0.24);
+  background: var(--color-surface);
+  border-color: var(--color-border-subtle);
   color: var(--color-text);
 }
 
 .btn-secondary:hover,
 .btn-secondary:focus-visible {
   transform: translateY(-1px);
-  border-color: rgba(255, 255, 255, 0.42);
+  border-color: var(--color-border);
+  background: var(--color-surface-alt);
   box-shadow: var(--shadow-xs);
 }
 
@@ -1418,8 +1474,8 @@ tr:last-child td {
 
 .footer {
   margin-top: auto;
-  background: rgba(6, 15, 36, 0.95);
-  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(14, 27, 63, 0.92);
+  border-top: 1px solid var(--color-border-subtle);
 }
 
 .footer__inner {
@@ -1462,7 +1518,7 @@ tr:last-child td {
 .footer__note {
   font-size: 0.85rem;
   color: var(--color-text-soft);
-  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  border-top: 1px solid var(--color-border-subtle);
   padding-top: var(--space-4);
 }
 
@@ -1471,15 +1527,6 @@ tr:last-child td {
 }
 
 @media (max-width: 959px) {
-  .site-header__inner {
-    grid-template-columns: auto 1fr auto;
-    align-items: stretch;
-  }
-
-  .header-search {
-    grid-column: 1 / -1;
-  }
-
   .site-shell {
     flex-direction: column;
     padding-top: var(--space-5);
@@ -1543,8 +1590,8 @@ tr:last-child td {
   text-align: center;
   color: var(--color-text-soft);
   border-radius: var(--radius-lg);
-  border: 1px dashed rgba(255, 255, 255, 0.18);
-  background: rgba(255, 255, 255, 0.04);
+  border: 1px dashed rgba(69, 188, 241, 0.4);
+  background: rgba(69, 188, 241, 0.12);
 }
 
 .anchor-offset {
@@ -1552,7 +1599,7 @@ tr:last-child td {
 }
 
 mark {
-  background: rgba(78, 163, 255, 0.3);
+  background: rgba(69, 188, 241, 0.3);
   color: inherit;
   border-radius: var(--radius-xs);
   padding: 0 var(--space-1);

--- a/styles/variables.css
+++ b/styles/variables.css
@@ -4,26 +4,26 @@
   --font-family-mono: "JetBrains Mono", "SFMono-Regular", Menlo, Consolas, monospace;
   --line-height-base: 1.6;
 
-  --color-bg: #050a1b;
-  --color-surface: #0e1934;
-  --color-surface-alt: #162449;
-  --color-surface-soft: #1f2f57;
-  --color-border: rgba(92, 130, 200, 0.45);
-  --color-border-subtle: rgba(92, 130, 200, 0.2);
-  --color-text: #f4f7ff;
-  --color-text-muted: rgba(244, 247, 255, 0.7);
-  --color-text-soft: rgba(244, 247, 255, 0.55);
-  --color-text-inverse: #07132b;
+  --color-bg: var(--tc-bg);
+  --color-surface: var(--tc-surface);
+  --color-surface-alt: var(--tc-surface-2);
+  --color-surface-soft: rgba(255, 255, 255, 0.12);
+  --color-border: var(--tc-border-strong);
+  --color-border-subtle: var(--tc-border);
+  --color-text: var(--tc-ink);
+  --color-text-muted: var(--tc-ink-muted);
+  --color-text-soft: var(--tc-ink-subtle);
+  --color-text-inverse: #050f2d;
 
-  --color-primary: #4ea3ff;
-  --color-primary-strong: #1f6dff;
-  --color-primary-soft: rgba(78, 163, 255, 0.16);
-  --color-secondary: #2dd4bf;
-  --color-secondary-soft: rgba(45, 212, 191, 0.16);
-  --color-highlight: #a855f7;
+  --color-primary: var(--tc-primary);
+  --color-primary-strong: var(--tc-primary-700);
+  --color-primary-soft: rgba(64, 102, 222, 0.22);
+  --color-secondary: var(--tc-accent);
+  --color-secondary-soft: rgba(69, 188, 241, 0.18);
+  --color-highlight: var(--tc-primary-300);
   --color-warning: #facc15;
   --color-warning-soft: rgba(250, 204, 21, 0.16);
-  --color-info-soft: rgba(78, 163, 255, 0.12);
+  --color-info-soft: rgba(69, 188, 241, 0.18);
 
   --space-0: 0rem;
   --space-1: 0.25rem;
@@ -36,17 +36,17 @@
   --space-8: 3rem;
   --space-9: 4rem;
 
-  --radius-xs: 0.375rem;
-  --radius-sm: 0.75rem;
-  --radius-md: 1rem;
-  --radius-lg: 1.5rem;
-  --radius-xl: 2rem;
+  --radius-xs: 0.5rem;
+  --radius-sm: var(--tc-radius);
+  --radius-md: var(--tc-radius-lg);
+  --radius-lg: 1.75rem;
+  --radius-xl: 2.25rem;
   --radius-pill: 999px;
 
-  --shadow-xs: 0 1px 2px rgba(5, 13, 33, 0.4);
-  --shadow-sm: 0 4px 16px rgba(7, 17, 40, 0.4);
-  --shadow-md: 0 16px 40px rgba(5, 20, 50, 0.45);
-  --shadow-lg: 0 28px 60px rgba(2, 10, 30, 0.55);
+  --shadow-xs: 0 4px 12px rgba(5, 8, 20, 0.35);
+  --shadow-sm: var(--tc-shadow);
+  --shadow-md: 0 14px 40px rgba(5, 8, 20, 0.38);
+  --shadow-lg: 0 30px 70px rgba(5, 8, 20, 0.45);
 
   --max-width-content: 72rem;
   --max-width-wide: 90rem;

--- a/tel-token.html
+++ b/tel-token.html
@@ -21,9 +21,21 @@
   <meta name="twitter:description" content="Understand how TEL powers the Telcoin Network, TELx liquidity, and governance incentives with references to official Association resources.">
   <meta name="twitter:image" content="https://telcoinwiki.com/assets/Telcoinwiki.png">
   <meta name="twitter:site" content="@telcoin">
-  <link rel="icon" type="image/svg+xml" href="/logo.svg">
+  <link rel="stylesheet" href="/src/styles/tokens.css">
   <link rel="preload" href="/dist/styles.css" as="style">
   <link rel="stylesheet" href="/dist/styles.css">
+  <link id="app-favicon" rel="icon" href="https://telcoin.org/favicon.ico" />
+  <script>
+    (function () {
+      var link = document.getElementById('app-favicon');
+      if (!link) return;
+      var img = new Image();
+      img.onerror = function () {
+        link.href = 'https://telcoin.network/favicon.ico';
+      };
+      img.src = link.href + '?v=1';
+    })();
+  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -45,13 +57,13 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
   <header class="site-header" data-header>
     <div class="site-header__inner">
-      <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
+      <a class="site-logo" data-home-link href="/index.html" aria-label="Telcoin Wiki home">
         <img src="/logo.svg" alt="Telcoin Wiki" width="40" height="40" fetchpriority="high">
         <span>Telcoin Wiki</span>
       </a>
       <button type="button" class="sidebar-toggle" data-sidebar-toggle aria-expanded="false" aria-controls="site-sidebar">Menu</button>
       <nav class="top-nav" aria-label="Primary">
-        <ul class="top-nav__list" data-nav>
+        <ul class="top-nav__list tc-tabbar" data-nav>
           <li><a class="top-nav__link" href="/start-here.html">Start Here</a></li>
           <li><a class="top-nav__link" href="/faq/">FAQ</a></li>
           <li><a class="top-nav__link" href="/wallet.html">Wallet</a></li>
@@ -65,17 +77,20 @@
           <li><a class="top-nav__link" href="/links.html">Links</a></li>
         </ul>
       </nav>
-      <div class="header-search" role="search">
-        <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
-        <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
-        <div class="search-panel" data-search-results hidden aria-label="Search suggestions"></div>
+      <div class="site-header__actions">
+        <div class="last-updated" data-last-updated></div>
+        <div class="header-search" role="search">
+          <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
+          <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
+          <div class="search-panel tc-card" data-search-results hidden aria-label="Search suggestions"></div>
+        </div>
       </div>
     </div>
   </header>
   <div class="sidebar-overlay" data-sidebar-overlay></div>
   <div class="site-shell">
     <aside id="site-sidebar" class="sidebar" data-sidebar>
-      <div class="sidebar__inner">
+      <div class="sidebar__inner tc-card">
         <p class="sidebar__heading">Knowledge base</p>
         <nav class="sidebar__nav" aria-label="Knowledge base">
           <ul class="sidebar__list" data-sidebar-list>
@@ -122,10 +137,10 @@
         </nav>
       </div>
     </aside>
-    <main id="main-content" class="site-main" tabindex="-1">
+    <main id="main-content" class="site-main tc-card" tabindex="-1">
       <nav class="breadcrumbs" aria-label="Breadcrumb" data-breadcrumbs></nav>
 
-      <section id="tel-overview" class="page-intro anchor-offset">
+      <section id="tel-overview" class="page-intro anchor-offset tc-card">
         <p class="page-intro__eyebrow">TEL Token</p>
         <h1 class="page-intro__title">Fuel for Telcoin services and governance</h1>
         <p class="page-intro__lede">TEL is the native asset of the Telcoin Network. It pays for transactions, aligns validators and liquidity providers, and anchors governance programs stewarded by the Telcoin Association.</p>

--- a/telx.html
+++ b/telx.html
@@ -21,9 +21,21 @@
   <meta name="twitter:description" content="Learn how TELx orchestrates design, liquidity mining, and user ownership within the Telcoin ecosystem with official resource links.">
   <meta name="twitter:image" content="https://telcoinwiki.com/assets/Telcoinwiki.png">
   <meta name="twitter:site" content="@telcoin">
-  <link rel="icon" type="image/svg+xml" href="/logo.svg">
+  <link rel="stylesheet" href="/src/styles/tokens.css">
   <link rel="preload" href="/dist/styles.css" as="style">
   <link rel="stylesheet" href="/dist/styles.css">
+  <link id="app-favicon" rel="icon" href="https://telcoin.org/favicon.ico" />
+  <script>
+    (function () {
+      var link = document.getElementById('app-favicon');
+      if (!link) return;
+      var img = new Image();
+      img.onerror = function () {
+        link.href = 'https://telcoin.network/favicon.ico';
+      };
+      img.src = link.href + '?v=1';
+    })();
+  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -45,13 +57,13 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
   <header class="site-header" data-header>
     <div class="site-header__inner">
-      <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
+      <a class="site-logo" data-home-link href="/index.html" aria-label="Telcoin Wiki home">
         <img src="/logo.svg" alt="Telcoin Wiki" width="40" height="40" fetchpriority="high">
         <span>Telcoin Wiki</span>
       </a>
       <button type="button" class="sidebar-toggle" data-sidebar-toggle aria-expanded="false" aria-controls="site-sidebar">Menu</button>
       <nav class="top-nav" aria-label="Primary">
-        <ul class="top-nav__list" data-nav>
+        <ul class="top-nav__list tc-tabbar" data-nav>
           <li><a class="top-nav__link" href="/start-here.html">Start Here</a></li>
           <li><a class="top-nav__link" href="/faq/">FAQ</a></li>
           <li><a class="top-nav__link" href="/wallet.html">Wallet</a></li>
@@ -65,17 +77,20 @@
           <li><a class="top-nav__link" href="/links.html">Links</a></li>
         </ul>
       </nav>
-      <div class="header-search" role="search">
-        <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
-        <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
-        <div class="search-panel" data-search-results hidden aria-label="Search suggestions"></div>
+      <div class="site-header__actions">
+        <div class="last-updated" data-last-updated></div>
+        <div class="header-search" role="search">
+          <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
+          <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
+          <div class="search-panel tc-card" data-search-results hidden aria-label="Search suggestions"></div>
+        </div>
       </div>
     </div>
   </header>
   <div class="sidebar-overlay" data-sidebar-overlay></div>
   <div class="site-shell">
     <aside id="site-sidebar" class="sidebar" data-sidebar>
-      <div class="sidebar__inner">
+      <div class="sidebar__inner tc-card">
         <p class="sidebar__heading">Knowledge base</p>
         <nav class="sidebar__nav" aria-label="Knowledge base">
           <ul class="sidebar__list" data-sidebar-list>
@@ -122,10 +137,10 @@
         </nav>
       </div>
     </aside>
-    <main id="main-content" class="site-main" tabindex="-1">
+    <main id="main-content" class="site-main tc-card" tabindex="-1">
       <nav class="breadcrumbs" aria-label="Breadcrumb" data-breadcrumbs></nav>
 
-      <section id="telx-overview" class="page-intro anchor-offset">
+      <section id="telx-overview" class="page-intro anchor-offset tc-card">
         <p class="page-intro__eyebrow">TELx</p>
         <h1 class="page-intro__title">The decentralized liquidity engine of the Telcoin Platform</h1>
         <p class="page-intro__lede">TELx orchestrates user-owned liquidity across Telcoin’s regulated DeFi stack. Designers, liquidity miners, and everyday users co-create a compliant, mobile-first financial network.</p>

--- a/wallet.html
+++ b/wallet.html
@@ -21,9 +21,21 @@
   <meta name="twitter:description" content="Learn what the Telcoin Wallet can do, how verification works, and where to find official support for remittances, Digital Cash, and TEL swaps.">
   <meta name="twitter:image" content="https://telcoinwiki.com/assets/Telcoinwiki.png">
   <meta name="twitter:site" content="@telcoin">
-  <link rel="icon" type="image/svg+xml" href="/logo.svg">
+  <link rel="stylesheet" href="/src/styles/tokens.css">
   <link rel="preload" href="/dist/styles.css" as="style">
   <link rel="stylesheet" href="/dist/styles.css">
+  <link id="app-favicon" rel="icon" href="https://telcoin.org/favicon.ico" />
+  <script>
+    (function () {
+      var link = document.getElementById('app-favicon');
+      if (!link) return;
+      var img = new Image();
+      img.onerror = function () {
+        link.href = 'https://telcoin.network/favicon.ico';
+      };
+      img.src = link.href + '?v=1';
+    })();
+  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -46,13 +58,13 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
   <header class="site-header" data-header>
     <div class="site-header__inner">
-      <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
+      <a class="site-logo" data-home-link href="/index.html" aria-label="Telcoin Wiki home">
         <img src="/logo.svg" alt="Telcoin Wiki" width="40" height="40" fetchpriority="high">
         <span>Telcoin Wiki</span>
       </a>
       <button type="button" class="sidebar-toggle" data-sidebar-toggle aria-expanded="false" aria-controls="site-sidebar">Menu</button>
       <nav class="top-nav" aria-label="Primary">
-        <ul class="top-nav__list" data-nav>
+        <ul class="top-nav__list tc-tabbar" data-nav>
           <li><a class="top-nav__link" href="/start-here.html">Start Here</a></li>
           <li><a class="top-nav__link" href="/faq/">FAQ</a></li>
           <li><a class="top-nav__link is-active" href="/wallet.html" aria-current="page">Wallet</a></li>
@@ -66,17 +78,20 @@
           <li><a class="top-nav__link" href="/links.html">Links</a></li>
         </ul>
       </nav>
-      <div class="header-search" role="search">
-        <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
-        <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
-        <div class="search-panel" data-search-results hidden aria-label="Search suggestions"></div>
+      <div class="site-header__actions">
+        <div class="last-updated" data-last-updated></div>
+        <div class="header-search" role="search">
+          <label class="sr-only" for="site-search">Search Telcoin Wiki</label>
+          <input id="site-search" class="search-input" type="search" name="q" placeholder="Search Telcoin Wiki" autocomplete="off" data-site-search>
+          <div class="search-panel tc-card" data-search-results hidden aria-label="Search suggestions"></div>
+        </div>
       </div>
     </div>
   </header>
   <div class="sidebar-overlay" data-sidebar-overlay></div>
   <div class="site-shell">
     <aside id="site-sidebar" class="sidebar" data-sidebar>
-      <div class="sidebar__inner">
+      <div class="sidebar__inner tc-card">
         <p class="sidebar__heading">Knowledge base</p>
         <nav class="sidebar__nav" aria-label="Knowledge base">
           <ul class="sidebar__list" data-sidebar-list>
@@ -123,10 +138,10 @@
         </nav>
       </div>
     </aside>
-    <main id="main-content" class="site-main" tabindex="-1">
+    <main id="main-content" class="site-main tc-card" tabindex="-1">
       <nav class="breadcrumbs" aria-label="Breadcrumb" data-breadcrumbs></nav>
 
-      <section id="wallet-overview" class="page-intro anchor-offset">
+      <section id="wallet-overview" class="page-intro anchor-offset tc-card">
         <p class="page-intro__eyebrow">Telcoin Wallet</p>
         <h1 class="page-intro__title">Mobile-first access to Telcoin services</h1>
         <p class="page-intro__lede">The Telcoin Wallet is the official gateway for remittances, Digital Cash, TEL swaps, and staking. Verification keeps the experience compliant while letting you manage funds directly from your device.</p>


### PR DESCRIPTION
## Summary
- wrap primary navigation shells, search panels, and hero intros with shared `tc-card`/`tc-tabbar` utilities to mirror roadmap surfaces
- update token definitions and CSS so tables, code blocks, and status chips share the roadmap palette and radii across pages
- sync chip markup and pools logic to the new `tc-chip` status variants for consistent badges sitewide

## Testing
- npm run build *(fails: package.json is invalid JSON in this repository)*

------
https://chatgpt.com/codex/tasks/task_e_68dd66677380833097d2d9bb51e64a28