### PR TITLE
feat: add smooth scrolling utilities

### DIFF
--- a/telcoinwiki-react/package-lock.json
+++ b/telcoinwiki-react/package-lock.json
@@ -8,10 +8,12 @@
       "name": "telcoinwiki-react",
       "version": "0.0.0",
       "dependencies": {
+        "@studio-freight/lenis": "^1.0.42",
         "@supabase/supabase-js": "^2.58.0",
         "@tanstack/react-query": "^5.90.2",
         "elasticlunr": "^0.9.5",
         "framer-motion": "^11.13.2",
+        "gsap": "^3.12.5",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-intersection-observer": "^9.13.0",
@@ -920,6 +922,13 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.35.tgz",
       "integrity": "sha512-slYrCpoxJUqzFDDNlvrOYRazQUNRvWPjXA17dAOISY3rDMxX6k8K4cj2H+hEYMHF81HO3uNd5rHVigAWRM5dSg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@studio-freight/lenis": {
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/@studio-freight/lenis/-/lenis-1.0.42.tgz",
+      "integrity": "sha512-HJAGf2DeM+BTvKzHv752z6Z7zy6bA643nZM7W88Ft9tnw2GsJSp6iJ+3cekjyMIWH+cloL2U9X82dKXgdU8kPg==",
+      "deprecated": "The '@studio-freight/lenis' package has been renamed to 'lenis'. Please update your dependencies: npm install lenis and visit the documentation: https://www.npmjs.com/package/lenis",
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
@@ -3979,6 +3988,12 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/gsap": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.13.0.tgz",
+      "integrity": "sha512-QL7MJ2WMjm1PHWsoFrAQH/J8wUeqZvMtHO58qdekHpCfhvhSL4gSiz6vJf5EeMP0LOn3ZCprL2ki/gjED8ghVw==",
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",

--- a/telcoinwiki-react/package.json
+++ b/telcoinwiki-react/package.json
@@ -16,8 +16,10 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.58.0",
     "@tanstack/react-query": "^5.90.2",
+    "@studio-freight/lenis": "^1.0.42",
     "elasticlunr": "^0.9.5",
     "framer-motion": "^11.13.2",
+    "gsap": "^3.12.5",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-intersection-observer": "^9.13.0",

--- a/telcoinwiki-react/src/hooks/useScrollTimeline.ts
+++ b/telcoinwiki-react/src/hooks/useScrollTimeline.ts
@@ -1,0 +1,96 @@
+import type { MutableRefObject, RefObject } from 'react'
+import { useEffect, useRef } from 'react'
+
+import gsap from 'gsap'
+import type { ScrollTrigger as ScrollTriggerType } from 'gsap/ScrollTrigger'
+import { ScrollTrigger } from 'gsap/ScrollTrigger'
+
+gsap.registerPlugin(ScrollTrigger)
+
+type Timeline = gsap.core.Timeline
+
+type ScrollTimelineTarget = Element | RefObject<Element> | null
+
+export interface UseScrollTimelineConfig {
+  /**
+   * Element that should control the ScrollTrigger instance.
+   */
+  target: ScrollTimelineTarget
+  /**
+   * Callback that receives the GSAP timeline. Define tweens inside this function.
+   */
+  create: (timeline: Timeline, context: gsap.Context) => void
+  /**
+   * Additional GSAP timeline options.
+   */
+  timeline?: gsap.TimelineVars
+  /**
+   * Optional ScrollTrigger configuration overriding the sensible defaults.
+   */
+  scrollTrigger?: ScrollTriggerType.Vars
+}
+
+const defaultScrollTrigger: ScrollTriggerType.Vars = {
+  start: 'top 80%',
+  end: 'bottom top',
+  toggleActions: 'play reverse play reverse',
+}
+
+function isRefObject(value: ScrollTimelineTarget): value is RefObject<Element> {
+  return Boolean(value && typeof value === 'object' && 'current' in value)
+}
+
+function resolveTarget(target: ScrollTimelineTarget): Element | null {
+  if (!target) {
+    return null
+  }
+
+  return isRefObject(target) ? target.current : target
+}
+
+export function useScrollTimeline({
+  target,
+  create,
+  timeline: timelineVars,
+  scrollTrigger,
+}: UseScrollTimelineConfig): MutableRefObject<Timeline | null> {
+  const timelineRef = useRef<Timeline | null>(null)
+
+  useEffect(() => {
+    const element = resolveTarget(target)
+
+    if (!element) {
+      return undefined
+    }
+
+    let timeline: Timeline | null = null
+
+    const context = gsap.context(() => {
+      timeline = gsap.timeline({
+        defaults: { ease: 'power1.out' },
+        ...timelineVars,
+        scrollTrigger: {
+          trigger: element,
+          ...defaultScrollTrigger,
+          ...scrollTrigger,
+        },
+      })
+
+      timelineRef.current = timeline
+      create(timeline, context)
+    }, element)
+
+    return () => {
+      context.revert()
+
+      if (timeline) {
+        timeline.scrollTrigger?.kill()
+        timeline.kill()
+      }
+
+      timelineRef.current = null
+    }
+  }, [target, create, timelineVars, scrollTrigger])
+
+  return timelineRef
+}

--- a/telcoinwiki-react/src/hooks/useSmoothScroll.ts
+++ b/telcoinwiki-react/src/hooks/useSmoothScroll.ts
@@ -1,0 +1,95 @@
+import { useEffect, useRef, useState } from 'react'
+
+import Lenis, { type LenisOptions } from '@studio-freight/lenis'
+import gsap from 'gsap'
+import { ScrollTrigger } from 'gsap/ScrollTrigger'
+
+gsap.registerPlugin(ScrollTrigger)
+
+export interface UseSmoothScrollOptions {
+  /**
+   * Allows consumers to disable Lenis entirely (e.g. for specific pages).
+   * Defaults to `true`.
+   */
+  enabled?: boolean
+  /**
+   * Options passed directly to the Lenis constructor.
+   */
+  lenis?: LenisOptions
+}
+
+export interface SmoothScrollHandle {
+  lenis: Lenis | null
+  prefersReducedMotion: boolean
+}
+
+const prefersReducedMotionQuery = '(prefers-reduced-motion: reduce)'
+
+export function useSmoothScroll(options: UseSmoothScrollOptions = {}): SmoothScrollHandle {
+  const { enabled = true, lenis: lenisOptions } = options
+  const lenisRef = useRef<Lenis | null>(null)
+  const frameRef = useRef<number | null>(null)
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
+    if (typeof window === 'undefined') {
+      return false
+    }
+
+    return window.matchMedia(prefersReducedMotionQuery).matches
+  })
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined
+    }
+
+    const mediaQuery = window.matchMedia(prefersReducedMotionQuery)
+    const handleChange = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches)
+    }
+
+    mediaQuery.addEventListener('change', handleChange)
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!enabled || prefersReducedMotion || typeof window === 'undefined') {
+      return undefined
+    }
+
+    const lenis = new Lenis({
+      smoothWheel: true,
+      smoothTouch: false,
+      ...lenisOptions,
+    })
+
+    lenisRef.current = lenis
+
+    const updateScrollTriggers = () => ScrollTrigger.update()
+    lenis.on('scroll', updateScrollTriggers)
+
+    ScrollTrigger.refresh()
+
+    const onAnimationFrame = (time: number) => {
+      lenis.raf(time)
+      frameRef.current = window.requestAnimationFrame(onAnimationFrame)
+    }
+
+    frameRef.current = window.requestAnimationFrame(onAnimationFrame)
+
+    return () => {
+      lenis.off('scroll', updateScrollTriggers)
+      if (frameRef.current !== null) {
+        window.cancelAnimationFrame(frameRef.current)
+        frameRef.current = null
+      }
+
+      lenis.destroy()
+      lenisRef.current = null
+    }
+  }, [enabled, lenisOptions, prefersReducedMotion])
+
+  return { lenis: lenisRef.current, prefersReducedMotion }
+}

--- a/telcoinwiki-react/vite.config.ts
+++ b/telcoinwiki-react/vite.config.ts
@@ -1,9 +1,17 @@
+import { fileURLToPath, URL } from 'node:url'
+
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react-swc'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+      '@scroll': fileURLToPath(new URL('./src/lib/scroll', import.meta.url)),
+    },
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- add Lenis and GSAP dependencies and expose scroll aliases for the React app
- implement a `useSmoothScroll` hook to initialize Lenis with reduced-motion guards and rAF syncing
- add a `useScrollTimeline` helper to register and clean up ScrollTrigger timelines for section animations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e430b7b6bc8330acc4104cd1d8a15f