### PR TITLE
Adjust hero floating chips layout and update home hero notice

### DIFF
--- a/telcoinwiki-react/src/components/home/HeroFloatingChips.tsx
+++ b/telcoinwiki-react/src/components/home/HeroFloatingChips.tsx
@@ -3,31 +3,22 @@ import { useEffect, useState } from 'react'
 
 const chips = [
   {
-    id: 'wallet-security',
-    label: 'Wallet security',
-    accent: 'from-telcoin-accent-soft to-transparent',
-    border: 'border-telcoin-accent-outline',
-    top: '5%',
-    left: '8%',
-    multiplier: 0.6,
-  },
-  {
     id: 'liquidity',
     label: 'TELx liquidity',
     accent: 'from-telcoin-royalTone-soft to-transparent',
     border: 'border-telcoin-royalTone-outline',
-    top: '30%',
-    left: '75%',
-    multiplier: -0.4,
+    top: '22%',
+    left: '68%',
+    multiplier: -0.5,
   },
   {
     id: 'remittance',
     label: 'Remittance corridors',
     accent: 'from-telcoin-accent-soft via-transparent to-transparent',
     border: 'border-telcoin-border',
-    top: '65%',
-    left: '15%',
-    multiplier: 0.8,
+    top: '64%',
+    left: '18%',
+    multiplier: 0.7,
   },
 ]
 
@@ -41,8 +32,8 @@ export function HeroFloatingChips() {
 
   useEffect(() => {
     const handlePointerMove = (event: PointerEvent) => {
-      const x = (event.clientX / window.innerWidth - 0.5) * 16
-      const y = (event.clientY / window.innerHeight - 0.5) * 16
+      const x = (event.clientX / window.innerWidth - 0.5) * 12
+      const y = (event.clientY / window.innerHeight - 0.5) * 12
       setOffset({ x, y })
     }
 

--- a/telcoinwiki-react/src/pages/HomePage.tsx
+++ b/telcoinwiki-react/src/pages/HomePage.tsx
@@ -24,14 +24,11 @@ export function HomePage() {
         title="Understand the Telcoin platform in minutes"
         lede="This unofficial wiki curates verified answers, onboarding checklists, and direct links to Telcoin Association and Telcoin company resources so newcomers can get started with confidence."
       >
-        <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-4 lg:gap-6">
           <HeroTicker />
-          <div className="notice notice--info" role="note">
-            <p className="notice__title">Unofficial helper</p>
-            <p>
-              Always confirm details inside the Telcoin Wallet or through official Association releases. The community keeps this wiki current, but the authoritative word lives at telco.in and telcoinassociation.org.
-            </p>
-          </div>
+          <p className="text-sm text-telcoin-ink/70">
+            Community-maintained reference. Confirm details inside the Telcoin Wallet or official Association releases.
+          </p>
         </div>
       </PageIntro>
 


### PR DESCRIPTION
## Summary
- remove the wallet security floating chip and rebalance the remaining hero chip positioning and animation offsets
- soften the hero pointer parallax effect to match the reduced chip count
- replace the hero notice block with a lightweight inline reminder beneath the ticker

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3384cb68c8330ad68b943eb9d4fb8