### PR TITLE
Add interactive network topology experience

### DIFF
--- a/telcoinwiki-react/src/components/network/InteractiveTopology.tsx
+++ b/telcoinwiki-react/src/components/network/InteractiveTopology.tsx
@@ -1,0 +1,213 @@
+import { motion } from 'framer-motion'
+import { useId, useMemo, useRef, useState, type KeyboardEvent } from 'react'
+
+import { networkTopology } from '../../data/network/topology'
+import type { TopologyEdge, TopologyEdgeType, TopologyNode } from '../../data/network/topology'
+import { usePrefersReducedMotion } from '../../hooks/usePrefersReducedMotion'
+
+const EDGE_COLORS: Record<TopologyEdgeType, string> = {
+  telFlow: '#2563eb',
+  telxFlow: '#9333ea',
+  tanTouchpoint: '#f97316',
+}
+
+const FLOW_LABELS: Record<TopologyEdgeType, string> = {
+  telFlow: 'TEL issuance & staking flow',
+  telxFlow: 'TELx liquidity flow',
+  tanTouchpoint: 'TAN compliance touchpoint',
+}
+
+const NODE_TYPE_STYLES: Record<TopologyNode['type'], string> = {
+  association: 'from-sky-500/90 to-sky-600/70',
+  validator: 'from-emerald-500/90 to-emerald-600/70',
+  liquidity: 'from-violet-500/85 to-violet-600/70',
+  endpoint: 'from-amber-500/90 to-amber-600/70',
+}
+
+const VIEWBOX = { width: 100, height: 88 }
+
+function buildPath(edge: TopologyEdge, nodeMap: Map<string, TopologyNode>): string {
+  const from = nodeMap.get(edge.from)
+  const to = nodeMap.get(edge.to)
+
+  if (!from || !to) {
+    return ''
+  }
+
+  const move = `M ${from.position.x} ${from.position.y}`
+  const destination = `${to.position.x} ${to.position.y}`
+
+  if (edge.curve) {
+    return `${move} Q ${edge.curve.x} ${edge.curve.y} ${destination}`
+  }
+
+  return `${move} L ${destination}`
+}
+
+export function InteractiveTopology() {
+  const prefersReducedMotion = usePrefersReducedMotion()
+  const [activeNodeId, setActiveNodeId] = useState<string>(networkTopology.nodes[0]?.id ?? '')
+  const instructionsId = useId()
+  const descriptionId = useId()
+  const nodeRefs = useRef<Record<string, HTMLButtonElement | null>>({})
+
+  const nodeMap = useMemo(() => new Map(networkTopology.nodes.map((node) => [node.id, node])), [])
+  const activeNode = nodeMap.get(activeNodeId) ?? networkTopology.nodes[0]
+
+  const activeEdgeIds = useMemo(() => {
+    return new Set(
+      networkTopology.edges
+        .filter((edge) => edge.from === activeNodeId || edge.to === activeNodeId)
+        .map((edge) => edge.id),
+    )
+  }, [activeNodeId])
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (['ArrowRight', 'ArrowLeft'].includes(event.key)) {
+      event.preventDefault()
+
+      const orderedNodes = networkTopology.nodes
+      const currentIndex = orderedNodes.findIndex((node) => node.id === activeNodeId)
+      if (currentIndex === -1) {
+        return
+      }
+
+      const direction = event.key === 'ArrowRight' ? 1 : -1
+      const nextIndex = (currentIndex + direction + orderedNodes.length) % orderedNodes.length
+      const nextNode = orderedNodes[nextIndex]
+
+      setActiveNodeId(nextNode.id)
+      nodeRefs.current[nextNode.id]?.focus()
+    }
+  }
+
+  return (
+    <div
+      className="relative flex flex-col gap-6"
+      role="group"
+      aria-labelledby={descriptionId}
+      aria-describedby={instructionsId}
+      onKeyDown={handleKeyDown}
+    >
+      <div className="sr-only" id={instructionsId}>
+        Use left and right arrow keys to explore the Telcoin engine topology. Hover or focus a node to reveal additional context.
+      </div>
+
+      <div className="relative overflow-hidden rounded-3xl border border-telcoin-ink/10 bg-telcoin-surface/60 p-4 shadow-lg shadow-telcoin-ink/10 backdrop-blur">
+        <svg
+          viewBox={`0 0 ${VIEWBOX.width} ${VIEWBOX.height}`}
+          className="h-full w-full"
+          role="presentation"
+        >
+          <defs>
+            <radialGradient id="topology-glow" cx="50%" cy="45%" r="65%">
+              <stop offset="0%" stopColor="#0ea5e9" stopOpacity="0.35" />
+              <stop offset="65%" stopColor="#312e81" stopOpacity="0" />
+            </radialGradient>
+          </defs>
+          <rect width="100" height="88" fill="url(#topology-glow)" rx="6" ry="6" />
+
+          {networkTopology.edges.map((edge, index) => {
+            const path = buildPath(edge, nodeMap)
+            const isActive = activeEdgeIds.has(edge.id)
+            const motionProps = prefersReducedMotion
+              ? { initial: { pathLength: 1 }, animate: { pathLength: 1 } }
+              : {
+                  initial: { pathLength: 0 },
+                  animate: { pathLength: 1 },
+                  transition: {
+                    duration: 3.6 + index * 0.4,
+                    repeat: Infinity,
+                    repeatType: 'reverse' as const,
+                    ease: 'easeInOut',
+                  },
+                }
+
+            return (
+              <motion.path
+                key={edge.id}
+                d={path}
+                stroke={EDGE_COLORS[edge.type]}
+                strokeWidth={isActive ? 2.2 : 1.4}
+                strokeOpacity={isActive ? 0.9 : 0.4}
+                strokeLinecap="round"
+                fill="none"
+                strokeDasharray="1 6"
+                {...motionProps}
+              >
+                <title>{edge.label}</title>
+              </motion.path>
+            )
+          })}
+        </svg>
+
+        <div className="pointer-events-none absolute inset-0">
+          {networkTopology.nodes.map((node) => {
+            const isActive = node.id === activeNodeId
+            return (
+              <div
+                key={node.id}
+                className="absolute"
+                style={{ left: `${node.position.x}%`, top: `${node.position.y}%` }}
+              >
+                <button
+                  type="button"
+                  ref={(element) => {
+                    nodeRefs.current[node.id] = element
+                  }}
+                  className={`pointer-events-auto flex -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-1 rounded-2xl border border-white/30 bg-gradient-to-br px-3 py-2 text-center shadow-lg shadow-telcoin-ink/20 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80 ${NODE_TYPE_STYLES[node.type]} ${
+                    isActive ? 'ring-2 ring-offset-2 ring-offset-telcoin-surface/80 ring-white/70' : ''
+                  }`}
+                  aria-pressed={isActive}
+                  aria-describedby={descriptionId}
+                  onFocus={() => setActiveNodeId(node.id)}
+                  onMouseEnter={() => setActiveNodeId(node.id)}
+                >
+                  <span className="text-[10px] font-semibold uppercase tracking-[0.2em] text-white/90">
+                    {node.label}
+                  </span>
+                  <span className="text-sm font-semibold text-white drop-shadow">{node.title}</span>
+                  <span className="text-[11px] text-white/80">{node.summary}</span>
+                </button>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      {activeNode ? (
+        <article
+          className="rounded-3xl border border-telcoin-ink/10 bg-white/90 p-6 shadow-xl shadow-telcoin-ink/10 backdrop-blur"
+          aria-live="polite"
+          id={descriptionId}
+        >
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-telcoin-ink/70">{activeNode.label}</p>
+          <h3 className="mt-2 text-2xl font-semibold text-telcoin-ink">{activeNode.title}</h3>
+          <p className="mt-3 text-base text-telcoin-ink-muted">{activeNode.details}</p>
+
+          <div className="mt-4 flex flex-wrap gap-2" aria-label="Related flows">
+            {activeNode.relatedFlows.map((flow) => (
+              <span
+                key={`${activeNode.id}-${flow}`}
+                className="inline-flex items-center gap-1 rounded-full border border-telcoin-ink/10 bg-telcoin-surface/70 px-3 py-1 text-xs font-medium text-telcoin-ink"
+              >
+                <span aria-hidden="true" className="h-2 w-2 rounded-full" style={{ backgroundColor: EDGE_COLORS[flow] }} />
+                {FLOW_LABELS[flow]}
+              </span>
+            ))}
+          </div>
+
+          {activeNode.cta ? (
+            <a
+              className="mt-5 inline-flex items-center justify-center gap-2 rounded-full border border-telcoin-ink/10 bg-telcoin-ink text-sm font-semibold text-white shadow-sm shadow-telcoin-ink/20 transition hover:bg-telcoin-ink/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-telcoin-ink"
+              href={activeNode.cta.href}
+            >
+              {activeNode.cta.label}
+              <span aria-hidden="true">→</span>
+            </a>
+          ) : null}
+        </article>
+      ) : null}
+    </div>
+  )
+}

--- a/telcoinwiki-react/src/data/network/topology.ts
+++ b/telcoinwiki-react/src/data/network/topology.ts
@@ -1,0 +1,227 @@
+export type TopologyNodeType = 'association' | 'validator' | 'liquidity' | 'endpoint'
+
+export type TopologyEdgeType = 'telFlow' | 'telxFlow' | 'tanTouchpoint'
+
+export interface TopologyNode {
+  id: string
+  title: string
+  label: string
+  type: TopologyNodeType
+  summary: string
+  details: string
+  position: { x: number; y: number }
+  relatedFlows: TopologyEdgeType[]
+  cta?: {
+    label: string
+    href: string
+  }
+}
+
+export interface TopologyEdge {
+  id: string
+  from: string
+  to: string
+  type: TopologyEdgeType
+  label: string
+  curve?: {
+    x: number
+    y: number
+  }
+}
+
+export interface NetworkTopology {
+  nodes: TopologyNode[]
+  edges: TopologyEdge[]
+}
+
+export const networkTopology: NetworkTopology = {
+  nodes: [
+    {
+      id: 'association-hub',
+      title: 'Telcoin Association',
+      label: 'Association',
+      type: 'association',
+      summary: 'Policy guardians steward validator onboarding and release cadence.',
+      details:
+        'The Association orchestrates governance, compliance reviews, and validator activation so the network engine stays aligned with regulatory guardrails.',
+      position: { x: 50, y: 32 },
+      relatedFlows: ['tanTouchpoint', 'telFlow'],
+      cta: {
+        label: 'Governance pillars',
+        href: '/governance#governance-structure',
+      },
+    },
+    {
+      id: 'validator-apac',
+      title: 'MNO Validator — APAC',
+      label: 'Validator APAC',
+      type: 'validator',
+      summary: 'Regional telecom secures consensus blocks.',
+      details:
+        'A GSMA member operator finalizes blocks close to high-volume Asian corridors, feeding TEL issuance rewards and uptime metrics back to the Association.',
+      position: { x: 18, y: 18 },
+      relatedFlows: ['telFlow', 'telxFlow'],
+      cta: {
+        label: 'Validator requirements',
+        href: '/network#network-security',
+      },
+    },
+    {
+      id: 'validator-na',
+      title: 'MNO Validator — North America',
+      label: 'Validator NA',
+      type: 'validator',
+      summary: 'Carrier-grade infrastructure anchors the network core.',
+      details:
+        'North American carriers pair telecom security practices with EVM tooling, relaying TELx program updates and TAN change controls.',
+      position: { x: 82, y: 18 },
+      relatedFlows: ['telFlow', 'tanTouchpoint'],
+      cta: {
+        label: 'Engine narrative',
+        href: '/#home-engine',
+      },
+    },
+    {
+      id: 'liquidity-telx',
+      title: 'TELx Liquidity Pool',
+      label: 'TELx Pool',
+      type: 'liquidity',
+      summary: 'Automated market makers balance TEL and stable value.',
+      details:
+        'Liquidity providers keep remittance pairs liquid so value routes instantly between corridors, TEL staking, and Digital Cash conversions.',
+      position: { x: 25, y: 58 },
+      relatedFlows: ['telxFlow'],
+      cta: {
+        label: 'Explore TELx pools',
+        href: '/pools#pools-overview',
+      },
+    },
+    {
+      id: 'liquidity-remittance',
+      title: 'Cross-border Corridor',
+      label: 'Remittance Flow',
+      type: 'liquidity',
+      summary: 'Compliant off-ramps settle customer transfers.',
+      details:
+        'Licensed partners settle fiat and mobile money payouts, pulling liquidity from TELx pools and reporting status back through TAN touchpoints.',
+      position: { x: 75, y: 58 },
+      relatedFlows: ['telxFlow', 'tanTouchpoint'],
+      cta: {
+        label: 'See remittance playbooks',
+        href: '/remittances#remittance-overview',
+      },
+    },
+    {
+      id: 'endpoint-wallet',
+      title: 'Telcoin Wallet',
+      label: 'Wallet',
+      type: 'endpoint',
+      summary: 'User experience routes TEL and Digital Cash.',
+      details:
+        'The Telcoin Wallet exposes regulated cash-in and cash-out, anchored to the Association-controlled smart contracts and network validators.',
+      position: { x: 50, y: 80 },
+      relatedFlows: ['telFlow', 'telxFlow', 'tanTouchpoint'],
+      cta: {
+        label: 'Wallet experience',
+        href: '/wallet#wallet-overview',
+      },
+    },
+    {
+      id: 'endpoint-digital-cash',
+      title: 'Digital Cash Reserves',
+      label: 'Digital Cash',
+      type: 'endpoint',
+      summary: 'Fully collateralized e-money issued through TAN.',
+      details:
+        'Reserve attestations, cash management, and TAN monitoring keep Digital Cash tokens redeemable, feeding compliance signals back to validators.',
+      position: { x: 50, y: 8 },
+      relatedFlows: ['tanTouchpoint', 'telxFlow'],
+      cta: {
+        label: 'Learn about Digital Cash',
+        href: '/digital-cash#digital-cash-use',
+      },
+    },
+  ],
+  edges: [
+    {
+      id: 'edge-association-wallet',
+      from: 'association-hub',
+      to: 'endpoint-wallet',
+      type: 'tanTouchpoint',
+      label: 'Compliance signals',
+      curve: { x: 50, y: 55 },
+    },
+    {
+      id: 'edge-association-digital-cash',
+      from: 'association-hub',
+      to: 'endpoint-digital-cash',
+      type: 'tanTouchpoint',
+      label: 'Reserve oversight',
+      curve: { x: 50, y: 18 },
+    },
+    {
+      id: 'edge-association-validator-apac',
+      from: 'association-hub',
+      to: 'validator-apac',
+      type: 'tanTouchpoint',
+      label: 'Validator policy sync',
+      curve: { x: 34, y: 26 },
+    },
+    {
+      id: 'edge-association-validator-na',
+      from: 'association-hub',
+      to: 'validator-na',
+      type: 'tanTouchpoint',
+      label: 'Validator policy sync',
+      curve: { x: 66, y: 26 },
+    },
+    {
+      id: 'edge-validator-apac-liquidity',
+      from: 'validator-apac',
+      to: 'liquidity-telx',
+      type: 'telFlow',
+      label: 'TEL staking rewards',
+      curve: { x: 20, y: 38 },
+    },
+    {
+      id: 'edge-validator-na-liquidity',
+      from: 'validator-na',
+      to: 'liquidity-remittance',
+      type: 'telFlow',
+      label: 'TEL staking rewards',
+      curve: { x: 80, y: 38 },
+    },
+    {
+      id: 'edge-liquidity-wallet',
+      from: 'liquidity-telx',
+      to: 'endpoint-wallet',
+      type: 'telxFlow',
+      label: 'TELx conversions',
+      curve: { x: 38, y: 72 },
+    },
+    {
+      id: 'edge-wallet-remittance',
+      from: 'endpoint-wallet',
+      to: 'liquidity-remittance',
+      type: 'telxFlow',
+      label: 'Remittance settlement',
+      curve: { x: 62, y: 72 },
+    },
+    {
+      id: 'edge-digital-cash-wallet',
+      from: 'endpoint-digital-cash',
+      to: 'endpoint-wallet',
+      type: 'telxFlow',
+      label: 'Digital Cash mint/burn',
+      curve: { x: 50, y: 40 },
+    },
+    {
+      id: 'edge-remittance-association',
+      from: 'liquidity-remittance',
+      to: 'association-hub',
+      type: 'tanTouchpoint',
+      label: 'Reporting & TAN updates',
+      curve: { x: 68, y: 44 },
+    },
+  ],
+}

--- a/telcoinwiki-react/src/pages/NetworkPage.tsx
+++ b/telcoinwiki-react/src/pages/NetworkPage.tsx
@@ -1,7 +1,7 @@
-import { CardGrid } from '../components/content/CardGrid'
 import { HeroOverlay } from '../components/content/HeroOverlay'
 import { PageIntro } from '../components/content/PageIntro'
 import { SourceBox } from '../components/content/SourceBox'
+import { InteractiveTopology } from '../components/network/InteractiveTopology'
 
 export function NetworkPage() {
   return (
@@ -17,54 +17,54 @@ export function NetworkPage() {
       />
 
       <section id="network-architecture" className="anchor-offset">
-        <h2>Architecture highlights</h2>
-        <CardGrid
-          columns={3}
-          items={[
-            {
-              id: 'network-architecture-evm',
-              title: 'EVM smart contracts',
-              body: (
-                <>
-                  <p>Developers can deploy Solidity contracts and integrate with tooling familiar to the broader Ethereum ecosystem.</p>
-                  <p>
-                    <a href="https://www.telcoinassociation.org/network" target="_blank" rel="noopener noreferrer">
-                      Association technical overview →
-                    </a>
-                  </p>
-                </>
-              ),
-            },
-            {
-              id: 'network-architecture-validators',
-              title: 'Validator criteria',
-              body: (
-                <>
-                  <p>Mobile network operators that meet Association-defined security and compliance standards can operate validators.</p>
-                  <p>
-                    <a href="https://www.telcoinassociation.org/network" target="_blank" rel="noopener noreferrer">
-                      Validator requirements →
-                    </a>
-                  </p>
-                </>
-              ),
-            },
-            {
-              id: 'network-architecture-performance',
-              title: 'Settlement performance',
-              body: (
-                <>
-                  <p>Transactions finalize in seconds, enabling instant settlement for Digital Cash, remittances, and TELx liquidity flows.</p>
-                  <p>
-                    <a href="https://www.telcoinnetwork.org" target="_blank" rel="noopener noreferrer">
-                      Network landing →
-                    </a>
-                  </p>
-                </>
-              ),
-            },
-          ]}
-        />
+        <h2>The engine topology</h2>
+        <p>
+          Explore how Association governance, validator operators, TELx liquidity, and app endpoints weave together to power Telcoin services. The interactive canvas below highlights how value and compliance signals move between pillars.
+        </p>
+
+        <div className="mt-10 grid gap-10 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
+          <InteractiveTopology />
+
+          <div className="flex flex-col gap-6">
+            <article className="rounded-3xl border border-telcoin-ink/10 bg-white/80 p-6 shadow-lg shadow-telcoin-ink/10 backdrop-blur">
+              <h3 className="text-xl font-semibold text-telcoin-ink">Governance orchestrates the engine</h3>
+              <p className="mt-3 text-base text-telcoin-ink-muted">
+                The Telcoin Association aligns validators and TAN operators so policy, upgrades, and reserve reporting keep the network compliant. Each touchpoint in the topology traces back to Association standards.
+              </p>
+              <a className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-telcoin-ink hover:text-telcoin-ink/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-telcoin-ink" href="/governance#governance-structure">
+                Review the governance charter <span aria-hidden="true">→</span>
+              </a>
+            </article>
+
+            <article className="rounded-3xl border border-telcoin-ink/10 bg-white/80 p-6 shadow-lg shadow-telcoin-ink/10 backdrop-blur">
+              <h3 className="text-xl font-semibold text-telcoin-ink">Liquidity keeps TEL and TELx responsive</h3>
+              <p className="mt-3 text-base text-telcoin-ink-muted">
+                TEL staking rewards flow from validators into TELx pools, where Digital Cash pairs balance corridor demand. Hover a liquidity node to see how swaps, burns, and remittances stay synchronized with validator output.
+              </p>
+              <a className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-telcoin-ink hover:text-telcoin-ink/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-telcoin-ink" href="/pools#pools-overview">
+                Explore TELx programs <span aria-hidden="true">→</span>
+              </a>
+            </article>
+
+            <article className="rounded-3xl border border-telcoin-ink/10 bg-white/80 p-6 shadow-lg shadow-telcoin-ink/10 backdrop-blur">
+              <h3 className="text-xl font-semibold text-telcoin-ink">Apps connect the experience</h3>
+              <p className="mt-3 text-base text-telcoin-ink-muted">
+                Telcoin Wallet endpoints and Digital Cash reserves translate network capacity into user-facing experiences. Their CTAs bridge to the Wallet, Digital Cash, and Home Engine sections so readers can keep following the storyline.
+              </p>
+              <div className="mt-4 flex flex-wrap gap-3">
+                <a className="inline-flex items-center gap-2 text-sm font-semibold text-telcoin-ink hover:text-telcoin-ink/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-telcoin-ink" href="/wallet#wallet-overview">
+                  See the wallet tour <span aria-hidden="true">→</span>
+                </a>
+                <a className="inline-flex items-center gap-2 text-sm font-semibold text-telcoin-ink hover:text-telcoin-ink/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-telcoin-ink" href="/digital-cash#digital-cash-use">
+                  Learn about Digital Cash <span aria-hidden="true">→</span>
+                </a>
+                <a className="inline-flex items-center gap-2 text-sm font-semibold text-telcoin-ink hover:text-telcoin-ink/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-telcoin-ink" href="/#home-engine">
+                  Revisit the Engine pillar <span aria-hidden="true">→</span>
+                </a>
+              </div>
+            </article>
+          </div>
+        </div>
       </section>
 
       <section id="network-governance" className="anchor-offset">


### PR DESCRIPTION
## Summary
- add an interactive topology canvas that animates validators, liquidity, and TAN flows with reduced-motion safeguards
- define a reusable network topology data model so the visualization and CTAs can reference Association nodes, flows, and endpoints
- replace the Network page card grid with the new experience and narrative copy that links into other Telcoin engine pillars

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5b518468483308fd3f05f324c5514