### PR TITLE
Refine header layout grouping

### DIFF
--- a/telcoinwiki-react/src/components/layout/Header.tsx
+++ b/telcoinwiki-react/src/components/layout/Header.tsx
@@ -80,81 +80,83 @@ export function Header({
           />
         </Link>
 
-        <nav className="top-nav" aria-label="Primary">
-          <ul className="pill-nav top-nav__list" ref={navListRef}>
-            {navItems.map((item) => {
-              const isMenuActive = item.id === activeNavId;
-              const isOpen = openMenuId === item.id;
-              if (!item.menu || item.menu.length === 0) {
-                return (
-                  <li key={item.id} className="nav-item">
-                    <NavLink
-                      className={({ isActive }) =>
-                        `top-nav__link${isActive ? ' is-active' : ''}`
-                      }
-                      to={item.href}
-                      onClick={closeMenus}
-                    >
-                      {item.label}
-                    </NavLink>
-                  </li>
-                );
-              }
-
-              return (
-                <li
-                  key={item.id}
-                  className="nav-item"
-                  data-open={isOpen ? 'true' : undefined}
-                >
-                  <button
-                    type="button"
-                    className={`nav-button${isMenuActive ? ' is-active' : ''}`}
-                    aria-haspopup="true"
-                    aria-expanded={isOpen}
-                    onClick={() => toggleMenu(item.id)}
-                  >
-                    {item.label} <span className="nav-caret">▾</span>
-                  </button>
-                  <div className="nav-menu" role="menu">
-                    {item.menu.map((entry) => (
-                      <Link
-                        key={entry.href}
-                        to={entry.href}
-                        role="menuitem"
-                        onClick={closeMenus}
-                      >
-                        {entry.label}
-                      </Link>
-                    ))}
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        </nav>
-
-        <button
-          type="button"
-          className="menu-btn"
-          data-sidebar-toggle
-          aria-expanded={mobileNavOpen}
-          aria-controls="mobile-drawer"
-          onClick={toggleMobileNav}
-        >
-          Menu
-        </button>
-
-        <div className="header-search">
+        <div className="site-header__actions">
           <button
             type="button"
-            className="search-trigger"
-            onClick={onSearchOpen}
-            aria-haspopup="dialog"
-            aria-expanded={isSearchOpen}
+            className="menu-btn"
+            data-sidebar-toggle
+            aria-expanded={mobileNavOpen}
+            aria-controls="mobile-drawer"
+            onClick={toggleMobileNav}
           >
-            Search
+            Menu
           </button>
+
+          <div className="header-search">
+            <button
+              type="button"
+              className="search-trigger"
+              onClick={onSearchOpen}
+              aria-haspopup="dialog"
+              aria-expanded={isSearchOpen}
+            >
+              Search
+            </button>
+          </div>
+
+          <nav className="top-nav" aria-label="Primary">
+            <ul className="pill-nav top-nav__list" ref={navListRef}>
+              {navItems.map((item) => {
+                const isMenuActive = item.id === activeNavId;
+                const isOpen = openMenuId === item.id;
+                if (!item.menu || item.menu.length === 0) {
+                  return (
+                    <li key={item.id} className="nav-item">
+                      <NavLink
+                        className={({ isActive }) =>
+                          `top-nav__link${isActive ? ' is-active' : ''}`
+                        }
+                        to={item.href}
+                        onClick={closeMenus}
+                      >
+                        {item.label}
+                      </NavLink>
+                    </li>
+                  );
+                }
+
+                return (
+                  <li
+                    key={item.id}
+                    className="nav-item"
+                    data-open={isOpen ? 'true' : undefined}
+                  >
+                    <button
+                      type="button"
+                      className={`nav-button${isMenuActive ? ' is-active' : ''}`}
+                      aria-haspopup="true"
+                      aria-expanded={isOpen}
+                      onClick={() => toggleMenu(item.id)}
+                    >
+                      {item.label} <span className="nav-caret">▾</span>
+                    </button>
+                    <div className="nav-menu" role="menu">
+                      {item.menu.map((entry) => (
+                        <Link
+                          key={entry.href}
+                          to={entry.href}
+                          role="menuitem"
+                          onClick={closeMenus}
+                        >
+                          {entry.label}
+                        </Link>
+                      ))}
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </nav>
         </div>
       </div>
 

--- a/telcoinwiki-react/src/styles/brand.css
+++ b/telcoinwiki-react/src/styles/brand.css
@@ -61,6 +61,8 @@ body {
   background-position: 0% 50%, center;
   backdrop-filter: blur(18px);
   border-bottom: 1px solid var(--tc-border);
+  --header-action-height: clamp(2.375rem, 3vw, 2.75rem);
+  --header-pill-min-width: clamp(7.5rem, 11vw, 9.5rem);
 }
 
 @keyframes headerPulse {
@@ -90,6 +92,7 @@ body {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+  justify-content: space-between;
   gap: clamp(12px, 2vw, 28px);
   padding-block: var(--header-pad-y);
 }
@@ -116,7 +119,20 @@ img.site-logo {
 }
 
 /* Nav pills (desktop) */
-.top-nav { order: 2; flex: 1 1 auto; min-width: 320px; }
+.site-header__actions {
+  margin-left: auto;
+  display: flex;
+  flex: 1 1 auto;
+  align-items: center;
+  justify-content: flex-end;
+  gap: clamp(12px, 2vw, 24px);
+  min-width: 0;
+}
+
+.top-nav {
+  flex: 0 1 auto;
+  min-width: 320px;
+}
 .pill-nav {
   display: flex;
   flex-wrap: wrap;
@@ -168,8 +184,11 @@ img.site-logo {
   position: relative;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 0.35rem;
-  padding: 0.65rem 1rem;
+  min-height: var(--header-action-height);
+  min-width: var(--header-pill-min-width);
+  padding: 0 var(--gap-5);
   border-radius: 9999px;
   border: 1px solid rgba(124, 200, 255, 0.18);
   background-color: var(--color-surface-alt, rgba(12, 26, 58, 0.92));
@@ -257,16 +276,41 @@ img.site-logo {
 }
 
 /* Menu button for mobile */
-.menu-btn { order: 3; display: none; align-items: center; justify-content: center; height: 40px; padding: 0 1rem; border-radius: 999px; background: var(--tc-surface); border: 1px solid var(--tc-border); color: var(--tc-ink); font-weight: 600; }
-@media (max-width: 960px) { .menu-btn { display: inline-flex; } .top-nav { display: none; } }
+.menu-btn {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  min-height: var(--header-action-height);
+  min-width: var(--header-pill-min-width);
+  padding: 0 var(--gap-5);
+  border-radius: 999px;
+  background: var(--tc-surface);
+  border: 1px solid var(--tc-border);
+  color: var(--tc-ink);
+  font-weight: 600;
+}
+
+@media (max-width: 960px) {
+  .menu-btn {
+    display: inline-flex;
+  }
+
+  .top-nav {
+    display: none;
+  }
+
+  .site-header__actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
 
 /* Search */
 .header-search {
-  order: 4;
-  flex: 1 0 280px;
   display: flex;
   align-items: center;
-  min-width: clamp(200px, 45vw, 320px);
+  flex: 1 1 clamp(200px, 35vw, 320px);
+  min-width: clamp(180px, 35vw, 280px);
 }
 .search-input {
   width: 100%;

--- a/telcoinwiki-react/src/styles/critical.css
+++ b/telcoinwiki-react/src/styles/critical.css
@@ -152,6 +152,8 @@ ol {
   -webkit-backdrop-filter: blur(24px);
   border-bottom: 1px solid var(--tc-border);
   box-shadow: var(--shadow-glass);
+  --header-action-height: 2.5rem;
+  --header-pill-min-width: 8.5rem;
 }
 
 .site-header__inner {
@@ -161,6 +163,7 @@ ol {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+  justify-content: space-between;
   gap: 0.75rem;
 }
 
@@ -201,7 +204,8 @@ ol {
 
 .top-nav {
   display: none;
-  flex: 1 1 auto;
+  flex: 0 1 auto;
+  min-width: 20rem;
 }
 
 .top-nav__list {
@@ -216,7 +220,10 @@ ol {
 .top-nav__link {
   display: inline-flex;
   align-items: center;
-  padding: 0.625rem 0.875rem;
+  justify-content: center;
+  min-height: var(--header-action-height);
+  min-width: var(--header-pill-min-width);
+  padding: 0 var(--space-4);
   border-radius: var(--radius-pill);
   border: 1px solid var(--tc-border);
   background: var(--tc-surface);
@@ -244,8 +251,11 @@ ol {
 .site-header__actions {
   margin-left: auto;
   display: flex;
+  flex: 1 1 auto;
   align-items: center;
-  gap: 1rem;
+  justify-content: flex-end;
+  gap: var(--space-4);
+  min-width: 0;
 }
 
 .last-updated {
@@ -255,10 +265,11 @@ ol {
 
 .header-search {
   position: relative;
-  flex: 0 1 auto;
   display: flex;
   align-items: center;
   justify-content: flex-end;
+  flex: 1 1 clamp(12.5rem, 35vw, 20rem);
+  min-width: clamp(11rem, 35vw, 18rem);
 }
 
 .tc-tabbar {
@@ -298,7 +309,7 @@ ol {
 }
 
 .header-search {
-  width: clamp(14rem, 36vw, 20rem);
+  width: min(100%, clamp(14rem, 36vw, 20rem));
 }
 
 @media (max-width: 959px) {


### PR DESCRIPTION
## Summary
- group the header menu toggle, search trigger, and primary nav inside a shared actions container so the cluster can flex as a unit
- adjust brand and critical styles to right-align the action group and standardize pill dimensions with shared header tokens
- ensure responsive behavior remains intact by syncing breakpoint handling for the menu button and search width

## Testing
- npm run lint
- Manual verification of header layout across desktop and sub-960px widths, including menu toggle visibility and focus order

------
https://chatgpt.com/codex/tasks/task_e_68e3384c1afc8330855fe07cb946cfff