### PR TITLE
Fix elasticlunr global alias crash

### DIFF
--- a/telcoinwiki-react/src/hooks/useSearchIndex.ts
+++ b/telcoinwiki-react/src/hooks/useSearchIndex.ts
@@ -1,4 +1,6 @@
 import elasticlunr, { type Index as ElasticIndex } from 'elasticlunr'
+
+globalThis.lunr ??= elasticlunr
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { SearchConfig } from '../config/types'
 import type { FaqEntry } from '../lib/queries'
@@ -37,6 +39,13 @@ export interface SearchResultGroup {
   id: SearchDocumentType
   label: string
   items: SearchResultItem[]
+}
+
+declare global {
+  // elasticlunr expects to access a global `lunr` alias when running in strict mode environments
+  interface GlobalThis {
+    lunr?: typeof elasticlunr
+  }
 }
 
 interface SearchIndexState {


### PR DESCRIPTION
## Summary
- ensure elasticlunr registers itself on `globalThis.lunr` before React hooks use it
- declare a global type augmentation so TypeScript recognizes the new alias

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2ccc96380833083bfc1a8ee41e12e