### PR TITLE
Add glassmorphism styling for sidebar navigation

### DIFF
--- a/telcoinwiki-react/src/components/layout/Sidebar.tsx
+++ b/telcoinwiki-react/src/components/layout/Sidebar.tsx
@@ -41,7 +41,9 @@ export function Sidebar({
                     }
                     to={item.href}
                   >
-                    {item.label}
+                    <span className="sidebar__linkInner">
+                      <span className="sidebar__linkLabel">{item.label}</span>
+                    </span>
                   </NavLink>
                   {isActive && headings.length > 0 ? (
                     <ul

--- a/telcoinwiki-react/src/styles/brand.css
+++ b/telcoinwiki-react/src/styles/brand.css
@@ -326,6 +326,58 @@ img.site-logo {
 .sidebar__inner.tc-card {
   border-radius: 1rem;
   padding: var(--gap-4);
+  background:
+    linear-gradient(135deg, rgba(124, 200, 255, 0.18), rgba(124, 200, 255, 0.06))
+      rgba(8, 15, 38, 0.75);
+  border: 1px solid rgba(124, 200, 255, 0.28);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 18px 48px rgba(5, 11, 31, 0.35);
+}
+
+.sidebar__inner.tc-card::before {
+  opacity: 0.75;
+}
+
+.sidebar__link {
+  background-color: rgba(6, 12, 32, 0.35);
+}
+
+.sidebar__link::before {
+  background:
+    linear-gradient(145deg, rgba(124, 200, 255, 0.28), rgba(128, 82, 227, 0.16));
+  box-shadow:
+    0 0 0 1px rgba(124, 200, 255, 0.28),
+    0 18px 38px rgba(6, 12, 32, 0.3);
+}
+
+.sidebar__link.is-active::before {
+  background:
+    linear-gradient(145deg, rgba(124, 200, 255, 0.35), rgba(128, 82, 227, 0.24));
+}
+
+.sidebar__linkLabel {
+  color: rgba(240, 245, 255, 0.9);
+}
+
+.sidebar__link:hover .sidebar__linkLabel,
+.sidebar__link:focus-visible .sidebar__linkLabel,
+.sidebar__link.is-active .sidebar__linkLabel {
+  color: #fff;
+}
+
+@media (max-width: 768px) {
+  .sidebar__inner.tc-card {
+    padding: clamp(var(--gap-3), 4vw, var(--gap-4));
+  }
+
+  .sidebar__inner.tc-card::before {
+    opacity: 0.55;
+  }
+
+  .sidebar__link::before {
+    box-shadow: 0 8px 18px rgba(5, 11, 31, 0.25);
+  }
 }
 
 /* Remove accidental “pill” backgrounds on headings on mobile */

--- a/telcoinwiki-react/src/styles/site.css
+++ b/telcoinwiki-react/src/styles/site.css
@@ -437,8 +437,30 @@ pre {
   top: calc(var(--header-height) + 1rem);
   padding: 1.5rem;
   border-radius: var(--radius-card);
+  background:
+    linear-gradient(135deg, rgba(124, 200, 255, 0.14), rgba(124, 200, 255, 0.04))
+      rgba(12, 26, 58, 0.65);
+  border: 1px solid rgba(124, 200, 255, 0.18);
   backdrop-filter: blur(24px);
   -webkit-backdrop-filter: blur(24px);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.05),
+    0 12px 32px rgba(5, 11, 31, 0.22);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.sidebar__inner::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(120% 120% at 0% 0%, rgba(124, 200, 255, 0.22), transparent 55%),
+    radial-gradient(110% 110% at 100% 0%, rgba(128, 82, 227, 0.18), transparent 58%),
+    radial-gradient(150% 150% at 50% 100%, rgba(52, 143, 235, 0.16), transparent 65%);
+  opacity: 0.9;
+  pointer-events: none;
+  mix-blend-mode: screen;
 }
 
 .sidebar__heading {
@@ -461,28 +483,123 @@ pre {
 }
 
 .sidebar__link {
+  position: relative;
+  display: block;
+  border-radius: calc(var(--radius-card) + 4px);
+  padding: var(--space-2) calc(var(--space-3) - 2px);
+  color: var(--tc-ink-muted);
+  border: 1px solid transparent;
+  isolation: isolate;
+  outline: none;
+  text-decoration: none;
+}
+
+.sidebar__link::before {
+  content: '';
+  position: absolute;
+  inset: 1px;
+  border-radius: calc(var(--radius-card) + 2px);
+  background:
+    linear-gradient(135deg, rgba(124, 200, 255, 0.22), rgba(52, 143, 235, 0.08));
+  opacity: 0;
+  transform: scale(0.98);
+  transition:
+    opacity var(--transition-base),
+    transform var(--transition-base);
+  pointer-events: none;
+  box-shadow:
+    0 0 0 1px rgba(124, 200, 255, 0.18),
+    0 12px 32px rgba(5, 11, 31, 0.18);
+}
+
+.sidebar__linkInner {
+  position: relative;
+  z-index: 1;
   display: flex;
   align-items: center;
   gap: var(--space-2);
   border-radius: var(--radius-card);
   padding: var(--space-2) var(--space-3);
-  color: var(--tc-ink-muted);
-  border: 1px solid transparent;
-  transition: background var(--transition-base), color var(--transition-base), border-color var(--transition-base);
+}
+
+.sidebar__linkLabel {
+  flex: 1 1 auto;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+  transition: color var(--transition-base);
 }
 
 .sidebar__link:hover,
 .sidebar__link:focus-visible {
   color: var(--tc-ink);
-  border-color: var(--tc-border);
-  background: var(--tc-surface-2);
+  border-color: rgba(124, 200, 255, 0.4);
   text-decoration: none;
+}
+
+.sidebar__link:hover::before,
+.sidebar__link:focus-visible::before {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.sidebar__link:focus-visible {
+  box-shadow: 0 0 0 2px rgba(124, 200, 255, 0.45);
 }
 
 .sidebar__link.is-active {
   color: var(--tc-ink);
-  border-color: var(--tc-border-strong);
-  background: var(--tc-surface-2);
+  border-color: rgba(124, 200, 255, 0.6);
+}
+
+.sidebar__link.is-active::before {
+  opacity: 1;
+  transform: scale(1);
+  background:
+    linear-gradient(135deg, rgba(124, 200, 255, 0.3), rgba(52, 143, 235, 0.18));
+}
+
+.sidebar__link.is-active .sidebar__linkLabel {
+  color: inherit;
+  font-weight: 600;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .sidebar__link,
+  .sidebar__link::before {
+    transition-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  .sidebar__link {
+    transition:
+      border-color var(--transition-base),
+      color var(--transition-base),
+      box-shadow var(--transition-base);
+  }
+
+  .sidebar__linkLabel {
+    transition:
+      color var(--transition-base),
+      font-size 320ms cubic-bezier(0.16, 1, 0.3, 1),
+      letter-spacing 320ms cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  .sidebar__link:hover .sidebar__linkLabel,
+  .sidebar__link:focus-visible .sidebar__linkLabel {
+    font-size: 0.99rem;
+    letter-spacing: 0.03em;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidebar__link,
+  .sidebar__link::before,
+  .sidebar__linkLabel {
+    transition: none;
+  }
+
+  .sidebar__link::before {
+    transform: none;
+  }
 }
 
 .sidebar__sublist {


### PR DESCRIPTION
## Summary
- wrap sidebar navigation labels with inner span hooks for richer state styling
- layer glassmorphism gradients and glowing overlays onto the sidebar card and link states
- add motion-aware typography transitions while preserving high-contrast focus affordances

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3384dba688330918120182ca48465