### PR TITLE
Align layout containers with shared width token

### DIFF
--- a/telcoinwiki-react/src/styles/brand.css
+++ b/telcoinwiki-react/src/styles/brand.css
@@ -4,7 +4,7 @@
 :root {
   --safe-top: env(safe-area-inset-top, 0px);
   --safe-bottom: env(safe-area-inset-bottom, 0px);
-  --container: clamp(16rem, 92vw, 1200px);
+  --container: var(--max-width-wide);
   --gap-1: 0.25rem;
   --gap-2: 0.5rem;
   --gap-3: 0.75rem;
@@ -38,9 +38,9 @@ body {
 }
 
 .container {
-  max-width: var(--container);
+  inline-size: min(100%, var(--container));
   margin-inline: auto;
-  padding-inline: var(--gap-4);
+  padding-inline: clamp(var(--gap-4), 5vw, var(--gap-6));
 }
 
 /* --- Header ------------------------------------------------------------ */

--- a/telcoinwiki-react/src/styles/site.css
+++ b/telcoinwiki-react/src/styles/site.css
@@ -417,8 +417,7 @@ pre {
   position: relative;
   display: flex;
   gap: 2rem;
-  width: min(100%, var(--container));
-  max-width: var(--container);
+  inline-size: min(100%, var(--container));
   margin: 0 auto;
   padding-top: clamp(2rem, 4vw, 3rem);
   padding-inline: clamp(1rem, 5vw, 3rem);


### PR DESCRIPTION
## Summary
- reuse the global `--max-width-wide` token for the brand container helper and update its padding clamp
- let `.site-shell` rely on the shared container width so the main column can expand on wide viewports

## Testing
- Not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e41408d3d08330b77ae3e869c2840f