### PR TITLE
Fix Netlify build configuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+fund=false
+audit=false
+progress=false

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  publish = "."
+  command = "npm install --no-audit --no-fund --include=dev && npm run build"
+
+[build.environment]
+  NODE_VERSION = "22.20.0"
+  NPM_FLAGS = "--no-audit --no-fund"

--- a/package.json
+++ b/package.json
@@ -4,14 +4,13 @@
   "private": true,
   "description": "Build tooling and quality checks for the Telcoin Wiki static site",
   "engines": {
-"engines": {
-  "node": ">=22 <23"
+    "node": ">=22 <23"
   },
   "scripts": {
-    "format": "prettier --write '**/*.{html,css,js,json,md}'",
-    "lint": "eslint '**/*.js' --max-warnings=0",
-    "check:html": "html-validate '**/*.html'",
-    "check:links": "linkinator . --recurse --silent --skip 'node_modules|dist'",
+    "format": "prettier --write \"**/*.{html,css,js,json,md}\"",
+    "lint": "eslint \"**/*.js\" --max-warnings=0",
+    "check:html": "html-validate \"**/*.html\"",
+    "check:links": "linkinator . --recurse --silent --skip \"node_modules|dist\"",
     "build:css": "csso styles/index.css --output dist/styles.css",
     "build:js": "mkdir -p dist && node scripts/build-status-data.js && node node_modules/terser/bin/terser js/main.js -o dist/main.js --compress --mangle && node node_modules/terser/bin/terser js/faq.js -o dist/faq.js --compress --mangle && node node_modules/terser/bin/terser js/pools-data.js -o dist/pools.js --compress --mangle",
     "build:img": "node scripts/optimize-images.js",


### PR DESCRIPTION
## Summary
- replace `package.json` with a valid JSON structure and retain the Node 22 engine range
- add `netlify.toml` to pin Node 22.20.0 and use an npm install based build command
- include `.npmrc` to disable npm fund/audit messaging in CI logs

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json OK')"`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68dd7270e5548330845433c0b13a0bd6