### PR TITLE
Animate header gradient and top nav pill interactions

### DIFF
--- a/telcoinwiki-react/src/styles/brand.css
+++ b/telcoinwiki-react/src/styles/brand.css
@@ -49,9 +49,42 @@ body {
   position: sticky;
   top: 0;
   z-index: 100;
-  background: rgba(5, 11, 31, 0.9);
+  background:
+    linear-gradient(
+      135deg,
+      rgba(52, 143, 235, 0.24) 0%,
+      rgba(128, 82, 227, 0.22) 48%,
+      rgba(52, 143, 235, 0.24) 100%
+    ),
+    rgba(5, 11, 31, 0.88);
+  background-size: 220% 220%, auto;
+  background-position: 0% 50%, center;
   backdrop-filter: blur(18px);
   border-bottom: 1px solid var(--tc-border);
+}
+
+@keyframes headerPulse {
+  0% {
+    background-position: 0% 50%, center;
+  }
+  50% {
+    background-position: 100% 50%, center;
+  }
+  100% {
+    background-position: 0% 50%, center;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .site-header {
+    animation: headerPulse 24s ease-in-out infinite;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .site-header {
+    background-position: 50% 50%, center;
+  }
 }
 .site-header__inner {
   display: flex;
@@ -98,6 +131,129 @@ img.site-logo {
 }
 .pill-nav > li {
   list-style: none;
+}
+
+@keyframes pillEntrance {
+  0% {
+    opacity: 0;
+    transform: translateY(12px) scale(0.94);
+  }
+  60% {
+    opacity: 1;
+    transform: translateY(-2px) scale(1.02);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+:where(.pill-nav, .top-nav__list) > li {
+  --pill-stagger: 0s;
+}
+
+:where(.pill-nav, .top-nav__list) > li:nth-child(2) { --pill-stagger: .05s; }
+:where(.pill-nav, .top-nav__list) > li:nth-child(3) { --pill-stagger: .1s; }
+:where(.pill-nav, .top-nav__list) > li:nth-child(4) { --pill-stagger: .15s; }
+:where(.pill-nav, .top-nav__list) > li:nth-child(5) { --pill-stagger: .2s; }
+:where(.pill-nav, .top-nav__list) > li:nth-child(6) { --pill-stagger: .25s; }
+:where(.pill-nav, .top-nav__list) > li:nth-child(7) { --pill-stagger: .3s; }
+:where(.pill-nav, .top-nav__list) > li:nth-child(8) { --pill-stagger: .35s; }
+:where(.pill-nav, .top-nav__list) > li:nth-child(9) { --pill-stagger: .4s; }
+:where(.pill-nav, .top-nav__list) > li:nth-child(10) { --pill-stagger: .45s; }
+:where(.pill-nav, .top-nav__list) > li:nth-child(11) { --pill-stagger: .5s; }
+:where(.pill-nav, .top-nav__list) > li:nth-child(12) { --pill-stagger: .55s; }
+
+.top-nav__link {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.65rem 1rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(124, 200, 255, 0.18);
+  background-color: var(--color-surface-alt, rgba(12, 26, 58, 0.92));
+  background-image: linear-gradient(145deg, rgba(124, 200, 255, 0.16), rgba(124, 200, 255, 0.05));
+  background-size: 220% 220%;
+  background-position: 0% 50%;
+  color: var(--tc-ink, #f5f7ff);
+  font-weight: 600;
+  white-space: nowrap;
+  text-decoration: none;
+  transform: translateY(0) scale(1);
+  transition:
+    transform 0.45s cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 0.45s cubic-bezier(0.16, 1, 0.3, 1),
+    background-color 0.35s ease,
+    background-position 0.45s ease,
+    background-image 0.35s ease,
+    border-color 0.35s ease,
+    color 0.25s ease;
+  box-shadow:
+    inset 0 0 0 1px rgba(124, 200, 255, 0.08),
+    0 1px 2px rgba(4, 10, 24, 0.65);
+  isolation: isolate;
+  animation: pillEntrance 0.6s cubic-bezier(0.33, 1, 0.68, 1) both;
+  animation-delay: var(--pill-stagger, 0s);
+}
+
+.top-nav__link::before {
+  content: "";
+  position: absolute;
+  inset: -35%;
+  background: radial-gradient(
+    circle at center,
+    rgba(124, 200, 255, 0.35),
+    rgba(124, 200, 255, 0)
+  );
+  opacity: 0;
+  transform: scale(0.75);
+  transition: opacity 0.45s ease, transform 0.45s ease;
+  z-index: -1;
+}
+
+.top-nav__link:hover,
+.top-nav__link:focus-visible {
+  color: var(--tc-ink, #f5f7ff);
+  border-color: rgba(124, 200, 255, 0.4);
+  background-color: var(--color-surface, rgba(16, 30, 64, 0.96));
+  background-image: linear-gradient(140deg, rgba(124, 200, 255, 0.32), rgba(124, 200, 255, 0.12));
+  background-position: 100% 50%;
+  transform: translateY(-2px) scale(1.04);
+  box-shadow:
+    0 14px 30px -16px rgba(124, 200, 255, 0.7),
+    0 0 0 1px rgba(124, 200, 255, 0.38);
+}
+
+.top-nav__link:hover::before,
+.top-nav__link:focus-visible::before,
+.top-nav__link.is-active::before {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.top-nav__link:focus-visible {
+  outline: none;
+}
+
+.top-nav__link.is-active {
+  color: var(--tc-ink, #f5f7ff);
+  border-color: rgba(124, 200, 255, 0.36);
+  background-color: var(--color-surface, rgba(16, 30, 64, 0.96));
+  background-image: linear-gradient(140deg, rgba(124, 200, 255, 0.28), rgba(124, 200, 255, 0.1));
+  background-position: 80% 50%;
+  box-shadow:
+    0 10px 26px -18px rgba(124, 200, 255, 0.65),
+    0 0 0 1px rgba(124, 200, 255, 0.34);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .top-nav__link {
+    animation: none;
+  }
+  :where(.pill-nav, .top-nav__list) > li {
+    --pill-stagger: 0s !important;
+  }
 }
 
 /* Menu button for mobile */


### PR DESCRIPTION
## Summary
- animate the sticky header background with a pulsing gradient that respects reduced motion preferences
- enhance top navigation pills with staggered entrance, hover glow, and focus treatments while retaining overflow scrolling support

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e327c1abec8330b86dd87dba90523a