### PR TITLE
Add cinematic stage backgrounds

### DIFF
--- a/telcoinwiki-react/src/components/cinematic/ColorMorphCard.tsx
+++ b/telcoinwiki-react/src/components/cinematic/ColorMorphCard.tsx
@@ -1,0 +1,40 @@
+import type { ComponentPropsWithoutRef, CSSProperties, ElementType } from 'react'
+import { forwardRef } from 'react'
+
+import { cn } from '../../utils/cn'
+import { clamp01, lerp } from '../../utils/interpolate'
+
+interface ColorMorphCardProps extends ComponentPropsWithoutRef<'article'> {
+  progress: number
+  as?: ElementType
+}
+
+export const ColorMorphCard = forwardRef<HTMLElement, ColorMorphCardProps>(function ColorMorphCard(
+  { as, progress, className, style, children, ...rest },
+  ref,
+) {
+  const Component = (as ?? 'article') as ElementType
+  const clamped = clamp01(progress)
+
+  const overlayAlpha = lerp(0.26, 0.64, clamped)
+  const borderAlpha = lerp(0.28, 0.56, clamped)
+  const shadowAlpha = lerp(0.18, 0.46, clamped)
+  const translateY = lerp(24, 0, clamped)
+  const scale = lerp(0.96, 1.0, clamped)
+  const opacity = lerp(0.82, 1, clamped)
+
+  const styleWithMorph = {
+    '--stage-card-overlay-alpha': overlayAlpha.toFixed(3),
+    '--stage-card-border-alpha': borderAlpha.toFixed(3),
+    '--stage-card-shadow-alpha': shadowAlpha.toFixed(3),
+    transform: `translateY(${translateY.toFixed(2)}px) scale(${scale.toFixed(3)})`,
+    opacity,
+    ...style,
+  } as CSSProperties
+
+  return (
+    <Component ref={ref as never} className={cn('color-morph-card', className)} style={styleWithMorph} {...rest}>
+      {children}
+    </Component>
+  )
+})

--- a/telcoinwiki-react/src/components/cinematic/StageBackdrop.tsx
+++ b/telcoinwiki-react/src/components/cinematic/StageBackdrop.tsx
@@ -1,0 +1,39 @@
+import type { ComponentPropsWithoutRef, CSSProperties } from 'react'
+
+import { cn } from '../../utils/cn'
+import { clamp01, lerp } from '../../utils/interpolate'
+
+interface StageBackdropProps extends ComponentPropsWithoutRef<'div'> {
+  progress: number
+}
+
+export function StageBackdrop({ progress, className, style, ...rest }: StageBackdropProps) {
+  const clamped = clamp01(progress)
+
+  const overlayAlpha = lerp(0.24, 0.58, clamped)
+  const spotAlpha = lerp(0.18, 0.46, clamped)
+  const clip = lerp(32, 0, clamped)
+  const spotX = lerp(44, 56, clamped)
+  const spotY = lerp(28, 64, clamped)
+  const opacity = lerp(0.82, 1, clamped)
+
+  const backdropStyle = {
+    '--stage-overlay-alpha': overlayAlpha.toFixed(3),
+    '--stage-spot-alpha': spotAlpha.toFixed(3),
+    '--stage-spot-x': `${spotX.toFixed(1)}%`,
+    '--stage-spot-y': `${spotY.toFixed(1)}%`,
+    '--stage-backdrop-clip': `${clip.toFixed(2)}%`,
+    '--stage-backdrop-opacity': opacity.toFixed(3),
+    ...style,
+  } as CSSProperties
+
+  return (
+    <div
+      aria-hidden
+      data-stage-backdrop
+      className={cn('stage-backdrop', className)}
+      style={backdropStyle}
+      {...rest}
+    />
+  )
+}

--- a/telcoinwiki-react/src/hooks/useStageTimeline.ts
+++ b/telcoinwiki-react/src/hooks/useStageTimeline.ts
@@ -1,0 +1,201 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import type { ScrollTrigger as ScrollTriggerType } from 'gsap/ScrollTrigger'
+
+import { clamp01, lerp } from '../utils/interpolate'
+import { usePrefersReducedMotion } from './usePrefersReducedMotion'
+import { useScrollTimeline } from './useScrollTimeline'
+
+interface StageStop {
+  hue: number
+  accentHue?: number
+  overlayOpacity?: number
+  spotOpacity?: number
+  cardOverlayOpacity?: number
+  cardBorderOpacity?: number
+  cardShadowOpacity?: number
+}
+
+export interface UseStageTimelineConfig {
+  target: Parameters<typeof useScrollTimeline>[0]['target']
+  from: StageStop
+  to: StageStop
+  scrollTrigger?: ScrollTriggerType.Vars
+  prefersReducedMotion?: boolean
+}
+
+interface NormalizedStageStop {
+  hue: number
+  accentHue: number
+  overlayOpacity: number
+  spotOpacity: number
+  cardOverlayOpacity: number
+  cardBorderOpacity: number
+  cardShadowOpacity: number
+}
+
+const defaultStop: NormalizedStageStop = {
+  hue: 220,
+  accentHue: 268,
+  overlayOpacity: 0.38,
+  spotOpacity: 0.28,
+  cardOverlayOpacity: 0.32,
+  cardBorderOpacity: 0.38,
+  cardShadowOpacity: 0.26,
+}
+
+const stageVariableMap: Record<keyof NormalizedStageStop, string> = {
+  hue: '--tc-stage-hue',
+  accentHue: '--tc-stage-accent-hue',
+  overlayOpacity: '--tc-stage-overlay-opacity',
+  spotOpacity: '--tc-stage-spot-opacity',
+  cardOverlayOpacity: '--tc-stage-card-overlay-opacity',
+  cardBorderOpacity: '--tc-stage-card-border-opacity',
+  cardShadowOpacity: '--tc-stage-card-shadow-opacity',
+}
+
+function normalizeStop(stop: StageStop): NormalizedStageStop {
+  return {
+    hue: stop.hue,
+    accentHue: stop.accentHue ?? defaultStop.accentHue,
+    overlayOpacity: stop.overlayOpacity ?? defaultStop.overlayOpacity,
+    spotOpacity: stop.spotOpacity ?? defaultStop.spotOpacity,
+    cardOverlayOpacity: stop.cardOverlayOpacity ?? defaultStop.cardOverlayOpacity,
+    cardBorderOpacity: stop.cardBorderOpacity ?? defaultStop.cardBorderOpacity,
+    cardShadowOpacity: stop.cardShadowOpacity ?? defaultStop.cardShadowOpacity,
+  }
+}
+
+function interpolateStops(start: NormalizedStageStop, end: NormalizedStageStop, progress: number): NormalizedStageStop {
+  return {
+    hue: lerp(start.hue, end.hue, progress),
+    accentHue: lerp(start.accentHue, end.accentHue, progress),
+    overlayOpacity: lerp(start.overlayOpacity, end.overlayOpacity, progress),
+    spotOpacity: lerp(start.spotOpacity, end.spotOpacity, progress),
+    cardOverlayOpacity: lerp(start.cardOverlayOpacity, end.cardOverlayOpacity, progress),
+    cardBorderOpacity: lerp(start.cardBorderOpacity, end.cardBorderOpacity, progress),
+    cardShadowOpacity: lerp(start.cardShadowOpacity, end.cardShadowOpacity, progress),
+  }
+}
+
+function applyStageStop(root: HTMLElement, stop: NormalizedStageStop) {
+  root.style.setProperty(stageVariableMap.hue, stop.hue.toFixed(2))
+  root.style.setProperty(stageVariableMap.accentHue, stop.accentHue.toFixed(2))
+  root.style.setProperty(stageVariableMap.overlayOpacity, stop.overlayOpacity.toFixed(3))
+  root.style.setProperty(stageVariableMap.spotOpacity, stop.spotOpacity.toFixed(3))
+  root.style.setProperty(stageVariableMap.cardOverlayOpacity, stop.cardOverlayOpacity.toFixed(3))
+  root.style.setProperty(stageVariableMap.cardBorderOpacity, stop.cardBorderOpacity.toFixed(3))
+  root.style.setProperty(stageVariableMap.cardShadowOpacity, stop.cardShadowOpacity.toFixed(3))
+}
+
+function useStageStopMemo(stop: StageStop): NormalizedStageStop {
+  return useMemo(() => normalizeStop(stop), [
+    stop.hue,
+    stop.accentHue,
+    stop.overlayOpacity,
+    stop.spotOpacity,
+    stop.cardOverlayOpacity,
+    stop.cardBorderOpacity,
+    stop.cardShadowOpacity,
+  ])
+}
+
+export function useStageTimeline({
+  target,
+  from,
+  to,
+  scrollTrigger,
+  prefersReducedMotion,
+}: UseStageTimelineConfig): number {
+  const prefersReducedMotionValue = usePrefersReducedMotion()
+  const shouldReduce = prefersReducedMotion ?? prefersReducedMotionValue
+  const [progress, setProgress] = useState(0)
+
+  const fromStop = useStageStopMemo(from)
+  const toStop = useStageStopMemo(to)
+
+  const combinedScrollTrigger = useMemo(() => {
+    const base: ScrollTriggerType.Vars = { ...(scrollTrigger ?? {}) }
+
+    if (shouldReduce) {
+      base.scrub = false
+    } else if (typeof base.scrub === 'undefined') {
+      base.scrub = true
+    }
+
+    return base
+  }, [scrollTrigger, shouldReduce])
+
+  useScrollTimeline({
+    target,
+    scrollTrigger: combinedScrollTrigger,
+    create: useCallback(
+      (timeline) => {
+        if (typeof document === 'undefined') {
+          return
+        }
+
+        const root = document.documentElement
+        const trigger = timeline.scrollTrigger
+
+        if (shouldReduce) {
+          const applyFrom = () => {
+            applyStageStop(root, fromStop)
+            setProgress(0)
+          }
+          const applyTo = () => {
+            applyStageStop(root, toStop)
+            setProgress(1)
+          }
+
+          trigger?.eventCallback('onEnter', applyTo)
+          trigger?.eventCallback('onEnterBack', applyTo)
+          trigger?.eventCallback('onLeave', applyFrom)
+          trigger?.eventCallback('onLeaveBack', applyFrom)
+
+          if (trigger && (trigger.progress > 0 || trigger.isActive)) {
+            applyTo()
+          } else {
+            applyFrom()
+          }
+
+          return
+        }
+
+        const update = (value: number) => {
+          const clamped = clamp01(value)
+
+          if (clamped <= 0 && !trigger?.isActive) {
+            setProgress(0)
+            return
+          }
+
+          const stageStop = interpolateStops(fromStop, toStop, clamped)
+          applyStageStop(root, stageStop)
+          setProgress(clamped)
+        }
+
+        timeline.to({}, {
+          duration: 1,
+          onUpdate: () => {
+            update(timeline.progress())
+          },
+        })
+
+        update(timeline.progress())
+      },
+      [fromStop, shouldReduce, toStop],
+    ),
+  })
+
+  useEffect(() => {
+    if (!shouldReduce || typeof document === 'undefined') {
+      return
+    }
+
+    const root = document.documentElement
+    applyStageStop(root, progress > 0 ? toStop : fromStop)
+  }, [fromStop, progress, shouldReduce, toStop])
+
+  return progress
+}

--- a/telcoinwiki-react/src/pages/HomePage.tsx
+++ b/telcoinwiki-react/src/pages/HomePage.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom'
-import { ColorShiftBackground } from '../components/cinematic/ColorShiftBackground'
+import { ColorMorphCard } from '../components/cinematic/ColorMorphCard'
+import { StageBackdrop } from '../components/cinematic/StageBackdrop'
 import { ScrollSplit } from '../components/cinematic/ScrollSplit'
 import { StickyModule } from '../components/cinematic/StickyModule'
 import { HeroOverlay } from '../components/content/HeroOverlay'
@@ -88,14 +89,10 @@ export function HomePage() {
         ref={hero.sectionRef}
         variant="hero"
         aria-labelledby="home-hero-heading"
-        className="relative isolate bg-hero-linear animate-gradient [background-size:180%_180%]"
+        className="stage-theme relative isolate bg-hero-linear animate-gradient [background-size:180%_180%]"
         overlay={
           <>
-            <ColorShiftBackground
-              style={hero.backgroundStyle}
-              from="rgba(18,101,255,0.35)"
-              to="rgba(142,82,255,0.25)"
-            />
+            <StageBackdrop progress={hero.stageProgress} />
             <HeroOverlay
               className="bg-gradient-to-br from-telcoin-surface/0 via-telcoin-surface/20 to-telcoin-surface/0"
               style={hero.overlayStyle}
@@ -127,10 +124,11 @@ export function HomePage() {
       </PageIntro>
 
       <StickyModule
+        className="stage-theme"
         ref={pillars.sectionRef}
         id="home-pillars"
         aria-labelledby="home-pillars-heading"
-        background={<ColorShiftBackground style={pillars.backgroundStyle} from="rgba(22,18,54,0.35)" to="rgba(67,34,122,0.25)" />}
+        background={<StageBackdrop progress={pillars.stageProgress} />}
         sticky={
           <div className="flex flex-col gap-4" data-pillars-intro>
             <p className="text-sm font-semibold uppercase tracking-[0.2em] text-telcoin-ink-subtle">Product pillars</p>
@@ -146,10 +144,12 @@ export function HomePage() {
         content={
           <div className="grid gap-6" role="list">
             {productPillars.map((pillar) => (
-              <article
+              <ColorMorphCard
+                as="article"
                 key={pillar.id}
                 role="listitem"
-                className="flex flex-col gap-4 rounded-2xl border border-telcoin-border bg-telcoin-surface/80 p-6 shadow-lg backdrop-blur"
+                progress={pillars.stageProgress}
+                className="flex flex-col gap-4 p-6 shadow-lg"
                 data-pillars-card
                 style={pillars.cardStyle}
               >
@@ -164,17 +164,18 @@ export function HomePage() {
                     <span aria-hidden>→</span>
                   </Link>
                 </p>
-              </article>
+              </ColorMorphCard>
             ))}
           </div>
         }
       />
 
       <StickyModule
+        className="stage-theme"
         ref={community.sectionRef}
         id="home-community"
         aria-labelledby="home-community-heading"
-        background={<ColorShiftBackground style={community.backgroundStyle} from="rgba(8, 38, 77, 0.35)" to="rgba(67, 157, 255, 0.25)" />}
+        background={<StageBackdrop progress={community.stageProgress} />}
         containerClassName="lg:gap-12"
         sticky={
           <ScrollSplit
@@ -219,9 +220,9 @@ export function HomePage() {
         ref={cta.sectionRef}
         id="home-cta"
         aria-labelledby="home-cta-heading"
-        className="relative isolate overflow-hidden"
+        className="stage-theme relative isolate overflow-hidden"
       >
-        <ColorShiftBackground style={cta.backgroundStyle} from="rgba(28,20,56,0.5)" to="rgba(105,67,255,0.25)" />
+        <StageBackdrop progress={cta.stageProgress} />
         <div className="mx-auto flex max-w-6xl flex-col gap-10 px-6 py-24 sm:px-8 lg:px-12">
           <div className="max-w-3xl space-y-4">
             <p className="text-sm font-semibold uppercase tracking-[0.2em] text-telcoin-ink-subtle" data-cta-copy style={cta.copyStyle}>
@@ -241,9 +242,15 @@ export function HomePage() {
               </Link>
             </div>
           </div>
-          <div className="rounded-2xl border border-telcoin-border/80 bg-telcoin-surface/90 p-6 shadow-lg backdrop-blur" data-cta-reveal style={cta.panelStyle}>
+          <ColorMorphCard
+            as="div"
+            progress={cta.stageProgress}
+            className="p-6 shadow-lg"
+            data-cta-reveal
+            style={cta.panelStyle}
+          >
             <DeepDiveFaqSections />
-          </div>
+          </ColorMorphCard>
         </div>
       </section>
     </>

--- a/telcoinwiki-react/src/styles/critical.css
+++ b/telcoinwiki-react/src/styles/critical.css
@@ -25,6 +25,14 @@
   --color-warning-soft: rgba(250, 204, 21, 0.18);
   --color-info-soft: var(--tc-accent-soft);
 
+  --tc-stage-hue: 220;
+  --tc-stage-accent-hue: 268;
+  --tc-stage-overlay-opacity: 0.38;
+  --tc-stage-spot-opacity: 0.28;
+  --tc-stage-card-overlay-opacity: 0.32;
+  --tc-stage-card-border-opacity: 0.38;
+  --tc-stage-card-shadow-opacity: 0.26;
+
   --space-1: 0.25rem;
   --space-2: 0.5rem;
   --space-3: 0.75rem;
@@ -166,6 +174,74 @@ ol {
 
 .skip-link:focus {
   top: var(--space-3);
+}
+
+.stage-theme {
+  position: relative;
+  isolation: isolate;
+  --stage-overlay-alpha: var(--tc-stage-overlay-opacity, 0.38);
+  --stage-spot-alpha: var(--tc-stage-spot-opacity, 0.28);
+  --stage-card-overlay-alpha: var(--tc-stage-card-overlay-opacity, 0.32);
+  --stage-card-border-alpha: var(--tc-stage-card-border-opacity, 0.38);
+  --stage-card-shadow-alpha: var(--tc-stage-card-shadow-opacity, 0.26);
+  --stage-spot-x: 50%;
+  --stage-spot-y: 35%;
+  --stage-backdrop-clip: 0%;
+  --stage-backdrop-opacity: 1;
+}
+
+.stage-backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  border-radius: inherit;
+  background-image:
+    radial-gradient(
+      120% 120% at var(--stage-spot-x, 50%) var(--stage-spot-y, 35%),
+      hsla(var(--tc-stage-accent-hue, 268) 92% 62% / var(--stage-spot-alpha, 0.28)),
+      transparent 72%
+    ),
+    linear-gradient(
+      130deg,
+      hsla(var(--tc-stage-hue, 220) 92% 58% / var(--stage-overlay-alpha, 0.38)),
+      hsla(calc(var(--tc-stage-accent-hue, 268) + 14) 88% 54% / calc(var(--stage-overlay-alpha, 0.38) * 0.65))
+    );
+  clip-path: inset(var(--stage-backdrop-clip, 0%) 0 0 0 round inherit);
+  opacity: var(--stage-backdrop-opacity, 1);
+  filter: saturate(115%);
+  transition:
+    clip-path 0.6s var(--transition-smooth),
+    opacity 0.6s var(--transition-smooth),
+    background-position 0.6s var(--transition-smooth),
+    background-size 0.6s var(--transition-smooth),
+    filter 0.6s var(--transition-smooth);
+}
+
+.color-morph-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  border-radius: var(--radius-big);
+  border: 1px solid hsla(var(--tc-stage-hue, 220) 78% 68% / var(--stage-card-border-alpha, 0.38));
+  background-image: linear-gradient(
+    135deg,
+    hsla(var(--tc-stage-hue, 220) 90% 60% / var(--stage-card-overlay-alpha, 0.32)),
+    hsla(var(--tc-stage-accent-hue, 268) 86% 60% / calc(var(--stage-card-overlay-alpha, 0.32) * 0.7))
+  );
+  box-shadow: 0 18px 42px hsla(var(--tc-stage-hue, 220) 62% 38% / var(--stage-card-shadow-alpha, 0.26));
+  color: var(--tc-ink);
+  background-color: rgba(5, 11, 31, 0.45);
+  overflow: hidden;
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  transition:
+    background-image 0.6s var(--transition-smooth),
+    border-color 0.6s var(--transition-smooth),
+    box-shadow 0.6s var(--transition-smooth),
+    transform 0.6s var(--transition-smooth),
+    opacity 0.6s var(--transition-smooth);
 }
 
 .site-header {

--- a/telcoinwiki-react/src/styles/site.css
+++ b/telcoinwiki-react/src/styles/site.css
@@ -141,6 +141,74 @@ pre {
   top: var(--space-3);
 }
 
+.stage-theme {
+  position: relative;
+  isolation: isolate;
+  --stage-overlay-alpha: var(--tc-stage-overlay-opacity, 0.38);
+  --stage-spot-alpha: var(--tc-stage-spot-opacity, 0.28);
+  --stage-card-overlay-alpha: var(--tc-stage-card-overlay-opacity, 0.32);
+  --stage-card-border-alpha: var(--tc-stage-card-border-opacity, 0.38);
+  --stage-card-shadow-alpha: var(--tc-stage-card-shadow-opacity, 0.26);
+  --stage-spot-x: 50%;
+  --stage-spot-y: 35%;
+  --stage-backdrop-clip: 0%;
+  --stage-backdrop-opacity: 1;
+}
+
+.stage-backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  border-radius: inherit;
+  background-image:
+    radial-gradient(
+      120% 120% at var(--stage-spot-x, 50%) var(--stage-spot-y, 35%),
+      hsla(var(--tc-stage-accent-hue, 268) 92% 62% / var(--stage-spot-alpha, 0.28)),
+      transparent 72%
+    ),
+    linear-gradient(
+      130deg,
+      hsla(var(--tc-stage-hue, 220) 92% 58% / var(--stage-overlay-alpha, 0.38)),
+      hsla(calc(var(--tc-stage-accent-hue, 268) + 14) 88% 54% / calc(var(--stage-overlay-alpha, 0.38) * 0.65))
+    );
+  clip-path: inset(var(--stage-backdrop-clip, 0%) 0 0 0 round inherit);
+  opacity: var(--stage-backdrop-opacity, 1);
+  filter: saturate(115%);
+  transition:
+    clip-path 0.6s var(--transition-smooth),
+    opacity 0.6s var(--transition-smooth),
+    background-position 0.6s var(--transition-smooth),
+    background-size 0.6s var(--transition-smooth),
+    filter 0.6s var(--transition-smooth);
+}
+
+.color-morph-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  border-radius: var(--radius-big);
+  border: 1px solid hsla(var(--tc-stage-hue, 220) 78% 68% / var(--stage-card-border-alpha, 0.38));
+  background-image: linear-gradient(
+    135deg,
+    hsla(var(--tc-stage-hue, 220) 90% 60% / var(--stage-card-overlay-alpha, 0.32)),
+    hsla(var(--tc-stage-accent-hue, 268) 86% 60% / calc(var(--stage-card-overlay-alpha, 0.32) * 0.7))
+  );
+  box-shadow: 0 18px 42px hsla(var(--tc-stage-hue, 220) 62% 38% / var(--stage-card-shadow-alpha, 0.26));
+  color: var(--tc-ink);
+  background-color: rgba(5, 11, 31, 0.45);
+  overflow: hidden;
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  transition:
+    background-image 0.6s var(--transition-smooth),
+    border-color 0.6s var(--transition-smooth),
+    box-shadow 0.6s var(--transition-smooth),
+    transform 0.6s var(--transition-smooth),
+    opacity 0.6s var(--transition-smooth);
+}
+
 .site-header {
   position: sticky;
   top: 0;

--- a/telcoinwiki-react/src/styles/tokens.css
+++ b/telcoinwiki-react/src/styles/tokens.css
@@ -44,6 +44,14 @@
   --tc-ocean-gradient: linear-gradient(256deg, rgba(55, 174, 255, 0.6), rgba(85, 51, 255, 0.6)),
     linear-gradient(245deg, rgba(51, 172, 255, 0.3) 43.29%, var(--tc-blue-violet) 78%);
 
+  --tc-stage-hue: 220;
+  --tc-stage-accent-hue: 268;
+  --tc-stage-overlay-opacity: 0.38;
+  --tc-stage-spot-opacity: 0.28;
+  --tc-stage-card-overlay-opacity: 0.32;
+  --tc-stage-card-border-opacity: 0.38;
+  --tc-stage-card-shadow-opacity: 0.26;
+
   --tc-radius: 1rem;
   --tc-radius-lg: 1.25rem;
   --tc-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);

--- a/telcoinwiki-react/src/utils/interpolate.ts
+++ b/telcoinwiki-react/src/utils/interpolate.ts
@@ -1,0 +1,19 @@
+export function clamp01(value: number): number {
+  if (Number.isNaN(value)) {
+    return 0
+  }
+
+  if (value < 0) {
+    return 0
+  }
+
+  if (value > 1) {
+    return 1
+  }
+
+  return value
+}
+
+export function lerp(start: number, end: number, t: number): number {
+  return start + (end - start) * t
+}


### PR DESCRIPTION
## Summary
- add StageBackdrop and ColorMorphCard cinematic primitives backed by shared interpolation helpers
- extend home scroll hooks and page markup to drive stage hues through the new useStageTimeline service
- expand global styles with stage CSS variables and theme utilities for dynamic gradients

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e451012b1083308dd01919bbe3aafe