### PR TITLE
Refine cinematic animations with lazy loading and accessibility safeguards

### DIFF
--- a/telcoinwiki-react/src/hooks/__tests__/useScrollTimeline.test.tsx
+++ b/telcoinwiki-react/src/hooks/__tests__/useScrollTimeline.test.tsx
@@ -1,0 +1,69 @@
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { timelineMock, contextMock } = vi.hoisted(() => {
+  const timeline = vi.fn(() => ({
+    kill: vi.fn(),
+    scrollTrigger: { kill: vi.fn() },
+  }))
+
+  const context = vi.fn((callback?: (ctx: unknown) => void) => {
+    const ctx = {
+      revert: vi.fn(),
+      add: vi.fn(),
+      ignore: vi.fn(),
+      kill: vi.fn(),
+      clear: vi.fn(),
+      isReverted: false,
+    }
+
+    if (callback) {
+      callback(ctx)
+    }
+
+    return ctx
+  })
+
+  return { timelineMock: timeline, contextMock: context }
+})
+
+vi.mock('gsap', () => ({
+  gsap: {
+    registerPlugin: vi.fn(),
+    timeline: timelineMock,
+    context: contextMock,
+  },
+}))
+
+vi.mock('gsap/ScrollTrigger', () => ({
+  ScrollTrigger: {
+    refresh: vi.fn(),
+    update: vi.fn(),
+  },
+}))
+
+import { useScrollTimeline } from '../useScrollTimeline'
+
+describe('useScrollTimeline', () => {
+  beforeEach(() => {
+    timelineMock.mockClear()
+    contextMock.mockClear()
+  })
+
+  it('skips timeline creation when no target is provided (reduced motion)', () => {
+    const createSpy = vi.fn()
+
+    const { unmount } = renderHook(() =>
+      useScrollTimeline({
+        target: null,
+        create: createSpy,
+      }),
+    )
+
+    expect(timelineMock).not.toHaveBeenCalled()
+    expect(contextMock).not.toHaveBeenCalled()
+    expect(createSpy).not.toHaveBeenCalled()
+
+    unmount()
+  })
+})

--- a/telcoinwiki-react/src/hooks/__tests__/useSmoothScroll.test.tsx
+++ b/telcoinwiki-react/src/hooks/__tests__/useSmoothScroll.test.tsx
@@ -38,7 +38,7 @@ vi.mock('gsap/ScrollTrigger', () => ({
 }))
 
 vi.mock('gsap', () => ({
-  default: {
+  gsap: {
     registerPlugin: vi.fn(),
     context: vi.fn((callback?: () => void) => {
       if (callback) {

--- a/telcoinwiki-react/src/pages/__tests__/HomePage.ssr.test.tsx
+++ b/telcoinwiki-react/src/pages/__tests__/HomePage.ssr.test.tsx
@@ -14,5 +14,6 @@ describe('HomePage SSR', () => {
 
     expect(markup).toContain('Understand the Telcoin platform in minutes')
     expect(markup).toContain('Choose a pathway tailored to your goal')
+    expect(markup).toContain('Volunteer editors, community ambassadors, and early adopters share verified answers')
   })
 })

--- a/telcoinwiki-react/src/setupTests.ts
+++ b/telcoinwiki-react/src/setupTests.ts
@@ -54,3 +54,21 @@ if (!('IntersectionObserver' in window)) {
   // @ts-expect-error - provide minimal stub for test environment
   window.IntersectionObserver = IntersectionObserverStub
 }
+
+if (!('visibilityState' in document)) {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    enumerable: true,
+    value: 'visible',
+    writable: true,
+  })
+}
+
+if (!('hidden' in document)) {
+  Object.defineProperty(document, 'hidden', {
+    configurable: true,
+    enumerable: true,
+    value: false,
+    writable: true,
+  })
+}


### PR DESCRIPTION
## Summary
- lazily load Lenis and ScrollTrigger in the smooth scroll hook so cinematic animation code only runs in the browser and respects low-power heuristics
- defer GSAP timeline setup in `useScrollTimeline` until a target exists to avoid initializing timelines when reduced motion is requested
- extend the test harness with reduced-motion and SSR expectations to cover the new behaviour

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e57392bfdc8330a5c932903ff488a1