### PR TITLE
Hide breadcrumbs on single-entry home page

### DIFF
--- a/telcoinwiki-react/src/components/layout/AppLayout.tsx
+++ b/telcoinwiki-react/src/components/layout/AppLayout.tsx
@@ -97,7 +97,7 @@ export function AppLayout({
           isOpen={isSidebarOpen}
         />
         <main id="main-content" className="site-main tc-card" tabIndex={-1}>
-          <Breadcrumbs trail={breadcrumbs} />
+          {(pageId !== 'home' || breadcrumbs.length > 1) && <Breadcrumbs trail={breadcrumbs} />}
           {children}
         </main>
       </div>


### PR DESCRIPTION
## Summary
- avoid rendering the breadcrumbs component on the home page when it is the only entry in the trail
- ensure the breadcrumb remains visible on deeper pages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3414d38888330bcf24442e458f390