### PR TITLE
Adjust sidebar styling to prevent nested scrollbar

### DIFF
--- a/telcoinwiki-react/src/styles/site.css
+++ b/telcoinwiki-react/src/styles/site.css
@@ -435,8 +435,6 @@ pre {
 .sidebar__inner {
   position: sticky;
   top: calc(var(--header-height) + 1rem);
-  max-height: calc(100vh - var(--header-height) - 3rem);
-  overflow-y: auto;
   padding: 1.5rem;
   border-radius: var(--radius-card);
   backdrop-filter: blur(24px);


### PR DESCRIPTION
## Summary
- remove the fixed max-height and overflow on the sticky sidebar container to prevent double scrolling

## Testing
- npm run dev -- --host 0.0.0.0 --port 5173

------
https://chatgpt.com/codex/tasks/task_e_68e2d4e153088330bbc836f663da5df1