### PR TITLE
Load elasticlunr dynamically

### DIFF
--- a/telcoinwiki-react/src/vendor/loadElasticlunr.ts
+++ b/telcoinwiki-react/src/vendor/loadElasticlunr.ts
@@ -1,0 +1,31 @@
+const ensureGlobalLunrBinding = (): void => {
+  if (typeof globalThis === 'undefined') {
+    return
+  }
+
+  new Function('if(typeof lunr==="undefined"){lunr=undefined;}')()
+}
+
+type ElasticlunrModule = typeof import('elasticlunr')
+
+declare global {
+  interface GlobalThis {
+    lunr?: ElasticlunrModule['default']
+  }
+}
+
+let cachedModule: ElasticlunrModule | null = null
+
+export const loadElasticlunr = async (): Promise<ElasticlunrModule> => {
+  ensureGlobalLunrBinding()
+
+  if (cachedModule) {
+    globalThis.lunr = cachedModule.default
+    return cachedModule
+  }
+
+  const module = (await import('elasticlunr')) as ElasticlunrModule
+  cachedModule = module
+  globalThis.lunr = module.default
+  return module
+}


### PR DESCRIPTION
## Summary
- add a safe `loadElasticlunr` helper that prepares the global `lunr` binding and caches the module
- update `useSearchIndex` to load elasticlunr lazily and build the index after the helper resolves

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2cfc98e308330817277c9fd9c9fcc