### PR TITLE
Fix scroll reset and provide fallback metrics for ticker

### DIFF
--- a/telcoinwiki-react/src/components/home/HeroTicker.tsx
+++ b/telcoinwiki-react/src/components/home/HeroTicker.tsx
@@ -27,7 +27,7 @@ const tickerVariants = {
 }
 
 export function HeroTicker() {
-  const { highlightedMetrics, isLoading, error, metrics } = useStatusMetricsRealtime()
+  const { highlightedMetrics, isLoading, error, metrics, isFallback } = useStatusMetricsRealtime()
 
   const visibleMetrics = useMemo(() => {
     if (highlightedMetrics.length > 0) return highlightedMetrics
@@ -44,8 +44,15 @@ export function HeroTicker() {
       <span className="font-semibold uppercase tracking-[0.2em] text-telcoin-ink-subtle">Live</span>
       <div className="flex min-h-[1.5rem] w-full flex-1 flex-col gap-3 overflow-visible sm:flex-row sm:items-center sm:gap-6 sm:overflow-hidden">
         {isLoading ? <span className="text-telcoin-ink-muted">Syncing Telcoin metrics…</span> : null}
-        {error ? <span className="text-red-300">{error.message}</span> : null}
-        {!isLoading && !error ? (
+        {!isLoading && isFallback ? (
+          <span className="text-telcoin-ink-muted">
+            Realtime updates unavailable; showing cached metrics.
+          </span>
+        ) : null}
+        {!isLoading && error && visibleMetrics.length === 0 ? (
+          <span className="text-red-300">Unable to load Telcoin metrics right now.</span>
+        ) : null}
+        {!isLoading && visibleMetrics.length > 0 ? (
           <AnimatePresence initial={false}>
             {visibleMetrics.map((metric) => (
               <motion.span

--- a/telcoinwiki-react/src/components/layout/AppLayout.tsx
+++ b/telcoinwiki-react/src/components/layout/AppLayout.tsx
@@ -37,8 +37,7 @@ export function AppLayout({
   })
   const breadcrumbs = useBreadcrumbTrail(pageId, pageMeta)
   const [isSearchOpen, setSearchOpen] = useState(false)
-  const location = useLocation()
-  const hash = location.hash
+  const { hash, pathname } = useLocation()
 
   const openSearch = () => setSearchOpen(true)
   const handleCloseSearch = () => setSearchOpen(false)
@@ -71,7 +70,7 @@ export function AppLayout({
     } else {
       window.scrollTo({ top: 0, behavior })
     }
-  }, [hash])
+  }, [hash, pathname])
 
   return (
     <>

--- a/telcoinwiki-react/src/hooks/useStatusMetrics.ts
+++ b/telcoinwiki-react/src/hooks/useStatusMetrics.ts
@@ -3,7 +3,7 @@ import { useQuery, type UseQueryResult } from '@tanstack/react-query'
 import type { StatusMetric } from '../lib/queries'
 import { supabaseQueries } from '../lib/queries'
 
-interface StatusMetricsResult {
+export interface StatusMetricsResult {
   metrics: StatusMetric[]
   source: 'supabase' | 'fallback'
 }
@@ -18,7 +18,7 @@ const fetchJson = async <T>(url: string): Promise<T> => {
   return (await response.json()) as T
 }
 
-const fallbackToStatusJson = async (): Promise<StatusMetricsResult> => {
+export const fallbackToStatusJson = async (): Promise<StatusMetricsResult> => {
   const data = await fetchJson<StatusJson>('/status.json')
   const metrics: StatusMetric[] = Object.entries(data).map(([key, value]) => ({
     key,
@@ -33,7 +33,7 @@ const fallbackToStatusJson = async (): Promise<StatusMetricsResult> => {
   return { metrics, source: 'fallback' }
 }
 
-const fetchStatusMetricsWithFallback = async (): Promise<StatusMetricsResult> => {
+export const fetchStatusMetricsWithFallback = async (): Promise<StatusMetricsResult> => {
   try {
     const metrics = await supabaseQueries.fetchStatusMetrics()
     return { metrics, source: 'supabase' }


### PR DESCRIPTION
## Summary
- reset the app layout scroll effect whenever the pathname changes so hash-less navigations start at the top
- share the status metrics fallback loader with the realtime hook and expose an `isFallback` flag
- show cached metrics in the hero ticker with a softer notice when realtime updates are unavailable

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e34104f11c833097f2cc8dfbfa1e58