### PR TITLE
Stabilize header dropdown split link styling

### DIFF
--- a/telcoinwiki-react/src/components/layout/Header.tsx
+++ b/telcoinwiki-react/src/components/layout/Header.tsx
@@ -125,22 +125,52 @@ export function Header({
                   );
                 }
 
+                const menuId = `nav-menu-${item.id}`;
+                const toggleId = `nav-toggle-${item.id}`;
+
                 return (
                   <li
                     key={item.id}
                     className="nav-item"
                     data-open={isOpen ? 'true' : undefined}
                   >
-                    <button
-                      type="button"
-                      className={`nav-button${isMenuActive ? ' is-active' : ''}`}
-                      aria-haspopup="true"
-                      aria-expanded={isOpen}
-                      onClick={() => toggleMenu(item.id)}
+                    <div
+                      className={`nav-button${
+                        isMenuActive ? ' is-active' : ''
+                      }${isOpen ? ' is-open' : ''}`}
                     >
-                      {item.label} <span className="nav-caret">▾</span>
-                    </button>
-                    <div className="nav-menu" role="menu">
+                      <NavLink
+                        className={({ isActive }) =>
+                          `top-nav__link nav-button__link${
+                            isActive || isMenuActive ? ' is-active' : ''
+                          }`
+                        }
+                        to={item.href}
+                        onClick={closeMenus}
+                      >
+                        {item.label}
+                      </NavLink>
+                      <button
+                        type="button"
+                        className="nav-button__toggle"
+                        aria-haspopup="menu"
+                        aria-expanded={isOpen}
+                        aria-controls={menuId}
+                        id={toggleId}
+                        aria-label={`Toggle ${item.label} menu`}
+                        onClick={() => toggleMenu(item.id)}
+                      >
+                        <span className="nav-caret" aria-hidden="true">
+                          ▾
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      id={menuId}
+                      className="nav-menu"
+                      role="menu"
+                      aria-labelledby={toggleId}
+                    >
                       {item.menu.map((entry) => (
                         <Link
                           key={entry.href}

--- a/telcoinwiki-react/src/styles/brand.css
+++ b/telcoinwiki-react/src/styles/brand.css
@@ -493,14 +493,42 @@ img.site-logo { height: clamp(28px, 6.5vw, 52px); }
 
 .nav-item { position: relative; }
 .nav-button {
+  display: inline-flex; align-items: stretch; gap: 0;
+  padding: 0;
+  min-height: var(--header-action-height);
+  min-width: var(--header-pill-min-width);
+  border-radius: var(--radius-pill);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-subtle);
+  color: var(--color-text-muted);
+  font-weight: 600;
+  transition: background-color var(--transition-base), border-color var(--transition-base), color var(--transition-base);
+  overflow: hidden;
+}
+.nav-button__link,
+.nav-button__toggle {
   display: inline-flex; align-items: center; gap: .4rem;
   padding: var(--space-2) var(--space-3);
-  border-radius: var(--radius-pill);
-  background: transparent; border: 1px solid var(--color-border-subtle);
-  color: var(--color-text); cursor: pointer; font-weight: 600;
-  transition: background-color var(--transition-base), border-color var(--transition-base), color var(--transition-base);
+  background: transparent; border: 0; color: inherit;
+  font: inherit; font-weight: inherit;
+  min-height: inherit;
 }
-.nav-caret { display:inline-block; transform: translateY(1px); opacity:.8; }
+.nav-button__link {
+  text-decoration: none;
+  flex: 1 1 auto;
+  justify-content: center;
+  white-space: nowrap;
+  border: 0;
+  background: transparent;
+}
+.nav-button__toggle {
+  border-left: 1px solid var(--color-border-subtle);
+  cursor: pointer;
+  min-width: 2.5rem;
+  justify-content: center;
+}
+.nav-button__link.is-active { color: inherit; }
+.nav-caret { display:inline-block; transform: translateY(1px); opacity:.8; transition: transform var(--transition-base); }
 .nav-menu {
   position: absolute; top: calc(100% + .4rem); left: 0; min-width: 16rem; display: none;
   background: var(--color-surface); border: 1px solid var(--color-border-subtle);
@@ -517,18 +545,27 @@ img.site-logo { height: clamp(28px, 6.5vw, 52px); }
 }
 .nav-item[data-open="true"] .nav-button,
 .nav-button:hover,
-.nav-button:focus-visible {
+.nav-button:focus-within,
+.nav-button.is-active {
   background: var(--color-surface-alt);
   border-color: var(--color-border);
   color: var(--color-text);
 }
+.nav-button__toggle:focus-visible,
+.nav-button__link:focus-visible {
+  outline: 2px solid var(--color-border);
+  outline-offset: 2px;
+}
+.nav-item[data-open="true"] .nav-button__toggle { border-color: var(--color-border); }
+.nav-button.is-open .nav-caret { transform: translateY(1px) rotate(180deg); }
 .pill-nav .nav-menu a {
   box-shadow: none; border: 1px solid var(--color-border-subtle);
   border-radius: .55rem; padding: .6rem .75rem; height: auto;
 }
 @media (max-width: 1024px) {
   .nav-menu { position: static; display: grid; box-shadow: none; margin-top: .35rem; }
-  .nav-button { width: 100%; justify-content: space-between; }
+  .nav-button { width: 100%; }
+  .nav-button__link { flex: 1; }
   .nav-item { width: 100%; }
   .nav-item + .nav-item { margin-top: .25rem; }
 }

--- a/telcoinwiki-react/src/styles/critical.css
+++ b/telcoinwiki-react/src/styles/critical.css
@@ -530,15 +530,56 @@ ol {
 /* --- Dropdown nav scaffolding --- */
 .nav-item { position: relative; }
 .nav-button {
+  display:inline-flex; align-items:stretch; gap:0;
+  padding:0;
+  min-height: var(--header-action-height);
+  min-width: var(--header-pill-min-width);
+  border-radius: var(--radius-pill);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-subtle);
+  color: var(--color-text-muted);
+  font-weight:600;
+  overflow:hidden;
+  transition: background var(--transition-base), border-color var(--transition-base), color var(--transition-base);
+}
+.nav-button__link,
+.nav-button__toggle {
   display:inline-flex; align-items:center; gap:.4rem;
   padding: var(--space-2) var(--space-3);
-  border-radius: var(--radius-sm);
-  background: transparent; border: 1px solid transparent;
-  color: var(--color-text); cursor: pointer;
+  background: transparent; border:0; color:inherit;
+  min-height: inherit;
 }
+.nav-button__link {
+  text-decoration:none;
+  flex:1 1 auto;
+  justify-content:center;
+  white-space:nowrap;
+  font-size:0.95rem;
+  border:0;
+  background:transparent;
+  box-shadow:none;
+}
+.nav-button__toggle {
+  border-left:1px solid var(--color-border-subtle);
+  cursor:pointer;
+  min-width:2.5rem;
+  justify-content:center;
+}
+.nav-button.is-active,
+.nav-button.is-open,
+.nav-item[data-open="true"] .nav-button,
 .nav-button:hover,
-.nav-button[aria-expanded="true"] { background: var(--color-surface-alt); }
-.nav-caret { display:inline-block; transform: translateY(1px); opacity:.8; }
+.nav-button:focus-within {
+  background: var(--color-surface-alt);
+  border-color: var(--color-border);
+  color: var(--color-text);
+}
+.nav-button__link.is-active { color: inherit; }
+.nav-button__link:focus-visible,
+.nav-button__toggle:focus-visible { outline:2px solid var(--color-border); outline-offset:2px; }
+.nav-item[data-open="true"] .nav-button__toggle { border-color: var(--color-border); }
+.nav-caret { display:inline-block; transform: translateY(1px); opacity:.8; transition: transform var(--transition-base); }
+.nav-button.is-open .nav-caret { transform: translateY(1px) rotate(180deg); }
 
 /* Dropdown panel */
 .nav-menu{
@@ -555,12 +596,16 @@ ol {
 .nav-menu a:hover,.nav-menu a:focus-visible{ background:var(--color-surface-alt); color:var(--color-text); }
 
 /* Mobile: inline panel */
-@media (max-width:1024px){ .nav-menu{ position:static; display:grid; box-shadow:none; border-radius:var(--radius-sm);} }
+@media (max-width:1024px){
+  .nav-menu{ position:static; display:grid; box-shadow:none; border-radius:var(--radius-sm);}
+  .nav-button{ width:100%; }
+  .nav-button__link{ flex:1; }
+}
 
 /* Normalize sitewide link styling (keep header pills un-underlined) */
 a{ color:var(--tc-accent); text-decoration:underline; text-underline-offset:2px; }
 a:hover{ text-decoration:underline; }
-a.top-nav__link, .nav-button, .nav-menu a{ text-decoration:none; }
+a.top-nav__link, .nav-button__link, .nav-button__toggle, .nav-menu a{ text-decoration:none; }
 
 /* Deep-Dive TOC chips & accordions */
 .toc-chips{ display:flex; flex-wrap:wrap; gap:.5rem; margin: var(--space-3) 0 var(--space-5); }


### PR DESCRIPTION
## Summary
- render dropdown nav items with a standalone `<NavLink>` and a disclosure button so the parent route stays reachable while keeping submenu toggles accessible
- align the shared `.nav-button` styles in both critical and brand layers to accommodate the split control without duplicate borders and while preserving active/hover states

## Testing
- npm run lint *(fails: existing unused variable errors in TelPriceChartPanel.tsx and TelxLiquidityPanel.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e33e31fdb48330b757bbae9385961b