### PR TITLE
Optimize cinematic layout animations and add tests

### DIFF
--- a/telcoinwiki-react/src/components/layout/CinematicLayout.tsx
+++ b/telcoinwiki-react/src/components/layout/CinematicLayout.tsx
@@ -1,9 +1,12 @@
-import type { ReactNode } from 'react'
+import { Suspense, lazy, useEffect, useState, type ReactNode } from 'react'
 import { useLocation } from 'react-router-dom'
 import type { NavItem, PageMetaMap, SearchConfig } from '../../config/types'
-import { StarfieldCanvas } from '../visual/StarfieldCanvas'
 import { Header } from './Header'
 import { MAIN_CONTENT_ID, useHashScroll, useLayoutChrome } from './layoutShared'
+
+const StarfieldCanvas = lazy(() =>
+  import('../visual/StarfieldCanvas').then((module) => ({ default: module.StarfieldCanvas })),
+)
 
 interface CinematicLayoutProps {
   pageId: string
@@ -23,6 +26,16 @@ export function CinematicLayout({
   const { hash, pathname } = useLocation()
   useHashScroll(hash, pathname)
 
+  const [shouldRenderStarfield, setShouldRenderStarfield] = useState(() => typeof window !== 'undefined')
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    setShouldRenderStarfield(true)
+  }, [])
+
   const currentMeta = pageMeta[pageId] ?? pageMeta.home
   const activeNavId = currentMeta?.navId ?? pageId ?? null
 
@@ -34,7 +47,11 @@ export function CinematicLayout({
 
   return (
     <>
-      <StarfieldCanvas />
+      {shouldRenderStarfield ? (
+        <Suspense fallback={null}>
+          <StarfieldCanvas />
+        </Suspense>
+      ) : null}
       <div className="app-layer app-layer--cinematic">
         <a className="skip-link" href={`#${MAIN_CONTENT_ID}`}>
           Skip to content

--- a/telcoinwiki-react/src/hooks/__tests__/useSmoothScroll.test.tsx
+++ b/telcoinwiki-react/src/hooks/__tests__/useSmoothScroll.test.tsx
@@ -1,0 +1,21 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { setMatchMedia } from '../../test-utils/mediaQuery'
+import { useSmoothScroll } from '../useSmoothScroll'
+
+describe('useSmoothScroll', () => {
+  it('disables Lenis timelines when prefers-reduced-motion is enabled', () => {
+    setMatchMedia('(prefers-reduced-motion: reduce)', true)
+
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame')
+
+    const { result } = renderHook(() => useSmoothScroll())
+
+    expect(result.current.prefersReducedMotion).toBe(true)
+    expect(result.current.lenis).toBeNull()
+    expect(rafSpy).not.toHaveBeenCalled()
+
+    rafSpy.mockRestore()
+  })
+})

--- a/telcoinwiki-react/src/hooks/useSmoothScroll.ts
+++ b/telcoinwiki-react/src/hooks/useSmoothScroll.ts
@@ -1,10 +1,9 @@
 import { useEffect, useRef, useState } from 'react'
 
-import Lenis, { type LenisOptions } from '@studio-freight/lenis'
-import gsap from 'gsap'
-import { ScrollTrigger } from 'gsap/ScrollTrigger'
+import type Lenis from '@studio-freight/lenis'
+import type { LenisOptions } from '@studio-freight/lenis'
 
-gsap.registerPlugin(ScrollTrigger)
+import { loadGsapWithScrollTrigger } from '../utils/lazyGsap'
 
 export interface UseSmoothScrollOptions {
   /**
@@ -24,6 +23,44 @@ export interface SmoothScrollHandle {
 }
 
 const prefersReducedMotionQuery = '(prefers-reduced-motion: reduce)'
+
+type LenisModule = typeof import('@studio-freight/lenis')
+type LenisConstructor = new (options?: LenisOptions) => Lenis
+
+let lenisModulePromise: Promise<LenisModule> | null = null
+
+function loadLenisModule(): Promise<LenisModule> {
+  if (!lenisModulePromise) {
+    lenisModulePromise = import('@studio-freight/lenis')
+  }
+
+  return lenisModulePromise
+}
+
+function determineFrameInterval(): number {
+  if (typeof navigator === 'undefined') {
+    return 1000 / 60
+  }
+
+  const nav = navigator as Navigator & {
+    connection?: { saveData?: boolean; effectiveType?: string }
+    hardwareConcurrency?: number
+  }
+
+  if (nav.connection?.saveData) {
+    return 1000 / 30
+  }
+
+  if (nav.connection?.effectiveType && ['slow-2g', '2g', '3g'].includes(nav.connection.effectiveType)) {
+    return 1000 / 30
+  }
+
+  if (typeof nav.hardwareConcurrency === 'number' && nav.hardwareConcurrency <= 4) {
+    return 1000 / 45
+  }
+
+  return 1000 / 60
+}
 
 export function useSmoothScroll(options: UseSmoothScrollOptions = {}): SmoothScrollHandle {
   const { enabled = true, lenis: lenisOptions } = options
@@ -56,37 +93,175 @@ export function useSmoothScroll(options: UseSmoothScrollOptions = {}): SmoothScr
 
   useEffect(() => {
     if (!enabled || prefersReducedMotion || typeof window === 'undefined') {
+      lenisRef.current = null
       return undefined
     }
 
-    const lenis = new Lenis({
-      smoothWheel: true,
-      smoothTouch: false,
-      ...lenisOptions,
-    })
+    let disposed = false
+    let lenisInstance: Lenis | null = null
+    let intersectionObserver: IntersectionObserver | null = null
+    let resizeObserver: ResizeObserver | null = null
+    let sentinel: HTMLDivElement | null = null
+    const cleanups: Array<() => void> = []
 
-    lenisRef.current = lenis
+    const frameInterval = determineFrameInterval()
+    let lastFrameTime = performance.now()
+    let pausedByVisibility = typeof document !== 'undefined' ? document.visibilityState === 'hidden' : false
+    let pausedByViewport = false
 
-    const updateScrollTriggers = () => ScrollTrigger.update()
-    lenis.on('scroll', updateScrollTriggers)
+    const isPaused = () => pausedByVisibility || pausedByViewport
 
-    ScrollTrigger.refresh()
-
-    const onAnimationFrame = (time: number) => {
-      lenis.raf(time)
-      frameRef.current = window.requestAnimationFrame(onAnimationFrame)
-    }
-
-    frameRef.current = window.requestAnimationFrame(onAnimationFrame)
-
-    return () => {
-      lenis.off('scroll', updateScrollTriggers)
+    const stopAnimation = () => {
       if (frameRef.current !== null) {
         window.cancelAnimationFrame(frameRef.current)
         frameRef.current = null
       }
+    }
 
-      lenis.destroy()
+    const onAnimationFrame = (time: number) => {
+      frameRef.current = null
+
+      if (!lenisInstance || isPaused()) {
+        return
+      }
+
+      if (time - lastFrameTime >= frameInterval) {
+        lenisInstance.raf(time)
+        lastFrameTime = time
+      }
+
+      frameRef.current = window.requestAnimationFrame(onAnimationFrame)
+    }
+
+    const startAnimation = () => {
+      if (frameRef.current !== null || !lenisInstance || isPaused()) {
+        return
+      }
+
+      lastFrameTime = performance.now()
+      frameRef.current = window.requestAnimationFrame(onAnimationFrame)
+    }
+
+    const syncAnimation = () => {
+      if (isPaused()) {
+        stopAnimation()
+      } else {
+        startAnimation()
+      }
+    }
+
+    const handleVisibilityChange = () => {
+      if (typeof document === 'undefined') {
+        return
+      }
+
+      pausedByVisibility = document.visibilityState === 'hidden'
+      syncAnimation()
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    cleanups.push(() => document.removeEventListener('visibilitychange', handleVisibilityChange))
+
+    if ('IntersectionObserver' in window) {
+      sentinel = document.createElement('div')
+      sentinel.setAttribute('data-smooth-scroll-visibility', 'true')
+      sentinel.style.cssText = 'position:fixed;width:1px;height:1px;top:0;left:0;pointer-events:none;opacity:0;'
+
+      document.body.appendChild(sentinel)
+
+      intersectionObserver = new IntersectionObserver((entries) => {
+        const entry = entries.at(-1)
+
+        if (!entry) {
+          return
+        }
+
+        pausedByViewport = !entry.isIntersecting || entry.intersectionRatio === 0
+        syncAnimation()
+      })
+
+      intersectionObserver.observe(sentinel)
+
+      cleanups.push(() => {
+        intersectionObserver?.disconnect()
+        sentinel?.remove()
+      })
+    } else if ('ResizeObserver' in window) {
+      resizeObserver = new ResizeObserver((entries) => {
+        const entry = entries.at(-1)
+
+        if (!entry) {
+          return
+        }
+
+        const { width, height } = entry.contentRect
+        pausedByViewport = width === 0 || height === 0
+        syncAnimation()
+      })
+
+      resizeObserver.observe(document.documentElement)
+      cleanups.push(() => resizeObserver?.disconnect())
+    } else {
+      const handleBlur = () => {
+        pausedByViewport = true
+        syncAnimation()
+      }
+      const handleFocus = () => {
+        pausedByViewport = false
+        syncAnimation()
+      }
+
+      window.addEventListener('blur', handleBlur)
+      window.addEventListener('focus', handleFocus)
+
+      cleanups.push(() => {
+        window.removeEventListener('blur', handleBlur)
+        window.removeEventListener('focus', handleFocus)
+      })
+    }
+
+    Promise.all([loadLenisModule(), loadGsapWithScrollTrigger()])
+      .then(([lenisModule, { ScrollTrigger }]) => {
+        if (disposed) {
+          return
+        }
+
+        const LenisExport = (lenisModule as LenisModule).default ??
+          (lenisModule as unknown as { Lenis?: LenisConstructor }).Lenis ??
+          (lenisModule as unknown as LenisConstructor)
+
+        const LenisCtor = LenisExport as LenisConstructor
+
+        const lenis = new LenisCtor({
+          smoothWheel: true,
+          smoothTouch: false,
+          ...lenisOptions,
+        })
+
+        lenisInstance = lenis
+        lenisRef.current = lenis
+
+        const updateScrollTriggers = () => ScrollTrigger.update()
+        lenis.on('scroll', updateScrollTriggers)
+        cleanups.push(() => lenis.off('scroll', updateScrollTriggers))
+
+        ScrollTrigger.refresh()
+        startAnimation()
+      })
+      .catch((error) => {
+        if (import.meta.env?.DEV) {
+          console.warn('Failed to initialise smooth scrolling', error)
+        }
+      })
+
+    return () => {
+      disposed = true
+
+      cleanups.splice(0).forEach((cleanup) => cleanup())
+      stopAnimation()
+
+      lenisInstance?.destroy()
+      lenisInstance = null
       lenisRef.current = null
     }
   }, [enabled, lenisOptions, prefersReducedMotion])

--- a/telcoinwiki-react/src/pages/__tests__/HomePage.static.test.tsx
+++ b/telcoinwiki-react/src/pages/__tests__/HomePage.static.test.tsx
@@ -1,0 +1,18 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+
+import { HomePage } from '../HomePage'
+
+describe('HomePage static rendering', () => {
+  it('includes meaningful marketing content without client-side JavaScript', () => {
+    const markup = renderToStaticMarkup(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>,
+    )
+
+    expect(markup).toContain('Understand the Telcoin platform in minutes')
+    expect(markup).toContain('Choose a pathway tailored to your goal')
+  })
+})

--- a/telcoinwiki-react/src/setupTests.ts
+++ b/telcoinwiki-react/src/setupTests.ts
@@ -1,1 +1,62 @@
 import '@testing-library/jest-dom/vitest'
+
+import { afterEach, beforeEach, vi } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import { matchMediaMock, resetMatchMedia } from './test-utils/mediaQuery'
+
+vi.mock('@studio-freight/lenis', () => {
+  const mockInstance = {
+    raf: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+    destroy: vi.fn(),
+  }
+
+  const Lenis = vi.fn(() => mockInstance)
+
+  return { default: Lenis }
+})
+
+vi.mock('gsap', () => {
+  const revert = vi.fn()
+  const context = vi.fn((fn: () => void) => {
+    fn()
+    return { revert }
+  })
+
+  const timeline = vi.fn(() => ({
+    to: vi.fn(),
+    progress: vi.fn(() => 0),
+    scrollTrigger: { kill: vi.fn(), isActive: false, progress: 0 },
+    kill: vi.fn(),
+  }))
+
+  return {
+    gsap: {
+      context,
+      timeline,
+      core: { Timeline: vi.fn() },
+    },
+  }
+})
+
+vi.mock('gsap/ScrollTrigger', () => ({
+  ScrollTrigger: {
+    update: vi.fn(),
+    refresh: vi.fn(),
+  },
+}))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: matchMediaMock,
+})
+
+beforeEach(() => {
+  resetMatchMedia()
+})
+
+afterEach(() => {
+  cleanup()
+})

--- a/telcoinwiki-react/src/test-utils/mediaQuery.ts
+++ b/telcoinwiki-react/src/test-utils/mediaQuery.ts
@@ -1,0 +1,92 @@
+import { vi } from 'vitest'
+
+type MediaQueryListener = (event: MediaQueryListEvent) => void
+
+interface MediaQueryControl {
+  matchMedia: (query: string) => MediaQueryList
+  setMatches: (query: string, matches: boolean) => void
+  reset: () => void
+}
+
+export function createMediaQueryControl(): MediaQueryControl {
+  const listeners = new Map<string, Set<MediaQueryListener>>()
+  const instances = new Map<string, Set<MediaQueryList>>()
+  const state = new Map<string, boolean>()
+
+  const notify = (query: string, matches: boolean) => {
+    const mqls = instances.get(query)
+    const changeEvent = { matches, media: query } as MediaQueryListEvent
+
+    if (mqls) {
+      for (const mql of mqls) {
+        ;(mql as unknown as { matches: boolean }).matches = matches
+
+        if (typeof mql.onchange === 'function') {
+          mql.onchange(changeEvent)
+        }
+      }
+    }
+
+    const registeredListeners = listeners.get(query)
+
+    if (registeredListeners) {
+      for (const listener of registeredListeners) {
+        listener(changeEvent)
+      }
+    }
+  }
+
+  const matchMedia = vi.fn((query: string): MediaQueryList => {
+    const initialMatches = state.get(query) ?? false
+    const queryListeners = listeners.get(query) ?? new Set<MediaQueryListener>()
+    listeners.set(query, queryListeners)
+
+    const mql: MediaQueryList = {
+      matches: initialMatches,
+      media: query,
+      onchange: null,
+      addEventListener: (_event: string, listener: EventListenerOrEventListenerObject) => {
+        if (typeof listener === 'function') {
+          queryListeners.add(listener as MediaQueryListener)
+        }
+      },
+      removeEventListener: (_event: string, listener: EventListenerOrEventListenerObject) => {
+        if (typeof listener === 'function') {
+          queryListeners.delete(listener as MediaQueryListener)
+        }
+      },
+      addListener: (listener: MediaQueryListener) => {
+        queryListeners.add(listener)
+      },
+      removeListener: (listener: MediaQueryListener) => {
+        queryListeners.delete(listener)
+      },
+      dispatchEvent: () => false,
+    }
+
+    const instancesForQuery = instances.get(query) ?? new Set<MediaQueryList>()
+    instancesForQuery.add(mql)
+    instances.set(query, instancesForQuery)
+
+    return mql
+  })
+
+  const setMatches = (query: string, matches: boolean) => {
+    state.set(query, matches)
+    notify(query, matches)
+  }
+
+  const reset = () => {
+    listeners.clear()
+    instances.clear()
+    state.clear()
+  }
+
+  return { matchMedia, setMatches, reset }
+}
+
+const mediaQueryControl = createMediaQueryControl()
+
+export const matchMediaMock = mediaQueryControl.matchMedia
+export const setMatchMedia = mediaQueryControl.setMatches
+export const resetMatchMedia = mediaQueryControl.reset

--- a/telcoinwiki-react/src/test-utils/mocks/gsap.ts
+++ b/telcoinwiki-react/src/test-utils/mocks/gsap.ts
@@ -1,0 +1,28 @@
+export interface ScrollTriggerMock {
+  kill: () => void
+  isActive: boolean
+  progress: number
+}
+
+const createScrollTrigger = (): ScrollTriggerMock => ({
+  kill: () => {},
+  isActive: false,
+  progress: 0,
+})
+
+const gsapInstance = {
+  context: (fn: () => void) => {
+    fn()
+    return { revert: () => {} }
+  },
+  timeline: (_options?: unknown) => ({
+    to: () => {},
+    progress: () => 0,
+    scrollTrigger: createScrollTrigger(),
+    kill: () => {},
+  }),
+}
+
+export const gsap = gsapInstance
+
+export default gsapInstance

--- a/telcoinwiki-react/src/test-utils/mocks/gsapScrollTrigger.ts
+++ b/telcoinwiki-react/src/test-utils/mocks/gsapScrollTrigger.ts
@@ -1,0 +1,6 @@
+export const ScrollTrigger = {
+  update: () => {},
+  refresh: () => {},
+}
+
+export default ScrollTrigger

--- a/telcoinwiki-react/src/test-utils/mocks/lenis.ts
+++ b/telcoinwiki-react/src/test-utils/mocks/lenis.ts
@@ -1,0 +1,17 @@
+export interface LenisOptions {
+  smoothWheel?: boolean
+  smoothTouch?: boolean
+  [key: string]: unknown
+}
+
+export default class Lenis {
+  constructor(_options?: LenisOptions) {}
+
+  raf(_time: number) {}
+
+  on(_event: string, _handler: () => void) {}
+
+  off(_event: string, _handler: () => void) {}
+
+  destroy() {}
+}

--- a/telcoinwiki-react/src/utils/lazyGsap.ts
+++ b/telcoinwiki-react/src/utils/lazyGsap.ts
@@ -1,0 +1,46 @@
+import type { ScrollTriggerStatic } from 'gsap/ScrollTrigger'
+
+type GsapModule = typeof import('gsap')
+
+interface GsapBundle {
+  gsap: GsapModule['gsap']
+  ScrollTrigger: ScrollTriggerStatic
+}
+
+let gsapBundlePromise: Promise<GsapBundle> | null = null
+
+export function loadGsapWithScrollTrigger(): Promise<GsapBundle> {
+  if (gsapBundlePromise) {
+    return gsapBundlePromise
+  }
+
+  let pluginRegistered = false
+
+  gsapBundlePromise = Promise.all([import('gsap'), import('gsap/ScrollTrigger')]).then(
+    ([gsapModule, scrollTriggerModule]) => {
+      const gsapInstance = (gsapModule as unknown as GsapModule).gsap ?? (gsapModule as GsapModule).default
+
+      if (!gsapInstance) {
+        throw new Error('Failed to load GSAP instance')
+      }
+
+      const ScrollTrigger =
+        scrollTriggerModule.ScrollTrigger ??
+        (scrollTriggerModule as unknown as { default?: ScrollTriggerStatic }).default ??
+        (scrollTriggerModule as unknown as ScrollTriggerStatic)
+
+      if (!ScrollTrigger) {
+        throw new Error('Failed to load GSAP ScrollTrigger plugin')
+      }
+
+      if (!pluginRegistered) {
+        gsapInstance.registerPlugin(ScrollTrigger)
+        pluginRegistered = true
+      }
+
+      return { gsap: gsapInstance, ScrollTrigger }
+    },
+  )
+
+  return gsapBundlePromise
+}

--- a/telcoinwiki-react/vite.config.ts
+++ b/telcoinwiki-react/vite.config.ts
@@ -3,6 +3,8 @@ import { fileURLToPath, URL } from 'node:url'
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react-swc'
 
+const isTest = process.env.VITEST === 'true'
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
@@ -10,6 +12,13 @@ export default defineConfig({
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
       '@scroll': fileURLToPath(new URL('./src/lib/scroll', import.meta.url)),
+      ...(isTest
+        ? {
+            '@studio-freight/lenis': fileURLToPath(new URL('./src/test-utils/mocks/lenis.ts', import.meta.url)),
+            'gsap/ScrollTrigger': fileURLToPath(new URL('./src/test-utils/mocks/gsapScrollTrigger.ts', import.meta.url)),
+            gsap: fileURLToPath(new URL('./src/test-utils/mocks/gsap.ts', import.meta.url)),
+          }
+        : {}),
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- lazy load the cinematic starfield canvas to keep documentation bundles lean
- refactor smooth scrolling to observe visibility, clamp frame rates, and guard against SSR
- add test utilities and coverage for reduced motion behavior and static marketing content

## Testing
- `npx vitest run --reporter verbose`


------
https://chatgpt.com/codex/tasks/task_e_68e47d0ae1148330875552edb40a569a