### PR TITLE
Fix hero typing loop width to prevent clipping

### DIFF
--- a/telcoinwiki-react/src/components/home/HeroTypingLoop.tsx
+++ b/telcoinwiki-react/src/components/home/HeroTypingLoop.tsx
@@ -3,7 +3,11 @@ import { useEffect, useState } from 'react'
 
 const phrases = ['Community Q&A', 'Guides', 'Links']
 
-const longestPhraseLength = Math.max(...phrases.map((phrase) => phrase.length))
+const longestPhrase = phrases.reduce((currentLongest, phrase) => {
+  return phrase.length > currentLongest.length ? phrase : currentLongest
+}, phrases[0])
+
+const longestPhraseLength = longestPhrase.length
 
 const typingVariants = {
   initial: { opacity: 0, y: 6 },
@@ -26,9 +30,15 @@ export function HeroTypingLoop() {
     <div className="flex items-center gap-2 text-base font-semibold text-telcoin-ink">
       <span className="text-telcoin-ink-subtle">Community Q&amp;A →</span>
       <div
-        className="relative h-6 overflow-hidden"
+        className="relative shrink-0 overflow-hidden"
         style={{ minWidth: `${longestPhraseLength}ch` }}
       >
+        <span
+          aria-hidden="true"
+          className="invisible flex items-center text-base font-semibold text-telcoin-accent"
+        >
+          {longestPhrase}
+        </span>
         <AnimatePresence initial={false} mode="wait">
           <motion.span
             key={phrases[index]}


### PR DESCRIPTION
## Summary
- derive the longest hero eyebrow phrase and use it to size the typing container
- add an invisible measurement span so the animated text can grow without clipping while keeping overflow hidden

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4222c12ac83308549b994b7777f71