### PR TITLE
Ensure hero typing loop fits longest phrase

### DIFF
--- a/telcoinwiki-react/src/components/home/HeroTypingLoop.tsx
+++ b/telcoinwiki-react/src/components/home/HeroTypingLoop.tsx
@@ -3,6 +3,8 @@ import { useEffect, useState } from 'react'
 
 const phrases = ['Community Q&A', 'Guides', 'Links']
 
+const longestPhraseLength = Math.max(...phrases.map((phrase) => phrase.length))
+
 const typingVariants = {
   initial: { opacity: 0, y: 6 },
   animate: { opacity: 1, y: 0 },
@@ -23,7 +25,10 @@ export function HeroTypingLoop() {
   return (
     <div className="flex items-center gap-2 text-base font-semibold text-telcoin-ink">
       <span className="text-telcoin-ink-subtle">Community Q&amp;A →</span>
-      <div className="relative h-6 min-w-[6ch] overflow-hidden">
+      <div
+        className="relative h-6 overflow-hidden"
+        style={{ minWidth: `${longestPhraseLength}ch` }}
+      >
         <AnimatePresence initial={false} mode="wait">
           <motion.span
             key={phrases[index]}


### PR DESCRIPTION
## Summary
- compute the longest hero typing phrase and use it to set the container's minimum width
- keep the overflow-hidden wrapper while allowing it to expand so animated text never clips

## Testing
- Ran Playwright-driven preview at desktop and mobile breakpoints to confirm hero eyebrow visibility

------
https://chatgpt.com/codex/tasks/task_e_68e327bd07448330b6de79c219340821