### PR TITLE
Align Netlify build command with preview deploy settings

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
-  publish = "."
-  command = "npm ci --no-audit --no-fund && npm run prebuild && rm -rf node_modules"
+  publish = "telcoinwiki-react/dist"
+  command = "npm ci --no-audit --no-fund && npm --prefix telcoinwiki-react ci --no-audit --no-fund && export VITE_SUPABASE_URL=\"${VITE_SUPABASE_URL:-$NEXT_PUBLIC_SUPABASE_URL}\" && export VITE_SUPABASE_ANON_KEY=\"${VITE_SUPABASE_ANON_KEY:-$NEXT_PUBLIC_SUPABASE_ANON_KEY}\" && npm run prebuild && npm run build && rm -rf node_modules telcoinwiki-react/node_modules"
 
 [build.environment]
   NODE_VERSION = "22.20.0"


### PR DESCRIPTION
## Summary
- point the top-level Netlify build publish directory at `telcoinwiki-react/dist`
- expand the build command to install root and app dependencies, export Supabase env vars, run the prebuild/build scripts, and clean up node_modules

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2c758f9e48330993c514f1fed266c