### PR TITLE
Refresh Telcoin palette to match marketing site

### DIFF
--- a/docs/design/palette.md
+++ b/docs/design/palette.md
@@ -1,0 +1,25 @@
+# Telcoin brand palette (2025 refresh)
+
+The color tokens below were resampled directly from [`telcoin.network`](https://telcoin.network) by inspecting the production Next.js CSS bundles (`/_next/static/css/*.css`). The hues align with the hero gradients (`.bg-ocean-gradient`, `.bg-ocean-hero-home`) and supporting utility classes that ship on the live site.
+
+| Token | Hex | RGB | Usage |
+| --- | --- | --- | --- |
+| `--tc-blue-sky` | `#37AEFF` | `rgb(55, 174, 255)` | Primary highlight, hover/focus states, and ocean gradient entry color. |
+| `--tc-blue-core` | `#0093F5` | `rgb(0, 147, 245)` | Core Telcoin call-to-action blue used on CTAs and active controls. |
+| `--tc-blue-royal` | `#391FFF` | `rgb(57, 31, 255)` | Deep royal accent leveraged for emphasis states and gradient tails. |
+| `--tc-blue-violet` | `#5533FF` | `rgb(85, 51, 255)` | Violet anchor from `.bg-ocean-hero-home` gradient overlays. |
+| `--tc-neutral-50` | `#F8F8FB` | `rgb(248, 248, 251)` | Lightest neutral for text ink mixes and glass surfaces. |
+| `--tc-neutral-100` | `#F2F2F5` | `rgb(242, 242, 245)` | Soft neutral backgrounds and subdued cards. |
+| `--tc-neutral-200` | `#DBDDE6` | `rgb(219, 221, 230)` | Border tints and table dividers. |
+| `--tc-neutral-300` | `#D3D3D3` | `rgb(211, 211, 211)` | Secondary strokes inside gradients (e.g., ocean hero fallback). |
+| `--tc-neutral-500` | `#636B92` | `rgb(99, 107, 146)` | Muted text and icon tint from body copy styles. |
+| `--tc-neutral-600` | `#535979` | `rgb(83, 89, 121)` | Deep neutral for subdued headings and metadata. |
+| `--tc-white` | `#FFFFFF` | `rgb(255, 255, 255)` | Pure white used for contrast checks and overlays. |
+
+## Derived gradients and transparencies
+
+- **Hero shell**: `radial-gradient(1200px 800px at 10% -10%, rgba(55, 174, 255, 0.16), transparent 70%), linear-gradient(180deg, #04345F 0%, #050B1F 60%)`
+- **Ocean glass**: `linear-gradient(256deg, rgba(55, 174, 255, 0.6), rgba(85, 51, 255, 0.6)), linear-gradient(245deg, rgba(51, 172, 255, 0.3) 43.29%, #5533FF 78%)`
+- **Soft fills**: `rgba(0, 147, 245, 0.22)` (primary), `rgba(55, 174, 255, 0.18)` (accent), `rgba(57, 31, 255, 0.32)` (royal)
+
+These values drive the refreshed `tokens.css` palette to ensure the wiki mirrors the live marketing site’s contrast and depth.

--- a/telcoinwiki-react/src/styles/brand.css
+++ b/telcoinwiki-react/src/styles/brand.css
@@ -33,8 +33,8 @@ body {
 /* --- Page chrome ------------------------------------------------------- */
 body {
   background:
-    radial-gradient(1200px 800px at 10% -10%, rgba(69, 188, 241, 0.14), transparent 65%),
-    linear-gradient(180deg, #10255e 0%, var(--tc-bg) 60%);
+    var(--tc-hero-radial),
+    var(--tc-hero-linear);
 }
 
 .container {
@@ -49,7 +49,7 @@ body {
   position: sticky;
   top: 0;
   z-index: 100;
-  background: rgba(14, 27, 63, 0.9);
+  background: rgba(5, 11, 31, 0.9);
   backdrop-filter: blur(18px);
   border-bottom: 1px solid var(--tc-border);
 }
@@ -112,8 +112,18 @@ img.site-logo {
   align-items: center;
   min-width: clamp(200px, 45vw, 320px);
 }
-.search-input { width: 100%; height: 42px; padding: 0 1rem; background: rgba(18,30,68,.92); border: 1px solid var(--tc-border); border-radius: 999px; color: var(--tc-ink); }
-.search-input::placeholder { color: rgba(255,255,255,.55); }
+.search-input {
+  width: 100%;
+  height: 42px;
+  padding: 0 1rem;
+  background: rgba(8, 18, 48, 0.92);
+  border: 1px solid var(--tc-border);
+  border-radius: 999px;
+  color: var(--tc-ink);
+}
+.search-input::placeholder {
+  color: rgba(248, 248, 251, 0.55);
+}
 
 /* Mobile drawer */
 .drawer { position: fixed; inset: 64px 1rem auto 1rem; background: var(--tc-surface); border: 1px solid var(--tc-border); border-radius: 1rem; box-shadow: var(--tc-shadow); padding: .75rem; display: none; z-index: 120; }

--- a/telcoinwiki-react/src/styles/critical.css
+++ b/telcoinwiki-react/src/styles/critical.css
@@ -13,17 +13,17 @@
   --color-text: var(--tc-ink);
   --color-text-muted: var(--tc-ink-muted);
   --color-text-soft: var(--tc-ink-subtle);
-  --color-text-inverse: #050f2d;
+  --color-text-inverse: #050B1F;
 
   --color-primary: var(--tc-primary-500);
   --color-primary-strong: var(--tc-primary-700);
-  --color-primary-soft: rgba(64, 102, 222, 0.22);
+  --color-primary-soft: var(--tc-primary-soft);
   --color-secondary: var(--tc-accent);
-  --color-secondary-soft: rgba(69, 188, 241, 0.18);
+  --color-secondary-soft: var(--tc-accent-soft);
   --color-highlight: var(--tc-primary-300);
   --color-warning: #facc15;
   --color-warning-soft: rgba(250, 204, 21, 0.18);
-  --color-info-soft: rgba(69, 188, 241, 0.18);
+  --color-info-soft: var(--tc-accent-soft);
 
   --space-1: 0.25rem;
   --space-2: 0.5rem;
@@ -65,8 +65,8 @@ body {
   line-height: var(--line-height-base);
   color: var(--tc-ink);
   background:
-    radial-gradient(1200px 800px at 10% -10%, rgba(69, 188, 241, 0.14), transparent 70%),
-    linear-gradient(180deg, #10255e 0%, var(--tc-bg) 60%);
+    var(--tc-hero-radial),
+    var(--tc-hero-linear);
   min-height: 100vh;
 }
 

--- a/telcoinwiki-react/src/styles/site.css
+++ b/telcoinwiki-react/src/styles/site.css
@@ -16,8 +16,8 @@ body {
   line-height: var(--line-height-base);
   color: var(--tc-ink);
   background:
-    radial-gradient(1200px 800px at 10% -10%, rgba(69, 188, 241, 0.14), transparent 70%),
-    linear-gradient(180deg, #10255e 0%, var(--tc-bg) 60%);
+    var(--tc-hero-radial),
+    var(--tc-hero-linear);
   min-height: 100vh;
 }
 
@@ -403,7 +403,7 @@ pre {
 }
 
 .search-result mark {
-  background: rgba(69, 188, 241, 0.25);
+  background: rgba(55, 174, 255, 0.25);
   color: var(--tc-ink);
   border-radius: var(--radius-xs);
   padding: 0 var(--space-1);
@@ -724,7 +724,7 @@ pre {
 }
 
 .getting-started.is-open .getting-started__toggle-icon {
-  background: rgba(64, 102, 222, 0.32);
+  background: rgba(57, 31, 255, 0.32);
 }
 
 .getting-started.is-open .getting-started__toggle-icon::after {
@@ -854,7 +854,7 @@ pre {
 }
 
 .notice--info {
-  border-color: rgba(64, 102, 222, 0.35);
+  border-color: rgba(57, 31, 255, 0.35);
   background: var(--color-info-soft);
 }
 
@@ -1146,8 +1146,8 @@ pre {
 
 .context-box {
   border-radius: var(--radius-lg);
-  border: 1px dashed rgba(69, 188, 241, 0.45);
-  background: rgba(69, 188, 241, 0.12);
+  border: 1px dashed rgba(55, 174, 255, 0.45);
+  background: rgba(55, 174, 255, 0.12);
   padding: var(--space-4);
   margin-bottom: var(--space-4);
 }
@@ -1345,7 +1345,7 @@ tr:last-child td {
   position: absolute;
   inset: 0;
   width: 0%;
-  background: linear-gradient(90deg, rgba(69, 188, 241, 0.7), rgba(64, 102, 222, 0.85));
+  background: linear-gradient(90deg, rgba(55, 174, 255, 0.7), rgba(57, 31, 255, 0.85));
   border-radius: inherit;
   transform-origin: left center;
 }
@@ -1465,14 +1465,14 @@ tr:last-child td {
 }
 
 .tc-chip.is-active {
-  background: rgba(69, 188, 241, 0.18);
-  border-color: rgba(69, 188, 241, 0.4);
+  background: rgba(55, 174, 255, 0.18);
+  border-color: rgba(55, 174, 255, 0.4);
   color: #dff6ff;
 }
 
 .tc-chip.is-archived {
-  background: rgba(64, 102, 222, 0.18);
-  border-color: rgba(64, 102, 222, 0.4);
+  background: rgba(57, 31, 255, 0.18);
+  border-color: rgba(57, 31, 255, 0.4);
   color: var(--tc-ink);
 }
 
@@ -1539,7 +1539,7 @@ tr:last-child td {
 
 .footer {
   margin-top: auto;
-  background: rgba(14, 27, 63, 0.92);
+  background: rgba(5, 11, 31, 0.92);
   border-top: 1px solid var(--color-border-subtle);
 }
 
@@ -1640,8 +1640,8 @@ tr:last-child td {
   text-align: center;
   color: var(--color-text-soft);
   border-radius: var(--radius-lg);
-  border: 1px dashed rgba(69, 188, 241, 0.4);
-  background: rgba(69, 188, 241, 0.12);
+  border: 1px dashed rgba(55, 174, 255, 0.4);
+  background: rgba(55, 174, 255, 0.12);
 }
 
 .anchor-offset {
@@ -1649,7 +1649,7 @@ tr:last-child td {
 }
 
 mark {
-  background: rgba(69, 188, 241, 0.3);
+  background: rgba(55, 174, 255, 0.3);
   color: inherit;
   border-radius: var(--radius-xs);
   padding: 0 var(--space-1);

--- a/telcoinwiki-react/src/styles/tokens.css
+++ b/telcoinwiki-react/src/styles/tokens.css
@@ -1,21 +1,48 @@
 :root {
-  /* Telcoin palette */
-  --tc-primary: #4066DE;
-  --tc-primary-50: #E4ECF7;
-  --tc-primary-300: #7F86D2;
-  --tc-primary-500: #4066DE;
-  --tc-primary-700: #2C2C7A;
-  --tc-accent: #45BCF1;
+  /* Telcoin palette — sampled from telcoin.network */
+  --tc-blue-sky: #37AEFF;
+  --tc-blue-core: #0093F5;
+  --tc-blue-royal: #391FFF;
+  --tc-blue-violet: #5533FF;
 
-  --tc-ink: rgba(255, 255, 255, 0.92);
-  --tc-ink-muted: rgba(255, 255, 255, 0.8);
-  --tc-ink-subtle: rgba(255, 255, 255, 0.65);
+  --tc-neutral-50: #F8F8FB;
+  --tc-neutral-100: #F2F2F5;
+  --tc-neutral-200: #DBDDE6;
+  --tc-neutral-300: #D3D3D3;
+  --tc-neutral-500: #636B92;
+  --tc-neutral-600: #535979;
+  --tc-white: #FFFFFF;
 
-  --tc-bg: #0f1a3a;
-  --tc-surface: rgba(255, 255, 255, 0.05);
-  --tc-surface-2: rgba(255, 255, 255, 0.08);
-  --tc-border: rgba(255, 255, 255, 0.1);
-  --tc-border-strong: rgba(255, 255, 255, 0.18);
+  --tc-primary-50: var(--tc-neutral-100);
+  --tc-primary-300: var(--tc-blue-sky);
+  --tc-primary-500: var(--tc-blue-core);
+  --tc-primary-700: var(--tc-blue-royal);
+  --tc-primary: var(--tc-primary-500);
+  --tc-accent: var(--tc-blue-sky);
+  --tc-accent-strong: var(--tc-blue-royal);
+
+  --tc-ink: rgba(248, 248, 251, 0.95);
+  --tc-ink-muted: rgba(248, 248, 251, 0.78);
+  --tc-ink-subtle: rgba(248, 248, 251, 0.62);
+
+  --tc-bg: #050B1F;
+  --tc-bg-gradient-top: #04345F;
+  --tc-surface: rgba(248, 248, 251, 0.06);
+  --tc-surface-2: rgba(248, 248, 251, 0.1);
+  --tc-border: rgba(219, 221, 230, 0.24);
+  --tc-border-strong: rgba(219, 221, 230, 0.42);
+
+  --tc-primary-soft: rgba(0, 147, 245, 0.22);
+  --tc-accent-soft: rgba(55, 174, 255, 0.18);
+  --tc-accent-veil: rgba(55, 174, 255, 0.12);
+  --tc-accent-outline: rgba(55, 174, 255, 0.45);
+  --tc-royal-soft: rgba(57, 31, 255, 0.32);
+  --tc-royal-outline: rgba(57, 31, 255, 0.4);
+
+  --tc-hero-radial: radial-gradient(1200px 800px at 10% -10%, rgba(55, 174, 255, 0.16), transparent 70%);
+  --tc-hero-linear: linear-gradient(180deg, var(--tc-bg-gradient-top) 0%, var(--tc-bg) 60%);
+  --tc-ocean-gradient: linear-gradient(256deg, rgba(55, 174, 255, 0.6), rgba(85, 51, 255, 0.6)),
+    linear-gradient(245deg, rgba(51, 172, 255, 0.3) 43.29%, var(--tc-blue-violet) 78%);
 
   --tc-radius: 1rem;
   --tc-radius-lg: 1.25rem;

--- a/telcoinwiki-react/src/styles/variables.css
+++ b/telcoinwiki-react/src/styles/variables.css
@@ -13,17 +13,17 @@
   --color-text: var(--tc-ink);
   --color-text-muted: var(--tc-ink-muted);
   --color-text-soft: var(--tc-ink-subtle);
-  --color-text-inverse: #050f2d;
+  --color-text-inverse: #050B1F;
 
   --color-primary: var(--tc-primary-500);
   --color-primary-strong: var(--tc-primary-700);
-  --color-primary-soft: rgba(64, 102, 222, 0.22);
+  --color-primary-soft: var(--tc-primary-soft);
   --color-secondary: var(--tc-accent);
-  --color-secondary-soft: rgba(69, 188, 241, 0.18);
+  --color-secondary-soft: var(--tc-accent-soft);
   --color-highlight: var(--tc-primary-300);
   --color-warning: #facc15;
   --color-warning-soft: rgba(250, 204, 21, 0.18);
-  --color-info-soft: rgba(69, 188, 241, 0.18);
+  --color-info-soft: var(--tc-accent-soft);
 
   --space-0: 0rem;
   --space-1: 0.25rem;


### PR DESCRIPTION
## Summary
- document the refreshed Telcoin palette sampled from telcoin.network
- update design tokens, gradients, and surfaces to use the new brand blues and neutrals
- align global/brand styles (search highlights, chips, footer, hero) with the live marketing look

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2d4e310388330a33bd65143ac6ce6