### PR TITLE
Fix GSAP imports in scroll hooks

### DIFF
--- a/telcoinwiki-react/src/hooks/useScrollTimeline.ts
+++ b/telcoinwiki-react/src/hooks/useScrollTimeline.ts
@@ -1,7 +1,7 @@
 import type { MutableRefObject, RefObject } from 'react'
 import { useEffect, useRef } from 'react'
 
-import gsap from 'gsap'
+import { gsap } from 'gsap'
 import type { ScrollTrigger as ScrollTriggerType } from 'gsap/ScrollTrigger'
 import { ScrollTrigger } from 'gsap/ScrollTrigger'
 

--- a/telcoinwiki-react/src/hooks/useSmoothScroll.ts
+++ b/telcoinwiki-react/src/hooks/useSmoothScroll.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 
 import Lenis, { type LenisOptions } from '@studio-freight/lenis'
-import gsap from 'gsap'
+import { gsap } from 'gsap'
 import { ScrollTrigger } from 'gsap/ScrollTrigger'
 
 gsap.registerPlugin(ScrollTrigger)


### PR DESCRIPTION
## Summary
- switch both scroll-related hooks to use the named gsap import while keeping ScrollTrigger registration intact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e47bb376808330a51ed241d27a6c7a