### PR TITLE
Use React Router links for internal navigation

### DIFF
--- a/telcoinwiki-react/src/components/layout/Breadcrumbs.tsx
+++ b/telcoinwiki-react/src/components/layout/Breadcrumbs.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom'
 import type { BreadcrumbNode } from '../../config/types'
 
 interface BreadcrumbsProps {
@@ -16,7 +17,7 @@ export function Breadcrumbs({ trail }: BreadcrumbsProps) {
             {isLast ? (
               <span aria-current="page">{node.label}</span>
             ) : (
-              <a href={node.url}>{node.label}</a>
+              <Link to={node.url}>{node.label}</Link>
             )}
           </span>
         )

--- a/telcoinwiki-react/src/components/layout/Header.tsx
+++ b/telcoinwiki-react/src/components/layout/Header.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
 import type { NavItem } from '../../config/types'
 
 interface HeaderProps {
@@ -62,7 +63,7 @@ export function Header({ navItems, activeNavId, onSearchOpen, isSearchOpen = fal
   return (
     <header className="site-header">
       <div className="site-header__inner container">
-        <a className="site-brand" href="/">
+        <Link className="site-brand" to="/">
           <img
             className="site-logo"
             src="/logo.svg"
@@ -70,7 +71,7 @@ export function Header({ navItems, activeNavId, onSearchOpen, isSearchOpen = fal
             loading="eager"
             decoding="async"
           />
-        </a>
+        </Link>
 
         <nav className="top-nav" aria-label="Primary">
           <ul className="pill-nav top-nav__list" ref={navListRef}>
@@ -80,14 +81,14 @@ export function Header({ navItems, activeNavId, onSearchOpen, isSearchOpen = fal
               if (!item.menu || item.menu.length === 0) {
                 return (
                   <li key={item.id} className="nav-item">
-                    <a
+                    <Link
                       className={`top-nav__link${isActive ? ' is-active' : ''}`}
-                      href={item.href}
+                      to={item.href}
                       aria-current={isActive ? 'page' : undefined}
                       onClick={closeMenus}
                     >
                       {item.label}
-                    </a>
+                    </Link>
                   </li>
                 )
               }
@@ -109,14 +110,14 @@ export function Header({ navItems, activeNavId, onSearchOpen, isSearchOpen = fal
                   </button>
                   <div className="nav-menu" role="menu">
                     {item.menu.map((entry) => (
-                      <a
+                      <Link
                         key={entry.href}
-                        href={entry.href}
+                        to={entry.href}
                         role="menuitem"
                         onClick={closeMenus}
                       >
                         {entry.label}
-                      </a>
+                      </Link>
                     ))}
                   </div>
                 </li>
@@ -158,9 +159,9 @@ export function Header({ navItems, activeNavId, onSearchOpen, isSearchOpen = fal
           <ul>
             {mobileItems.map((item) => (
               <li key={`mobile-${item.id}`} className="nav-item">
-                <a href={item.href} onClick={handleMobileLinkClick}>
+                <Link to={item.href} onClick={handleMobileLinkClick}>
                   {item.label}
-                </a>
+                </Link>
               </li>
             ))}
           </ul>

--- a/telcoinwiki-react/src/components/layout/Sidebar.tsx
+++ b/telcoinwiki-react/src/components/layout/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom'
 import type { SidebarHeading } from '../../config/types'
 
 interface SidebarItemProps {
@@ -28,14 +29,14 @@ export function Sidebar({ items, activeId, headings = [], isOpen = false }: Side
               const isActive = item.id === activeId
               return (
                 <li key={item.id} className="sidebar__item">
-                  <a
+                  <Link
                     id={`sidebar-link-${item.id}`}
                     className={`sidebar__link${isActive ? ' is-active' : ''}`}
-                    href={item.href}
+                    to={item.href}
                     aria-current={isActive ? 'page' : undefined}
                   >
                     {item.label}
-                  </a>
+                  </Link>
                   {isActive && headings.length > 0 ? (
                     <ul className="sidebar__sublist" aria-labelledby={`sidebar-link-${item.id}`}>
                       {headings.map((heading) => (

--- a/telcoinwiki-react/src/components/search/SearchModal.tsx
+++ b/telcoinwiki-react/src/components/search/SearchModal.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react'
+import { Link } from 'react-router-dom'
 import type { SearchConfig } from '../../config/types'
 import { useSearchIndex } from '../../hooks/useSearchIndex'
 
@@ -162,9 +163,9 @@ export function SearchModal({ isOpen, onClose, searchConfig }: SearchModalProps)
                     runningIndex += 1
                     const currentIndex = runningIndex
                     return (
-                      <a
+                      <Link
                         key={`${group.id}-${item.doc.ref}-${itemIndex}`}
-                        href={item.doc.url}
+                        to={item.doc.url}
                         className="search-modal__result"
                         ref={(element) => {
                           if (element) {
@@ -179,7 +180,7 @@ export function SearchModal({ isOpen, onClose, searchConfig }: SearchModalProps)
                           className="search-modal__result-snippet"
                           dangerouslySetInnerHTML={{ __html: item.snippet }}
                         />
-                      </a>
+                      </Link>
                     )
                   })}
                 </Fragment>


### PR DESCRIPTION
## Summary
- replace anchor tags with React Router `Link` components across header, sidebar, breadcrumbs, and search results to keep navigation client-side
- preserve existing active state and close-menu behaviors when using the router links

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e2bf714618833093dc72810f0e57f4