### PR TITLE
Standardize hero intros across pages

### DIFF
--- a/telcoinwiki-react/src/components/content/HeroOverlay.tsx
+++ b/telcoinwiki-react/src/components/content/HeroOverlay.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react'
+
+interface HeroOverlayProps {
+  children?: ReactNode
+}
+
+export function HeroOverlay({ children }: HeroOverlayProps) {
+  return (
+    <>
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,var(--tc-blue-sky)_0%,transparent_65%)] opacity-80" />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom_right,rgba(85,51,255,0.3)_0%,transparent_70%)] mix-blend-screen" />
+      {children}
+    </>
+  )
+}

--- a/telcoinwiki-react/src/components/wallet/TelPriceChartPanel.tsx
+++ b/telcoinwiki-react/src/components/wallet/TelPriceChartPanel.tsx
@@ -8,7 +8,7 @@ function formatCurrency(value: number, currency: string) {
       currency: currency.toUpperCase(),
       maximumFractionDigits: value < 1 ? 4 : 2,
     }).format(value)
-  } catch (error) {
+  } catch {
     return `$${value.toFixed(value < 1 ? 4 : 2)}`
   }
 }

--- a/telcoinwiki-react/src/components/wallet/TelxLiquidityPanel.tsx
+++ b/telcoinwiki-react/src/components/wallet/TelxLiquidityPanel.tsx
@@ -7,7 +7,7 @@ function formatUsd(value: number | null) {
   }
   try {
     return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(value)
-  } catch (error) {
+  } catch {
     return `$${value.toFixed(0)}`
   }
 }

--- a/telcoinwiki-react/src/pages/AboutPage.tsx
+++ b/telcoinwiki-react/src/pages/AboutPage.tsx
@@ -1,3 +1,4 @@
+import { HeroOverlay } from '../components/content/HeroOverlay'
 import { PageIntro } from '../components/content/PageIntro'
 import { SourceBox } from '../components/content/SourceBox'
 
@@ -6,6 +7,9 @@ export function AboutPage() {
     <>
       <PageIntro
         id="about-mission"
+        variant="hero"
+        className="bg-hero-linear animate-gradient [background-size:180%_180%]"
+        overlay={<HeroOverlay />}
         eyebrow="About"
         title="Why this wiki exists"
         lede="Telcoin Wiki is a community project that collects concise answers and official links so newcomers can find trustworthy information without wading through social media threads."

--- a/telcoinwiki-react/src/pages/BuildersPage.tsx
+++ b/telcoinwiki-react/src/pages/BuildersPage.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 import { CardGrid } from '../components/content/CardGrid'
 import { ContextBox } from '../components/content/ContextBox'
+import { HeroOverlay } from '../components/content/HeroOverlay'
 import { PageIntro } from '../components/content/PageIntro'
 import { SourceBox } from '../components/content/SourceBox'
 
@@ -9,6 +10,9 @@ export function BuildersPage() {
     <>
       <PageIntro
         id="builders-overview"
+        variant="hero"
+        className="bg-hero-linear animate-gradient [background-size:180%_180%]"
+        overlay={<HeroOverlay />}
         eyebrow="Builders"
         title="Resources for Telcoin contributors"
         lede="Whether you monitor TELx pools, experiment with dashboards, or contribute research, this page surfaces the core tools and official touchpoints for building with Telcoin."

--- a/telcoinwiki-react/src/pages/DeepDivePage.tsx
+++ b/telcoinwiki-react/src/pages/DeepDivePage.tsx
@@ -1,13 +1,18 @@
+import { HeroOverlay } from '../components/content/HeroOverlay'
+import { PageIntro } from '../components/content/PageIntro'
+
 export function DeepDivePage() {
   return (
     <>
-      <section className="page-intro tc-card">
-        <p className="page-intro__eyebrow">Deep-Dive</p>
-        <h1 className="page-intro__title">Learn Telcoin by Pathway</h1>
-        <p className="page-intro__lede">
-          Explore the Telcoin ecosystem by topic. Each section expands into concise answers and background that tie into the
-          app, the network, and the bank.
-        </p>
+      <PageIntro
+        id="deep-dive-overview"
+        variant="hero"
+        className="bg-hero-linear animate-gradient [background-size:180%_180%]"
+        overlay={<HeroOverlay />}
+        eyebrow="Deep-Dive"
+        title="Learn Telcoin by Pathway"
+        lede="Explore the Telcoin ecosystem by topic. Each section expands into concise answers and background that tie into the app, the network, and the bank."
+      >
         <nav className="toc-chips" aria-label="Deep-Dive sections">
           <a className="toc-chip" href="#deep-network">
             Telcoin Network
@@ -25,7 +30,7 @@ export function DeepDivePage() {
             Telcoin Holdings
           </a>
         </nav>
-      </section>
+      </PageIntro>
 
       <section id="deep-network" className="dd-section">
         <h2>Telcoin Network</h2>

--- a/telcoinwiki-react/src/pages/DigitalCashPage.tsx
+++ b/telcoinwiki-react/src/pages/DigitalCashPage.tsx
@@ -1,4 +1,5 @@
 import { CardGrid } from '../components/content/CardGrid'
+import { HeroOverlay } from '../components/content/HeroOverlay'
 import { PageIntro } from '../components/content/PageIntro'
 import { SourceBox } from '../components/content/SourceBox'
 
@@ -7,6 +8,9 @@ export function DigitalCashPage() {
     <>
       <PageIntro
         id="digital-cash-overview"
+        variant="hero"
+        className="bg-hero-linear animate-gradient [background-size:180%_180%]"
+        overlay={<HeroOverlay />}
         eyebrow="Digital Cash"
         title="Instant-settlement fiat on the Telcoin Network"
         lede="Digital Cash brings fiat-backed currencies like eUSD, eCAD, and ePHP directly into the Telcoin Wallet. Each asset is designed to settle in seconds on the Telcoin Network while preserving the compliance expectations of its underlying fiat."

--- a/telcoinwiki-react/src/pages/FaqPage.tsx
+++ b/telcoinwiki-react/src/pages/FaqPage.tsx
@@ -1,4 +1,5 @@
 import { FaqExplorer } from '../components/content/FaqExplorer'
+import { HeroOverlay } from '../components/content/HeroOverlay'
 import { PageIntro } from '../components/content/PageIntro'
 import { SourceBox } from '../components/content/SourceBox'
 import { SEARCH_CONFIG } from '../config/search'
@@ -8,6 +9,9 @@ export function FaqPage() {
     <>
       <PageIntro
         id="faq-hero"
+        variant="hero"
+        className="bg-hero-linear animate-gradient [background-size:180%_180%]"
+        overlay={<HeroOverlay />}
         eyebrow="FAQ"
         title="Filterable Telcoin FAQ"
         lede="Search by keyword or filter by topic to find trusted answers. Every entry links back to Telcoin Association or Telcoin product resources for verification."

--- a/telcoinwiki-react/src/pages/GovernancePage.tsx
+++ b/telcoinwiki-react/src/pages/GovernancePage.tsx
@@ -1,4 +1,5 @@
 import { CardGrid } from '../components/content/CardGrid'
+import { HeroOverlay } from '../components/content/HeroOverlay'
 import { PageIntro } from '../components/content/PageIntro'
 import { SourceBox } from '../components/content/SourceBox'
 
@@ -7,6 +8,9 @@ export function GovernancePage() {
     <>
       <PageIntro
         id="governance-overview"
+        variant="hero"
+        className="bg-hero-linear animate-gradient [background-size:180%_180%]"
+        overlay={<HeroOverlay />}
         eyebrow="Governance & Association"
         title="Who stewards Telcoin?"
         lede="The Telcoin Association, a Swiss Verein, leads Telcoin Network governance, validator onboarding, and issuance policies for TEL and Digital Cash. Community councils partner with the Association to review and advance proposals."

--- a/telcoinwiki-react/src/pages/HomePage.tsx
+++ b/telcoinwiki-react/src/pages/HomePage.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom'
 import { FaqExplorer } from '../components/content/FaqExplorer'
+import { HeroOverlay } from '../components/content/HeroOverlay'
 import { PageIntro } from '../components/content/PageIntro'
 import { HeroFloatingChips } from '../components/home/HeroFloatingChips'
 import { HeroTicker } from '../components/home/HeroTicker'
@@ -14,11 +15,9 @@ export function HomePage() {
         variant="hero"
         className="bg-hero-linear animate-gradient [background-size:180%_180%]"
         overlay={
-          <>
-            <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,var(--tc-blue-sky)_0%,transparent_65%)] opacity-80" />
-            <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom_right,rgba(85,51,255,0.3)_0%,transparent_70%)] mix-blend-screen" />
+          <HeroOverlay>
             <HeroFloatingChips />
-          </>
+          </HeroOverlay>
         }
         eyebrow={<HeroTypingLoop />}
         title="Understand the Telcoin platform in minutes"

--- a/telcoinwiki-react/src/pages/LinksPage.tsx
+++ b/telcoinwiki-react/src/pages/LinksPage.tsx
@@ -1,4 +1,5 @@
 import { CardGrid } from '../components/content/CardGrid'
+import { HeroOverlay } from '../components/content/HeroOverlay'
 import { PageIntro } from '../components/content/PageIntro'
 import { SourceBox } from '../components/content/SourceBox'
 
@@ -7,6 +8,9 @@ export function LinksPage() {
     <>
       <PageIntro
         id="links-overview"
+        variant="hero"
+        className="bg-hero-linear animate-gradient [background-size:180%_180%]"
+        overlay={<HeroOverlay />}
         eyebrow="Official links"
         title="Verified Telcoin destinations"
         lede="Bookmark these official Telcoin channels for product information, governance updates, status notifications, legal notices, and security alerts."

--- a/telcoinwiki-react/src/pages/NetworkPage.tsx
+++ b/telcoinwiki-react/src/pages/NetworkPage.tsx
@@ -1,4 +1,5 @@
 import { CardGrid } from '../components/content/CardGrid'
+import { HeroOverlay } from '../components/content/HeroOverlay'
 import { PageIntro } from '../components/content/PageIntro'
 import { SourceBox } from '../components/content/SourceBox'
 
@@ -7,6 +8,9 @@ export function NetworkPage() {
     <>
       <PageIntro
         id="network-overview"
+        variant="hero"
+        className="bg-hero-linear animate-gradient [background-size:180%_180%]"
+        overlay={<HeroOverlay />}
         eyebrow="Telcoin Network"
         title="Carrier-secured, EVM compatible"
         lede="The Telcoin Network is an EVM chain whose validators are GSMA-member mobile network operators. It connects remittances, Digital Cash, TEL staking, and TELx liquidity under a compliance-first governance model."

--- a/telcoinwiki-react/src/pages/PoolsPage.tsx
+++ b/telcoinwiki-react/src/pages/PoolsPage.tsx
@@ -1,5 +1,6 @@
 import { PageIntro } from '../components/content/PageIntro'
 import { ContextBox } from '../components/content/ContextBox'
+import { HeroOverlay } from '../components/content/HeroOverlay'
 import { TelxPoolsTable } from '../components/content/TelxPoolsTable'
 import { SourceBox } from '../components/content/SourceBox'
 
@@ -8,6 +9,9 @@ export function PoolsPage() {
     <>
       <PageIntro
         id="pools-overview"
+        variant="hero"
+        className="bg-hero-linear animate-gradient [background-size:180%_180%]"
+        overlay={<HeroOverlay />}
         eyebrow="TELx Pools"
         title="Pools overview"
         lede="Monitor the health of Telcoin’s on-chain liquidity. Status chips reflect governance-defined lifecycle stages; metrics refresh alongside community updates."

--- a/telcoinwiki-react/src/pages/PortfolioPage.tsx
+++ b/telcoinwiki-react/src/pages/PortfolioPage.tsx
@@ -1,5 +1,6 @@
 import { PageIntro } from '../components/content/PageIntro'
 import { ContextBox } from '../components/content/ContextBox'
+import { HeroOverlay } from '../components/content/HeroOverlay'
 import { SourceBox } from '../components/content/SourceBox'
 
 export function PortfolioPage() {
@@ -7,6 +8,9 @@ export function PortfolioPage() {
     <>
       <PageIntro
         id="portfolio-overview"
+        variant="hero"
+        className="bg-hero-linear animate-gradient [background-size:180%_180%]"
+        overlay={<HeroOverlay />}
         eyebrow="TELx Portfolio"
         title="Your TELx positions"
         lede="A design-time view of TEL claimable rewards and liquidity provider tokens. Use it to imagine how TELx wallets surface positions with glass panels, friendly chips, and clear callouts."

--- a/telcoinwiki-react/src/pages/RemittancesPage.tsx
+++ b/telcoinwiki-react/src/pages/RemittancesPage.tsx
@@ -1,4 +1,5 @@
 import { CardGrid } from '../components/content/CardGrid'
+import { HeroOverlay } from '../components/content/HeroOverlay'
 import { PageIntro } from '../components/content/PageIntro'
 import { SourceBox } from '../components/content/SourceBox'
 import { StatusValue } from '../components/content/StatusValue'
@@ -8,6 +9,9 @@ export function RemittancesPage() {
     <>
       <PageIntro
         id="remittance-overview"
+        variant="hero"
+        className="bg-hero-linear animate-gradient [background-size:180%_180%]"
+        overlay={<HeroOverlay />}
         eyebrow="Remittances"
         title="Send money with Telcoin"
         lede={

--- a/telcoinwiki-react/src/pages/StartHerePage.tsx
+++ b/telcoinwiki-react/src/pages/StartHerePage.tsx
@@ -1,5 +1,7 @@
 import { Link } from 'react-router-dom'
 import { FaqCard } from '../components/content/FaqCard'
+import { HeroOverlay } from '../components/content/HeroOverlay'
+import { PageIntro } from '../components/content/PageIntro'
 import { SourceBox } from '../components/content/SourceBox'
 import { StatusValue } from '../components/content/StatusValue'
 
@@ -247,22 +249,22 @@ const quickStartCards = [
 export function StartHerePage() {
   return (
     <>
-      <section id="start-intro" className="page-intro anchor-offset tc-card">
-        <p className="page-intro__eyebrow">Start here</p>
-        <h1 className="page-intro__title">Your Telcoin onboarding checklist</h1>
-        <p className="page-intro__lede">
-          Use these quick answers to ground yourself in the Telcoin Wallet, Digital Cash, remittance coverage, TEL utility, and
-          the governance structure that keeps everything compliant.
-        </p>
+      <PageIntro
+        id="start-intro"
+        variant="hero"
+        className="bg-hero-linear animate-gradient [background-size:180%_180%]"
+        overlay={<HeroOverlay />}
+        eyebrow="Start here"
+        title="Your Telcoin onboarding checklist"
+        lede="Use these quick answers to ground yourself in the Telcoin Wallet, Digital Cash, remittance coverage, TEL utility, and the governance structure that keeps everything compliant."
+      >
         <div className="notice" role="note">
           <p className="notice__title">How to use this page</p>
           <p>
-            Each card links to the community FAQ for context and to the official Telcoin or Association resource for authoritative
-            guidance. Bookmark the sections you rely on most—the cards will stay updated as the ecosystem evolves.
+            Each card links to the community FAQ for context and to the official Telcoin or Association resource for authoritative guidance. Bookmark the sections you rely on most—the cards will stay updated as the ecosystem evolves.
           </p>
         </div>
-      </section>
-
+      </PageIntro>
       <section id="quick-actions" className="anchor-offset">
         <h2>Essential first steps</h2>
         <div className="card-grid card-grid--cols-2" role="list">

--- a/telcoinwiki-react/src/pages/TelTokenPage.tsx
+++ b/telcoinwiki-react/src/pages/TelTokenPage.tsx
@@ -1,4 +1,5 @@
 import { CardGrid } from '../components/content/CardGrid'
+import { HeroOverlay } from '../components/content/HeroOverlay'
 import { PageIntro } from '../components/content/PageIntro'
 import { SourceBox } from '../components/content/SourceBox'
 
@@ -7,6 +8,9 @@ export function TelTokenPage() {
     <>
       <PageIntro
         id="tel-overview"
+        variant="hero"
+        className="bg-hero-linear animate-gradient [background-size:180%_180%]"
+        overlay={<HeroOverlay />}
         eyebrow="TEL Token"
         title="Fuel for Telcoin services and governance"
         lede="TEL is the native asset of the Telcoin Network. It pays for transactions, aligns validators and liquidity providers, and anchors governance programs stewarded by the Telcoin Association."

--- a/telcoinwiki-react/src/pages/TelxPage.tsx
+++ b/telcoinwiki-react/src/pages/TelxPage.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 import { CardGrid } from '../components/content/CardGrid'
 import { ContextBox } from '../components/content/ContextBox'
+import { HeroOverlay } from '../components/content/HeroOverlay'
 import { PageIntro } from '../components/content/PageIntro'
 import { SourceBox } from '../components/content/SourceBox'
 
@@ -9,6 +10,9 @@ export function TelxPage() {
     <>
       <PageIntro
         id="telx-overview"
+        variant="hero"
+        className="bg-hero-linear animate-gradient [background-size:180%_180%]"
+        overlay={<HeroOverlay />}
         eyebrow="TELx"
         title="The decentralized liquidity engine of the Telcoin Platform"
         lede="TELx orchestrates user-owned liquidity across Telcoin’s regulated DeFi stack. Designers, liquidity miners, and everyday users co-create a compliant, mobile-first financial network."

--- a/telcoinwiki-react/src/pages/WalletPage.tsx
+++ b/telcoinwiki-react/src/pages/WalletPage.tsx
@@ -1,3 +1,5 @@
+import { HeroOverlay } from '../components/content/HeroOverlay'
+import { PageIntro } from '../components/content/PageIntro'
 import { SourceBox } from '../components/content/SourceBox'
 import { StatusValue } from '../components/content/StatusValue'
 import { WalletOverviewPanels } from '../components/wallet/WalletOverviewPanels'
@@ -5,14 +7,15 @@ import { WalletOverviewPanels } from '../components/wallet/WalletOverviewPanels'
 export function WalletPage() {
   return (
     <>
-      <section id="wallet-overview" className="page-intro anchor-offset tc-card">
-        <p className="page-intro__eyebrow">Telcoin Wallet</p>
-        <h1 className="page-intro__title">Mobile-first access to Telcoin services</h1>
-        <p className="page-intro__lede">
-          The Telcoin Wallet is the official gateway for remittances, Digital Cash, TEL swaps, and staking. Verification keeps
-          the experience compliant while letting you manage funds directly from your device.
-        </p>
-      </section>
+      <PageIntro
+        id="wallet-overview"
+        variant="hero"
+        className="bg-hero-linear animate-gradient [background-size:180%_180%]"
+        overlay={<HeroOverlay />}
+        eyebrow="Telcoin Wallet"
+        title="Mobile-first access to Telcoin services"
+        lede="The Telcoin Wallet is the official gateway for remittances, Digital Cash, TEL swaps, and staking. Verification keeps the experience compliant while letting you manage funds directly from your device."
+      />
 
       <section id="wallet-capabilities" className="anchor-offset">
         <h2>What the Wallet enables</h2>


### PR DESCRIPTION
## Summary
- add a reusable `HeroOverlay` helper and pass the hero variant to every `PageIntro` so site-wide intros share the same gradient treatment
- replace bespoke hero markup on the Start Here, Deep Dive, and Wallet pages with the shared `PageIntro` hero structure for consistent layout
- tidy wallet overview panels to keep linting green after the refactor

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e33e33f1748330917e60717cfd77cb