### PR TITLE
Adjust starfield meteor frequency and fade-in timing

### DIFF
--- a/telcoinwiki-react/src/components/visual/StarfieldCanvas.css
+++ b/telcoinwiki-react/src/components/visual/StarfieldCanvas.css
@@ -8,7 +8,7 @@
   z-index: 0;
   background: transparent;
   opacity: 0;
-  transition: opacity 2s ease;
+  transition: opacity 10s linear;
 }
 
 .starfield-canvas--visible {


### PR DESCRIPTION
## Summary
- reduce shooting star frequency and intensity for a subtler starfield background
- delay the canvas fade-in until the user scrolls and extend the transition to a 10-second linear fade

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e418d800b083309584231105c23794