### PR TITLE
fix Verify Supabase workflow to read VITE_* or NEXT_PUBLIC_* secrets

### DIFF
--- a/.github/workflows/verify-supabase.yml
+++ b/.github/workflows/verify-supabase.yml
@@ -6,12 +6,16 @@ on:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    # Export BOTH naming conventions; the script accepts either
     env:
-      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+      VITE_SUPABASE_URL:             ${{ secrets.VITE_SUPABASE_URL }}
+      VITE_SUPABASE_ANON_KEY:        ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+      NEXT_PUBLIC_SUPABASE_URL:      ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
       NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: '20' }
+        with:
+          node-version: '20'
       - run: node -v
       - run: npm run verify:supabase


### PR DESCRIPTION
## Summary
- export both VITE_* and NEXT_PUBLIC_* Supabase secrets in the verify workflow environment
- document why both prefixes are provided so the verification script can find either secret pair

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e19ed82d4c83308e3b0e79bf1b7a3c