### PR TITLE
Header: logo-only brand, 2× responsive logo, remove Last Updated & extra pill; tidy spacing across breakpoints.

### DIFF
--- a/404.html
+++ b/404.html
@@ -59,8 +59,8 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
     <header class="site-header">
       <div class="site-header__inner container">
-        <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
-          <img src="/logo.svg" alt="" width="56" height="56"><span>Telcoin Wiki</span>
+        <a class="site-brand" href="/">
+          <img class="site-logo" src="/logo.svg" alt="Telcoin Wiki logo" loading="eager" decoding="async" />
         </a>
 
         <!-- Desktop nav -->

--- a/about.html
+++ b/about.html
@@ -58,8 +58,8 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
     <header class="site-header">
       <div class="site-header__inner container">
-        <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
-          <img src="/logo.svg" alt="" width="56" height="56"><span>Telcoin Wiki</span>
+        <a class="site-brand" href="/">
+          <img class="site-logo" src="/logo.svg" alt="Telcoin Wiki logo" loading="eager" decoding="async" />
         </a>
 
         <!-- Desktop nav -->

--- a/builders.html
+++ b/builders.html
@@ -58,8 +58,8 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
     <header class="site-header">
       <div class="site-header__inner container">
-        <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
-          <img src="/logo.svg" alt="" width="56" height="56"><span>Telcoin Wiki</span>
+        <a class="site-brand" href="/">
+          <img class="site-logo" src="/logo.svg" alt="Telcoin Wiki logo" loading="eager" decoding="async" />
         </a>
 
         <!-- Desktop nav -->

--- a/deep-dive.html
+++ b/deep-dive.html
@@ -58,8 +58,8 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
     <header class="site-header">
       <div class="site-header__inner container">
-        <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
-          <img src="/logo.svg" alt="" width="56" height="56"><span>Telcoin Wiki</span>
+        <a class="site-brand" href="/">
+          <img class="site-logo" src="/logo.svg" alt="Telcoin Wiki logo" loading="eager" decoding="async" />
         </a>
 
         <!-- Desktop nav -->

--- a/digital-cash.html
+++ b/digital-cash.html
@@ -58,8 +58,8 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
     <header class="site-header">
       <div class="site-header__inner container">
-        <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
-          <img src="/logo.svg" alt="" width="56" height="56"><span>Telcoin Wiki</span>
+        <a class="site-brand" href="/">
+          <img class="site-logo" src="/logo.svg" alt="Telcoin Wiki logo" loading="eager" decoding="async" />
         </a>
 
         <!-- Desktop nav -->

--- a/faq/index.html
+++ b/faq/index.html
@@ -60,8 +60,8 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
     <header class="site-header">
       <div class="site-header__inner container">
-        <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
-          <img src="/logo.svg" alt="" width="56" height="56"><span>Telcoin Wiki</span>
+        <a class="site-brand" href="/">
+          <img class="site-logo" src="/logo.svg" alt="Telcoin Wiki logo" loading="eager" decoding="async" />
         </a>
 
         <!-- Desktop nav -->

--- a/governance.html
+++ b/governance.html
@@ -58,8 +58,8 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
     <header class="site-header">
       <div class="site-header__inner container">
-        <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
-          <img src="/logo.svg" alt="" width="56" height="56"><span>Telcoin Wiki</span>
+        <a class="site-brand" href="/">
+          <img class="site-logo" src="/logo.svg" alt="Telcoin Wiki logo" loading="eager" decoding="async" />
         </a>
 
         <!-- Desktop nav -->

--- a/index.html
+++ b/index.html
@@ -512,8 +512,8 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
     <header class="site-header">
       <div class="site-header__inner container">
-        <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
-          <img src="/logo.svg" alt="" width="56" height="56"><span>Telcoin Wiki</span>
+        <a class="site-brand" href="/">
+          <img class="site-logo" src="/logo.svg" alt="Telcoin Wiki logo" loading="eager" decoding="async" />
         </a>
 
         <!-- Desktop nav -->

--- a/links.html
+++ b/links.html
@@ -58,8 +58,8 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
     <header class="site-header">
       <div class="site-header__inner container">
-        <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
-          <img src="/logo.svg" alt="" width="56" height="56"><span>Telcoin Wiki</span>
+        <a class="site-brand" href="/">
+          <img class="site-logo" src="/logo.svg" alt="Telcoin Wiki logo" loading="eager" decoding="async" />
         </a>
 
         <!-- Desktop nav -->

--- a/network.html
+++ b/network.html
@@ -58,8 +58,8 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
     <header class="site-header">
       <div class="site-header__inner container">
-        <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
-          <img src="/logo.svg" alt="" width="56" height="56"><span>Telcoin Wiki</span>
+        <a class="site-brand" href="/">
+          <img class="site-logo" src="/logo.svg" alt="Telcoin Wiki logo" loading="eager" decoding="async" />
         </a>
 
         <!-- Desktop nav -->

--- a/pools.html
+++ b/pools.html
@@ -59,8 +59,8 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
     <header class="site-header">
       <div class="site-header__inner container">
-        <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
-          <img src="/logo.svg" alt="" width="56" height="56"><span>Telcoin Wiki</span>
+        <a class="site-brand" href="/">
+          <img class="site-logo" src="/logo.svg" alt="Telcoin Wiki logo" loading="eager" decoding="async" />
         </a>
 
         <!-- Desktop nav -->

--- a/portfolio.html
+++ b/portfolio.html
@@ -58,8 +58,8 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
     <header class="site-header">
       <div class="site-header__inner container">
-        <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
-          <img src="/logo.svg" alt="" width="56" height="56"><span>Telcoin Wiki</span>
+        <a class="site-brand" href="/">
+          <img class="site-logo" src="/logo.svg" alt="Telcoin Wiki logo" loading="eager" decoding="async" />
         </a>
 
         <!-- Desktop nav -->

--- a/remittances.html
+++ b/remittances.html
@@ -59,8 +59,8 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
     <header class="site-header">
       <div class="site-header__inner container">
-        <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
-          <img src="/logo.svg" alt="" width="56" height="56"><span>Telcoin Wiki</span>
+        <a class="site-brand" href="/">
+          <img class="site-logo" src="/logo.svg" alt="Telcoin Wiki logo" loading="eager" decoding="async" />
         </a>
 
         <!-- Desktop nav -->

--- a/start-here.html
+++ b/start-here.html
@@ -59,8 +59,8 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
     <header class="site-header">
       <div class="site-header__inner container">
-        <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
-          <img src="/logo.svg" alt="" width="56" height="56"><span>Telcoin Wiki</span>
+        <a class="site-brand" href="/">
+          <img class="site-logo" src="/logo.svg" alt="Telcoin Wiki logo" loading="eager" decoding="async" />
         </a>
 
         <!-- Desktop nav -->

--- a/styles/brand.css
+++ b/styles/brand.css
@@ -11,6 +11,9 @@
   --gap-4: 1rem;
   --gap-5: 1.5rem;
   --gap-6: 2rem;
+  --header-pad-y: clamp(10px, 1.2vw, 18px);
+  --logo-min: 48px;
+  --logo-max: 96px;
 }
 
 html,
@@ -42,11 +45,42 @@ body {
 
 /* --- Header ------------------------------------------------------------ */
 /* Responsive header layout */
-.site-header { position: sticky; top: 0; z-index: 100; background: rgba(14,27,63,.9); backdrop-filter: blur(18px); border-bottom: 1px solid var(--tc-border); }
-.site-header__inner { display: flex; flex-wrap: wrap; align-items: center; gap: .75rem 1rem; padding: .75rem 1rem; }
-.site-logo { display: inline-flex; align-items: center; gap: .6rem; font-weight: 700; color: var(--tc-ink); }
-.site-logo img { width: 56px; height: 56px; border-radius: .5rem; }
-@media (max-width: 960px) { .site-logo img { width: 48px; height: 48px; } }
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: rgba(14, 27, 63, 0.9);
+  backdrop-filter: blur(18px);
+  border-bottom: 1px solid var(--tc-border);
+}
+.site-header__inner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: clamp(12px, 2vw, 28px);
+  padding-block: var(--header-pad-y);
+}
+.site-brand {
+  display: inline-flex;
+  align-items: center;
+  line-height: 0;
+  text-decoration: none;
+  margin-right: clamp(12px, 2vw, 28px);
+  border-radius: 0.75rem;
+}
+.site-brand:hover,
+.site-brand:focus-visible {
+  text-decoration: none;
+}
+.site-brand .site-logo,
+img.site-logo {
+  display: block;
+  height: clamp(var(--logo-min), 8vw, var(--logo-max));
+  width: auto;
+  max-height: none !important;
+  padding: 0;
+  border-radius: 0.75rem;
+}
 
 /* Nav pills (desktop) */
 .top-nav { order: 2; flex: 1 1 auto; min-width: 320px; }
@@ -60,7 +94,13 @@ body {
 @media (max-width: 960px) { .menu-btn { display: inline-flex; } .top-nav { display: none; } }
 
 /* Search */
-.header-search { order: 4; flex: 1 0 280px; }
+.header-search {
+  order: 4;
+  flex: 1 0 280px;
+  display: flex;
+  align-items: center;
+  min-width: clamp(200px, 45vw, 320px);
+}
 .search-input { width: 100%; height: 42px; padding: 0 1rem; background: rgba(18,30,68,.92); border: 1px solid var(--tc-border); border-radius: 999px; color: var(--tc-ink); }
 .search-input::placeholder { color: rgba(255,255,255,.55); }
 
@@ -72,7 +112,15 @@ body {
 .drawer a:hover, .drawer a:focus-visible { background: var(--tc-surface-2); text-decoration: none; }
 
 /* Remove obsolete elements */
-.last-updated, .search-panel { display: none !important; }
+.header-pill,
+.search-underline,
+.header__decor,
+.last-updated,
+.header-updated,
+[data-last-updated],
+.search-panel {
+  display: none !important;
+}
 
 /* --- Cards/sections polish -------------------------------------------- */
 .tc-card {

--- a/tel-token.html
+++ b/tel-token.html
@@ -58,8 +58,8 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
     <header class="site-header">
       <div class="site-header__inner container">
-        <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
-          <img src="/logo.svg" alt="" width="56" height="56"><span>Telcoin Wiki</span>
+        <a class="site-brand" href="/">
+          <img class="site-logo" src="/logo.svg" alt="Telcoin Wiki logo" loading="eager" decoding="async" />
         </a>
 
         <!-- Desktop nav -->

--- a/telx.html
+++ b/telx.html
@@ -58,8 +58,8 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
     <header class="site-header">
       <div class="site-header__inner container">
-        <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
-          <img src="/logo.svg" alt="" width="56" height="56"><span>Telcoin Wiki</span>
+        <a class="site-brand" href="/">
+          <img class="site-logo" src="/logo.svg" alt="Telcoin Wiki logo" loading="eager" decoding="async" />
         </a>
 
         <!-- Desktop nav -->

--- a/wallet.html
+++ b/wallet.html
@@ -59,8 +59,8 @@
   <a class="skip-link" href="#main-content">Skip to content</a>
     <header class="site-header">
       <div class="site-header__inner container">
-        <a class="site-logo" href="/index.html" aria-label="Telcoin Wiki home">
-          <img src="/logo.svg" alt="" width="56" height="56"><span>Telcoin Wiki</span>
+        <a class="site-brand" href="/">
+          <img class="site-logo" src="/logo.svg" alt="Telcoin Wiki logo" loading="eager" decoding="async" />
         </a>
 
         <!-- Desktop nav -->


### PR DESCRIPTION
## Summary
- show only the Telcoin logo in the global header brand link and point it to the root path
- enlarge the logo with responsive sizing tokens and tune header spacing so nav and search stay centered across breakpoints
- remove the unused Last Updated callout and decorative search pill globally while keeping existing colors and behavior

## Testing
- Manual verification in browser

## Screenshots
![Header at 375px](browser:/invocations/vucpuhbo/artifacts/artifacts/header-375.png)
![Header at 768px](browser:/invocations/vucpuhbo/artifacts/artifacts/header-768.png)
![Header at 1280px](browser:/invocations/vucpuhbo/artifacts/artifacts/header-1280.png)

------
https://chatgpt.com/codex/tasks/task_e_68ddc2605e1c8330b027c240f60ba530