### PR TITLE
Restore cinematic layout by exporting default component

### DIFF
--- a/telcoinwiki-react/src/components/layout/CinematicLayout.tsx
+++ b/telcoinwiki-react/src/components/layout/CinematicLayout.tsx
@@ -64,3 +64,5 @@ export function CinematicLayout({
     </>
   )
 }
+
+export default CinematicLayout


### PR DESCRIPTION
## Summary
- export `CinematicLayout` as the module default so the lazy loader receives a valid component
- simplify the lazy import in `App.tsx` to rely on the new default export

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5010c7ccc8330909faa4eea20865d