### PR TITLE
Refactor home page into cinematic sections

### DIFF
--- a/telcoinwiki-react/src/components/cinematic/ColorShiftBackground.tsx
+++ b/telcoinwiki-react/src/components/cinematic/ColorShiftBackground.tsx
@@ -1,0 +1,33 @@
+import type { ComponentPropsWithoutRef } from 'react'
+
+import { cn } from '../../utils/cn'
+
+interface ColorShiftBackgroundProps extends ComponentPropsWithoutRef<'div'> {
+  from?: string
+  to?: string
+}
+
+export function ColorShiftBackground({
+  className,
+  style,
+  from = 'rgba(31, 103, 255, 0.45)',
+  to = 'rgba(112, 67, 255, 0.2)',
+  ...rest
+}: ColorShiftBackgroundProps) {
+  return (
+    <div
+      data-color-shift=""
+      aria-hidden
+      className={cn(
+        'absolute inset-0 -z-10 overflow-hidden transition-[clip-path] duration-700 ease-out',
+        className,
+      )}
+      style={{
+        backgroundImage: `linear-gradient(135deg, ${from} 0%, ${to} 100%)`,
+        clipPath: 'inset(var(--color-shift-clip, 0%) 0 0 0)',
+        ...style,
+      }}
+      {...rest}
+    />
+  )
+}

--- a/telcoinwiki-react/src/components/cinematic/ScrollSplit.tsx
+++ b/telcoinwiki-react/src/components/cinematic/ScrollSplit.tsx
@@ -1,0 +1,41 @@
+import type { ComponentPropsWithoutRef, ReactNode } from 'react'
+import { forwardRef, useMemo } from 'react'
+
+import { cn } from '../../utils/cn'
+
+interface ScrollSplitProps extends ComponentPropsWithoutRef<'div'> {
+  lead: ReactNode
+  aside?: ReactNode
+  asideTop?: string | number
+  asideClassName?: string
+  leadClassName?: string
+}
+
+export const ScrollSplit = forwardRef<HTMLDivElement, ScrollSplitProps>(function ScrollSplit(
+  { lead, aside, asideTop = '25vh', asideClassName, leadClassName, className, ...rest },
+  ref,
+) {
+  const resolvedTop = useMemo(() => (typeof asideTop === 'number' ? `${asideTop}px` : asideTop), [asideTop])
+
+  return (
+    <div
+      ref={ref}
+      className={cn('grid gap-12 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]', className)}
+      data-scroll-split=""
+      {...rest}
+    >
+      <div className={cn('flex flex-col gap-6', leadClassName)} data-scroll-split-lead="">
+        {lead}
+      </div>
+      {aside ? (
+        <div
+          className={cn('flex flex-col gap-6 lg:sticky', asideClassName)}
+          style={{ top: resolvedTop }}
+          data-scroll-split-aside=""
+        >
+          {aside}
+        </div>
+      ) : null}
+    </div>
+  )
+})

--- a/telcoinwiki-react/src/components/cinematic/StickyModule.tsx
+++ b/telcoinwiki-react/src/components/cinematic/StickyModule.tsx
@@ -1,0 +1,61 @@
+import type { ComponentPropsWithoutRef, ReactNode } from 'react'
+import { forwardRef, useMemo } from 'react'
+
+import { cn } from '../../utils/cn'
+
+interface StickyModuleProps extends ComponentPropsWithoutRef<'section'> {
+  sticky: ReactNode
+  content: ReactNode
+  top?: string | number
+  containerClassName?: string
+  stickyClassName?: string
+  contentClassName?: string
+  background?: ReactNode
+}
+
+export const StickyModule = forwardRef<HTMLElement, StickyModuleProps>(function StickyModule(
+  {
+    sticky,
+    content,
+    top = '20vh',
+    containerClassName,
+    stickyClassName,
+    contentClassName,
+    className,
+    background,
+    ...rest
+  },
+  ref,
+) {
+  const resolvedTop = useMemo(() => (typeof top === 'number' ? `${top}px` : top), [top])
+
+  return (
+    <section
+      ref={ref}
+      className={cn('relative isolate', className)}
+      data-sticky-module=""
+      {...rest}
+    >
+      {background}
+      <div
+        className={cn(
+          'mx-auto flex max-w-6xl flex-col gap-12 px-6 py-24 sm:px-8 lg:gap-16 lg:px-12',
+          containerClassName,
+        )}
+      >
+        <div className="grid gap-12 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)] lg:items-start">
+          <div
+            className={cn('lg:sticky lg:self-start', stickyClassName)}
+            style={{ top: resolvedTop }}
+            data-sticky-module-lead=""
+          >
+            {sticky}
+          </div>
+          <div className={cn('flex flex-col gap-10', contentClassName)} data-sticky-module-content="">
+            {content}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+})

--- a/telcoinwiki-react/src/components/content/HeroOverlay.tsx
+++ b/telcoinwiki-react/src/components/content/HeroOverlay.tsx
@@ -1,15 +1,22 @@
-import type { ReactNode } from 'react'
+import type { ComponentPropsWithoutRef, ReactNode } from 'react'
 
-interface HeroOverlayProps {
+import { cn } from '../../utils/cn'
+
+interface HeroOverlayProps extends ComponentPropsWithoutRef<'div'> {
   children?: ReactNode
 }
 
-export function HeroOverlay({ children }: HeroOverlayProps) {
+export function HeroOverlay({ children, className, style, ...rest }: HeroOverlayProps) {
   return (
-    <>
+    <div
+      className={cn('relative h-full w-full overflow-hidden', className)}
+      style={style}
+      aria-hidden
+      {...rest}
+    >
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,var(--tc-blue-sky)_0%,transparent_65%)] opacity-80" />
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom_right,rgba(85,51,255,0.3)_0%,transparent_70%)] mix-blend-screen" />
       {children}
-    </>
+    </div>
   )
 }

--- a/telcoinwiki-react/src/components/content/PageIntro.tsx
+++ b/telcoinwiki-react/src/components/content/PageIntro.tsx
@@ -1,37 +1,47 @@
-import type { ReactNode } from 'react'
+import type { ComponentPropsWithoutRef, ReactNode } from 'react'
+import { forwardRef } from 'react'
+
 import { cn } from '../../utils/cn'
 
 type PageIntroVariant = 'card' | 'hero'
 
-interface PageIntroProps {
+interface PageIntroProps extends Omit<ComponentPropsWithoutRef<'section'>, 'children'> {
   id: string
   eyebrow: ReactNode
   title: ReactNode
   lede: ReactNode
   children?: ReactNode
   variant?: PageIntroVariant
-  className?: string
   contentClassName?: string
   overlay?: ReactNode
   topRight?: ReactNode
 }
 
-export function PageIntro({
-  id,
-  eyebrow,
-  title,
-  lede,
-  children,
-  variant = 'card',
-  className,
-  contentClassName,
-  overlay,
-  topRight,
-}: PageIntroProps) {
+export const PageIntro = forwardRef<HTMLElement, PageIntroProps>(function PageIntro(
+  {
+    id,
+    eyebrow,
+    title,
+    lede,
+    children,
+    variant = 'card',
+    className,
+    contentClassName,
+    overlay,
+    topRight,
+    ...rest
+  },
+  ref,
+) {
   const variantClassName = variant === 'hero' ? 'glass-hero' : 'tc-card'
 
   return (
-    <section id={id} className={cn('page-intro anchor-offset relative overflow-hidden', variantClassName, className)}>
+    <section
+      id={id}
+      ref={ref}
+      className={cn('page-intro anchor-offset relative overflow-hidden', variantClassName, className)}
+      {...rest}
+    >
       {overlay ? <div className="pointer-events-none absolute inset-0" aria-hidden>{overlay}</div> : null}
       <div className={cn('relative z-10 flex flex-col gap-6', variant === 'hero' ? 'p-8 sm:p-10 lg:p-12' : 'p-6 sm:p-8', contentClassName)}>
         <div className={cn('flex flex-col gap-4', variant === 'hero' ? 'max-w-3xl' : undefined)}>
@@ -72,4 +82,4 @@ export function PageIntro({
       ) : null}
     </section>
   )
-}
+})

--- a/telcoinwiki-react/src/hooks/useHomeScrollSections.ts
+++ b/telcoinwiki-react/src/hooks/useHomeScrollSections.ts
@@ -1,0 +1,210 @@
+import { useMemo, useRef } from 'react'
+import type { CSSProperties, RefObject } from 'react'
+
+import { useScrollTimeline } from './useScrollTimeline'
+import { usePrefersReducedMotion } from './usePrefersReducedMotion'
+
+type TimelineCreator = Parameters<typeof useScrollTimeline>[0]['create']
+
+function createRevealStyle(prefersReducedMotion: boolean, initial: string): CSSProperties | undefined {
+  return prefersReducedMotion ? { '--color-shift-clip': '0%' } : { '--color-shift-clip': initial }
+}
+
+function createFadeInStyle(prefersReducedMotion: boolean): CSSProperties | undefined {
+  return prefersReducedMotion ? { opacity: 1, transform: 'none' } : undefined
+}
+
+interface BaseSectionState {
+  sectionRef: RefObject<HTMLElement>
+  prefersReducedMotion: boolean
+}
+
+interface HeroSectionState extends BaseSectionState {
+  overlayStyle: CSSProperties | undefined
+  copyStyle: CSSProperties | undefined
+  backgroundStyle: CSSProperties | undefined
+}
+
+interface PillarSectionState extends BaseSectionState {
+  backgroundStyle: CSSProperties | undefined
+  cardStyle: CSSProperties | undefined
+}
+
+interface CommunitySectionState extends BaseSectionState {
+  backgroundStyle: CSSProperties | undefined
+  itemStyle: CSSProperties | undefined
+  asideStyle: CSSProperties | undefined
+}
+
+interface CtaSectionState extends BaseSectionState {
+  backgroundStyle: CSSProperties | undefined
+  copyStyle: CSSProperties | undefined
+  panelStyle: CSSProperties | undefined
+}
+
+function useCinematicSection(
+  prefersReducedMotion: boolean,
+  sectionRef: RefObject<HTMLElement>,
+  create: TimelineCreator,
+  options?: Parameters<typeof useScrollTimeline>[0]['scrollTrigger'],
+) {
+  useScrollTimeline({
+    target: prefersReducedMotion ? null : sectionRef,
+    create,
+    scrollTrigger: options,
+  })
+}
+
+export function useHomeHeroScroll(): HeroSectionState {
+  const sectionRef = useRef<HTMLElement | null>(null)
+  const prefersReducedMotion = usePrefersReducedMotion()
+
+  const overlayStyle = useMemo(() => {
+    if (prefersReducedMotion) {
+      return { clipPath: 'inset(0% 0 0 0)', '--cinematic-reveal': '0%' } as CSSProperties
+    }
+
+    return {
+      clipPath: 'inset(var(--cinematic-reveal, 0%) 0 0 0)',
+      '--cinematic-reveal': '65%',
+    } as CSSProperties
+  }, [prefersReducedMotion])
+
+  const copyStyle = useMemo(() => createFadeInStyle(prefersReducedMotion), [prefersReducedMotion])
+  const backgroundStyle = useMemo(
+    () => (prefersReducedMotion ? { '--color-shift-clip': '0%' } : { '--color-shift-clip': '45%' }),
+    [prefersReducedMotion],
+  )
+
+  useCinematicSection(prefersReducedMotion, sectionRef, (timeline) => {
+    timeline.fromTo(
+      '[data-hero-copy]',
+      { autoAlpha: 0, y: 48 },
+      { autoAlpha: 1, y: 0, duration: 1, stagger: 0.1, ease: 'power2.out' },
+      0,
+    )
+
+    timeline.fromTo(
+      '[data-hero-overlay]',
+      { '--cinematic-reveal': '65%' },
+      { '--cinematic-reveal': '0%', duration: 1.2, ease: 'power2.out' },
+      0,
+    )
+
+    timeline.fromTo(
+      '[data-color-shift]',
+      { '--color-shift-clip': '45%' },
+      { '--color-shift-clip': '0%', duration: 1.1, ease: 'power2.out' },
+      0,
+    )
+  })
+
+  return { sectionRef, prefersReducedMotion, overlayStyle, copyStyle, backgroundStyle }
+}
+
+export function useHomeProductPillarsScroll(): PillarSectionState {
+  const sectionRef = useRef<HTMLElement | null>(null)
+  const prefersReducedMotion = usePrefersReducedMotion()
+
+  const backgroundStyle = useMemo(() => createRevealStyle(prefersReducedMotion, '55%'), [prefersReducedMotion])
+  const cardStyle = useMemo(() => createFadeInStyle(prefersReducedMotion), [prefersReducedMotion])
+
+  useCinematicSection(
+    prefersReducedMotion,
+    sectionRef,
+    (timeline) => {
+      timeline.fromTo(
+        '[data-pillars-card]',
+        { autoAlpha: 0, y: 40 },
+        { autoAlpha: 1, y: 0, duration: 0.7, stagger: 0.15, ease: 'power2.out' },
+      )
+
+      timeline.fromTo(
+        '[data-color-shift]',
+        { '--color-shift-clip': '55%' },
+        { '--color-shift-clip': '0%', duration: 1, ease: 'power2.out' },
+        0,
+      )
+    },
+    { start: 'top 75%', end: 'bottom 25%' },
+  )
+
+  return { sectionRef, prefersReducedMotion, backgroundStyle, cardStyle }
+}
+
+export function useHomeCommunityProofScroll(): CommunitySectionState {
+  const sectionRef = useRef<HTMLElement | null>(null)
+  const prefersReducedMotion = usePrefersReducedMotion()
+
+  const backgroundStyle = useMemo(() => createRevealStyle(prefersReducedMotion, '65%'), [prefersReducedMotion])
+  const itemStyle = useMemo(() => createFadeInStyle(prefersReducedMotion), [prefersReducedMotion])
+  const asideStyle = useMemo(() => createFadeInStyle(prefersReducedMotion), [prefersReducedMotion])
+
+  useCinematicSection(
+    prefersReducedMotion,
+    sectionRef,
+    (timeline) => {
+      timeline.fromTo(
+        '[data-community-proof-item]',
+        { autoAlpha: 0, y: 36 },
+        { autoAlpha: 1, y: 0, duration: 0.6, stagger: 0.1, ease: 'power2.out' },
+        0,
+      )
+
+      timeline.fromTo(
+        '[data-scroll-split-aside]',
+        { autoAlpha: 0, y: 24 },
+        { autoAlpha: 1, y: 0, duration: 0.8, ease: 'power2.out' },
+        0.15,
+      )
+
+      timeline.fromTo(
+        '[data-color-shift]',
+        { '--color-shift-clip': '65%' },
+        { '--color-shift-clip': '0%', duration: 1.05, ease: 'power2.out' },
+        0,
+      )
+    },
+    { start: 'top 80%', end: 'bottom 25%' },
+  )
+
+  return { sectionRef, prefersReducedMotion, backgroundStyle, itemStyle, asideStyle }
+}
+
+export function useHomeCtaScroll(): CtaSectionState {
+  const sectionRef = useRef<HTMLElement | null>(null)
+  const prefersReducedMotion = usePrefersReducedMotion()
+
+  const backgroundStyle = useMemo(() => createRevealStyle(prefersReducedMotion, '58%'), [prefersReducedMotion])
+  const copyStyle = useMemo(() => createFadeInStyle(prefersReducedMotion), [prefersReducedMotion])
+  const panelStyle = useMemo(() => createFadeInStyle(prefersReducedMotion), [prefersReducedMotion])
+
+  useCinematicSection(
+    prefersReducedMotion,
+    sectionRef,
+    (timeline) => {
+      timeline.fromTo(
+        '[data-cta-copy]',
+        { autoAlpha: 0, y: 32 },
+        { autoAlpha: 1, y: 0, duration: 0.7, stagger: 0.12, ease: 'power2.out' },
+      )
+
+      timeline.fromTo(
+        '[data-cta-reveal]',
+        { autoAlpha: 0, y: 36 },
+        { autoAlpha: 1, y: 0, duration: 0.8, ease: 'power2.out' },
+        0.2,
+      )
+
+      timeline.fromTo(
+        '[data-color-shift]',
+        { '--color-shift-clip': '58%' },
+        { '--color-shift-clip': '0%', duration: 1, ease: 'power2.out' },
+        0,
+      )
+    },
+    { start: 'top 80%', end: 'bottom 20%' },
+  )
+
+  return { sectionRef, prefersReducedMotion, backgroundStyle, copyStyle, panelStyle }
+}

--- a/telcoinwiki-react/src/hooks/usePrefersReducedMotion.ts
+++ b/telcoinwiki-react/src/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react'
+
+const PREFERS_REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)'
+
+export function usePrefersReducedMotion(): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return false
+    }
+
+    return window.matchMedia(PREFERS_REDUCED_MOTION_QUERY).matches
+  })
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return undefined
+    }
+
+    const mediaQueryList = window.matchMedia(PREFERS_REDUCED_MOTION_QUERY)
+
+    const updatePreference = (event: MediaQueryListEvent | MediaQueryList) => {
+      setPrefersReducedMotion(event.matches)
+    }
+
+    updatePreference(mediaQueryList)
+
+    if ('addEventListener' in mediaQueryList) {
+      mediaQueryList.addEventListener('change', updatePreference)
+    } else {
+      mediaQueryList.addListener(updatePreference)
+    }
+
+    return () => {
+      if ('removeEventListener' in mediaQueryList) {
+        mediaQueryList.removeEventListener('change', updatePreference)
+      } else {
+        mediaQueryList.removeListener(updatePreference)
+      }
+    }
+  }, [])
+
+  return prefersReducedMotion
+}

--- a/telcoinwiki-react/src/pages/HomePage.tsx
+++ b/telcoinwiki-react/src/pages/HomePage.tsx
@@ -1,28 +1,124 @@
 import { Link } from 'react-router-dom'
+import { ColorShiftBackground } from '../components/cinematic/ColorShiftBackground'
+import { ScrollSplit } from '../components/cinematic/ScrollSplit'
+import { StickyModule } from '../components/cinematic/StickyModule'
 import { HeroOverlay } from '../components/content/HeroOverlay'
 import { PageIntro } from '../components/content/PageIntro'
 import { HeroFloatingChips } from '../components/home/HeroFloatingChips'
 import { HeroTicker } from '../components/home/HeroTicker'
 import { HeroTypingLoop } from '../components/home/HeroTypingLoop'
 import { DeepDiveFaqSections } from '../components/deepDive/DeepDiveFaqSections'
+import {
+  useHomeCtaScroll,
+  useHomeHeroScroll,
+  useHomeCommunityProofScroll,
+  useHomeProductPillarsScroll,
+} from '../hooks/useHomeScrollSections'
+
+const productPillars = [
+  {
+    id: 'orientation',
+    eyebrow: 'Orientation',
+    title: 'Understand the ecosystem',
+    body: 'See how the Wallet, Telcoin Network, and Association work together before you dive into product specifics.',
+    href: '/start-here',
+    cta: 'Start the quickstart',
+  },
+  {
+    id: 'wallet',
+    eyebrow: 'Wallet basics',
+    title: 'Set up and secure your app',
+    body: 'Walk through verification, recovery phrases, and security best practices to keep your account protected.',
+    href: '/wallet',
+    cta: 'Open the wallet playbook',
+  },
+  {
+    id: 'digital-cash',
+    eyebrow: 'Digital Cash',
+    title: 'Learn about stable-value assets',
+    body: 'Understand supported e-money tokens, how minting works, and where to monitor reserve disclosures.',
+    href: '/digital-cash',
+    cta: 'Explore Digital Cash',
+  },
+  {
+    id: 'remittances',
+    eyebrow: 'Remittances',
+    title: 'Move money across borders',
+    body: 'Track active corridors, payout partners, and pricing straight from official Telcoin Wallet updates.',
+    href: '/remittances',
+    cta: 'Check remittance corridors',
+  },
+  {
+    id: 'deep-dive',
+    eyebrow: 'Deep dive',
+    title: 'Go beyond the basics',
+    body: 'Connect with TEL token utility, TELx liquidity programs, and governance resources when you’re ready for advanced topics.',
+    href: '/deep-dive',
+    cta: 'Review deep-dive guides',
+  },
+]
+
+const communityHighlights = [
+  {
+    title: 'Contributions from Telcoin advocates',
+    description:
+      'Volunteer editors, community ambassadors, and early adopters share verified answers so new users can move faster.',
+  },
+  {
+    title: 'Links back to official releases',
+    description:
+      'Every guide points to canonical Telcoin Association statements, Telcoin Wallet updates, and regulatory notices.',
+  },
+  {
+    title: 'Context from real-world usage',
+    description: 'Workflow walkthroughs and checklists come from people actively sending remittances and managing liquidity.',
+  },
+]
 
 export function HomePage() {
+  const hero = useHomeHeroScroll()
+  const pillars = useHomeProductPillarsScroll()
+  const community = useHomeCommunityProofScroll()
+  const cta = useHomeCtaScroll()
+
   return (
     <>
       <PageIntro
         id="home-hero"
+        ref={hero.sectionRef}
         variant="hero"
-        className="bg-hero-linear animate-gradient [background-size:180%_180%]"
+        aria-labelledby="home-hero-heading"
+        className="relative isolate bg-hero-linear animate-gradient [background-size:180%_180%]"
         overlay={
-          <HeroOverlay>
-            <HeroFloatingChips />
-          </HeroOverlay>
+          <>
+            <ColorShiftBackground
+              style={hero.backgroundStyle}
+              from="rgba(18,101,255,0.35)"
+              to="rgba(142,82,255,0.25)"
+            />
+            <HeroOverlay
+              className="bg-gradient-to-br from-telcoin-surface/0 via-telcoin-surface/20 to-telcoin-surface/0"
+              style={hero.overlayStyle}
+              data-hero-overlay=""
+            >
+              <HeroFloatingChips />
+            </HeroOverlay>
+          </>
         }
         eyebrow={<HeroTypingLoop />}
-        title="Understand the Telcoin platform in minutes"
-        lede="This unofficial wiki curates verified answers, onboarding checklists, and direct links to Telcoin Association and Telcoin company resources so newcomers can get started with confidence."
+        title={
+          <span id="home-hero-heading" data-hero-copy style={hero.copyStyle}>
+            Understand the Telcoin platform in minutes
+          </span>
+        }
+        lede={
+          <span data-hero-copy style={hero.copyStyle}>
+            This unofficial wiki curates verified answers, onboarding checklists, and direct links to Telcoin Association and
+            Telcoin company resources so newcomers can get started with confidence.
+          </span>
+        }
       >
-        <div className="flex flex-col gap-4 lg:gap-6">
+        <div className="flex flex-col gap-4 lg:gap-6" data-hero-copy style={hero.copyStyle}>
           <HeroTicker />
           <p className="text-sm text-telcoin-ink/70">
             Community-maintained reference. Confirm details inside the Telcoin Wallet or official Association releases.
@@ -30,72 +126,125 @@ export function HomePage() {
         </div>
       </PageIntro>
 
-      <section id="learning-pathways" className="lp anchor-offset">
-        <div className="lp-head">
-          <h2>Learning pathways</h2>
-          <p className="lp-lead">
-            Five curated tracks connect you to the official docs and community explainers that answer the most common Telcoin
-            questions.
-          </p>
-        </div>
-        <div className="lp-grid" role="list">
-          <article className="lp-card" role="listitem">
-            <span className="lp-eyebrow">Orientation</span>
-            <h3 className="lp-title">Understand the ecosystem</h3>
-            <p className="lp-body">
-              See how the Wallet, Telcoin Network, and Association work together before you dive into product specifics.
+      <StickyModule
+        ref={pillars.sectionRef}
+        id="home-pillars"
+        aria-labelledby="home-pillars-heading"
+        background={<ColorShiftBackground style={pillars.backgroundStyle} from="rgba(22,18,54,0.35)" to="rgba(67,34,122,0.25)" />}
+        sticky={
+          <div className="flex flex-col gap-4" data-pillars-intro>
+            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-telcoin-ink-subtle">Product pillars</p>
+            <h2 id="home-pillars-heading" className="text-3xl font-semibold text-telcoin-ink lg:text-4xl">
+              Choose a pathway tailored to your goal
+            </h2>
+            <p className="max-w-xl text-lg text-telcoin-ink-muted">
+              Five curated tracks map the Telcoin experience—from orientation through deep-dive liquidity strategies—so you
+              can explore at your own pace.
             </p>
-            <p className="lp-cta">
-              <Link to="/start-here">Start the quickstart</Link>
-            </p>
-          </article>
-          <article className="lp-card" role="listitem">
-            <span className="lp-eyebrow">Wallet basics</span>
-            <h3 className="lp-title">Set up and secure your app</h3>
-            <p className="lp-body">
-              Walk through verification, recovery phrases, and security best practices to keep your account protected.
-            </p>
-            <p className="lp-cta">
-              <Link to="/wallet">Open the wallet playbook</Link>
-            </p>
-          </article>
-          <article className="lp-card" role="listitem">
-            <span className="lp-eyebrow">Digital Cash</span>
-            <h3 className="lp-title">Learn about stable-value assets</h3>
-            <p className="lp-body">
-              Understand supported e-money tokens, how minting works, and where to monitor reserve disclosures.
-            </p>
-            <p className="lp-cta">
-              <Link to="/digital-cash">Explore Digital Cash</Link>
-            </p>
-          </article>
-          <article className="lp-card" role="listitem">
-            <span className="lp-eyebrow">Remittances</span>
-            <h3 className="lp-title">Move money across borders</h3>
-            <p className="lp-body">
-              Track active corridors, payout partners, and pricing straight from official Telcoin Wallet updates.
-            </p>
-            <p className="lp-cta">
-              <Link to="/remittances">Check remittance corridors</Link>
-            </p>
-          </article>
-          <article className="lp-card" role="listitem">
-            <span className="lp-eyebrow">Deep dive</span>
-            <h3 className="lp-title">Go beyond the basics</h3>
-            <p className="lp-body">
-              Connect with TEL token utility, TELx liquidity programs, and governance resources when you’re ready for advanced
-              topics.
-            </p>
-            <p className="lp-cta">
-              <Link to="/deep-dive">Review deep-dive guides</Link>
-            </p>
-          </article>
-        </div>
-      </section>
+          </div>
+        }
+        content={
+          <div className="grid gap-6" role="list">
+            {productPillars.map((pillar) => (
+              <article
+                key={pillar.id}
+                role="listitem"
+                className="flex flex-col gap-4 rounded-2xl border border-telcoin-border bg-telcoin-surface/80 p-6 shadow-lg backdrop-blur"
+                data-pillars-card
+                style={pillars.cardStyle}
+              >
+                <span className="text-xs font-semibold uppercase tracking-[0.2em] text-telcoin-ink-subtle">
+                  {pillar.eyebrow}
+                </span>
+                <h3 className="text-xl font-semibold text-telcoin-ink">{pillar.title}</h3>
+                <p className="text-base text-telcoin-ink-muted">{pillar.body}</p>
+                <p>
+                  <Link className="inline-flex items-center gap-2 text-sm font-semibold text-telcoin-accent" to={pillar.href}>
+                    {pillar.cta}
+                    <span aria-hidden>→</span>
+                  </Link>
+                </p>
+              </article>
+            ))}
+          </div>
+        }
+      />
 
-      <section id="faq" className="faq anchor-offset" aria-labelledby="faq-heading">
-        <h2 id="faq-heading">FAQs</h2>
-        <DeepDiveFaqSections />
+      <StickyModule
+        ref={community.sectionRef}
+        id="home-community"
+        aria-labelledby="home-community-heading"
+        background={<ColorShiftBackground style={community.backgroundStyle} from="rgba(8, 38, 77, 0.35)" to="rgba(67, 157, 255, 0.25)" />}
+        containerClassName="lg:gap-12"
+        sticky={
+          <ScrollSplit
+            lead={
+              <>
+                <p className="text-sm font-semibold uppercase tracking-[0.2em] text-telcoin-ink-subtle">Community proof</p>
+                <h2 id="home-community-heading" className="text-3xl font-semibold text-telcoin-ink lg:text-4xl">
+                  Built alongside the Telcoin community
+                </h2>
+                <p className="text-lg text-telcoin-ink-muted">
+                  Real users publish the checklists and resources they rely on every day, while live network data keeps the
+                  story grounded in what’s shipping now.
+                </p>
+              </>
+            }
+            asideTop="18vh"
+            aside={
+              <div data-scroll-split-aside style={community.asideStyle}>
+                <HeroTicker />
+              </div>
+            }
+          />
+        }
+        content={
+          <ul className="grid gap-6" role="list">
+            {communityHighlights.map((highlight) => (
+              <li
+                key={highlight.title}
+                className="rounded-2xl border border-telcoin-border/80 bg-telcoin-surface/80 p-6 shadow-md backdrop-blur"
+                data-community-proof-item
+                style={community.itemStyle}
+              >
+                <h3 className="text-lg font-semibold text-telcoin-ink">{highlight.title}</h3>
+                <p className="mt-2 text-base text-telcoin-ink-muted">{highlight.description}</p>
+              </li>
+            ))}
+          </ul>
+        }
+      />
+
+      <section
+        ref={cta.sectionRef}
+        id="home-cta"
+        aria-labelledby="home-cta-heading"
+        className="relative isolate overflow-hidden"
+      >
+        <ColorShiftBackground style={cta.backgroundStyle} from="rgba(28,20,56,0.5)" to="rgba(105,67,255,0.25)" />
+        <div className="mx-auto flex max-w-6xl flex-col gap-10 px-6 py-24 sm:px-8 lg:px-12">
+          <div className="max-w-3xl space-y-4">
+            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-telcoin-ink-subtle" data-cta-copy style={cta.copyStyle}>
+              Keep going
+            </p>
+            <h2 id="home-cta-heading" className="text-3xl font-semibold text-telcoin-ink lg:text-4xl" data-cta-copy style={cta.copyStyle}>
+              Stay curious with Telcoin deep dives and FAQs
+            </h2>
+            <p className="text-lg text-telcoin-ink-muted" data-cta-copy style={cta.copyStyle}>
+              Bookmark the wiki to check corridor updates, compare Telcoin Wallet releases, or answer the next question your
+              friends ask. The FAQ below surfaces our most-read explainers.
+            </p>
+            <div data-cta-copy style={cta.copyStyle}>
+              <Link className="inline-flex items-center gap-2 text-sm font-semibold text-telcoin-accent" to="/start-here">
+                See the onboarding guide
+                <span aria-hidden>→</span>
+              </Link>
+            </div>
+          </div>
+          <div className="rounded-2xl border border-telcoin-border/80 bg-telcoin-surface/90 p-6 shadow-lg backdrop-blur" data-cta-reveal style={cta.panelStyle}>
+            <DeepDiveFaqSections />
+          </div>
+        </div>
       </section>
     </>
   )


### PR DESCRIPTION
## Summary
- rebuild the home page into hero, product pillar, community proof, and CTA sections that drive new scroll animations
- add cinematic primitives for sticky storytelling layouts and gradient reveals
- introduce reusable scroll hooks with reduced-motion fallbacks and refactor shared overlays to support the new effects

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4322e4e4c83309ec605f6f181191c