### PR TITLE
Fix FAQ rendering fallback and whitespace search handling

### DIFF
--- a/telcoinwiki-react/src/components/content/FaqExplorer.tsx
+++ b/telcoinwiki-react/src/components/content/FaqExplorer.tsx
@@ -10,9 +10,22 @@ interface FaqExplorerProps {
 
 const stripHtml = (value: string): string => value.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim()
 
+const createDomParser = (): DOMParser | null => {
+  if (typeof DOMParser === 'undefined') {
+    return null
+  }
+  return new DOMParser()
+}
+
 const renderAnswerHtml = (html: string, keyPrefix: string): ReactNode => {
   if (!html) return null
-  const parser = new DOMParser()
+
+  const parser = createDomParser()
+
+  if (!parser || typeof Node === 'undefined') {
+    return <span key={keyPrefix}>{stripHtml(html)}</span>
+  }
+
   const doc = parser.parseFromString(html, 'text/html')
   const nodes = Array.from(doc.body.childNodes)
 

--- a/telcoinwiki-react/src/components/search/SearchModal.tsx
+++ b/telcoinwiki-react/src/components/search/SearchModal.tsx
@@ -16,6 +16,7 @@ export function SearchModal({ isOpen, onClose, searchConfig }: SearchModalProps)
   const resultRefs = useRef<HTMLAnchorElement[]>([])
   const { search, isLoading, error, isFallback, reload } = useSearchIndex(searchConfig)
   const [query, setQuery] = useState('')
+  const trimmedQuery = query.trim()
 
   useEffect(() => {
     if (isOpen) {
@@ -46,7 +47,7 @@ export function SearchModal({ isOpen, onClose, searchConfig }: SearchModalProps)
     }
   }, [isOpen, onClose])
 
-  const results = useMemo(() => (query ? search(query) : []), [query, search])
+  const results = useMemo(() => (trimmedQuery ? search(trimmedQuery) : []), [trimmedQuery, search])
   const totalResults = useMemo(
     () => results.reduce((count, group) => count + group.items.length, 0),
     [results],
@@ -94,7 +95,7 @@ export function SearchModal({ isOpen, onClose, searchConfig }: SearchModalProps)
     }
   }
 
-  const showEmptyState = query.length > 0 && !totalResults && !isLoading && !error
+  const showEmptyState = trimmedQuery.length > 0 && !totalResults && !isLoading && !error
 
   let runningIndex = -1
 


### PR DESCRIPTION
## Summary
- guard the FAQ answer renderer against missing DOM APIs and provide a safe text fallback when parsing fails
- trim search input queries before searching so whitespace-only input no longer triggers empty-state messaging

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e343abfb088330849bca927de5d9c3