### PR TITLE
Enhance starfield shooting stars and fade-in

### DIFF
--- a/telcoinwiki-react/src/components/visual/StarfieldCanvas.css
+++ b/telcoinwiki-react/src/components/visual/StarfieldCanvas.css
@@ -7,4 +7,10 @@
   pointer-events: none;
   z-index: 0;
   background: transparent;
+  opacity: 0;
+  transition: opacity 2s ease;
+}
+
+.starfield-canvas--visible {
+  opacity: 1;
 }


### PR DESCRIPTION
## Summary
- increase shooting star frequency, brightness, and trail definition for higher impact
- slow overall starfield rotation by 50% on desktop viewports while respecting resize changes
- add a fade-in transition so the canvas becomes visible after page load

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e40eaef86483308452cb63cfb58a5c