### PR TITLE
Simplify layout layering so GitHub conflict editor loads

### DIFF
--- a/telcoinwiki-react/src/components/layout/AppLayout.tsx
+++ b/telcoinwiki-react/src/components/layout/AppLayout.tsx
@@ -76,35 +76,33 @@ export function AppLayout({
   return (
     <>
       <StarfieldCanvas />
-      <div className="app-layer">
-        <a className="skip-link" href="#main-content">
-          Skip to content
-        </a>
-        <Header
-          navItems={navItems}
-          activeNavId={activeNavId}
-          onSearchOpen={openSearch}
-          isSearchOpen={isSearchOpen}
+      <a className="skip-link" href="#main-content">
+        Skip to content
+      </a>
+      <Header
+        navItems={navItems}
+        activeNavId={activeNavId}
+        onSearchOpen={openSearch}
+        isSearchOpen={isSearchOpen}
+      />
+      <div
+        className={`sidebar-overlay${isSidebarOpen ? ' is-active' : ''}`}
+        data-sidebar-overlay
+        onClick={closeSidebar}
+      />
+      <div className="site-shell">
+        <Sidebar
+          items={sidebarItems}
+          activeId={currentMeta?.navId ?? pageId}
+          headings={headings}
+          isOpen={isSidebarOpen}
         />
-        <div
-          className={`sidebar-overlay${isSidebarOpen ? ' is-active' : ''}`}
-          data-sidebar-overlay
-          onClick={closeSidebar}
-        />
-        <div className="site-shell">
-          <Sidebar
-            items={sidebarItems}
-            activeId={currentMeta?.navId ?? pageId}
-            headings={headings}
-            isOpen={isSidebarOpen}
-          />
-          <main id="main-content" className="site-main tc-card" tabIndex={-1}>
-            {(pageId !== 'home' || breadcrumbs.length > 1) && <Breadcrumbs trail={breadcrumbs} />}
-            {children}
-          </main>
-        </div>
-        <SearchModal isOpen={isSearchOpen} onClose={handleCloseSearch} searchConfig={searchConfig} />
+        <main id="main-content" className="site-main tc-card" tabIndex={-1}>
+          {(pageId !== 'home' || breadcrumbs.length > 1) && <Breadcrumbs trail={breadcrumbs} />}
+          {children}
+        </main>
       </div>
+      <SearchModal isOpen={isSearchOpen} onClose={handleCloseSearch} searchConfig={searchConfig} />
     </>
   )
 }

--- a/telcoinwiki-react/src/components/visual/StarfieldCanvas.css
+++ b/telcoinwiki-react/src/components/visual/StarfieldCanvas.css
@@ -5,6 +5,6 @@
   height: 100%;
   display: block;
   pointer-events: none;
-  z-index: 0;
+  z-index: -1;
   background: transparent;
 }

--- a/telcoinwiki-react/src/styles/critical.css
+++ b/telcoinwiki-react/src/styles/critical.css
@@ -70,11 +70,6 @@ body {
   min-height: 100vh;
 }
 
-.app-layer {
-  position: relative;
-  z-index: 1;
-}
-
 main {
   display: block;
 }


### PR DESCRIPTION
## Summary
- remove the extra app-layer wrapper so the main layout structure matches the previous markup while still mounting the starfield canvas
- push the starfield canvas behind the rest of the UI and drop the unused stacking rule

## Testing
- npm --prefix telcoinwiki-react run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3f49c030c8330a3de0bf130ac6c78