### PR TITLE
Fix hero card flicker during scroll

### DIFF
--- a/telcoinwiki-react/src/components/cinematic/ColorMorphCard.tsx
+++ b/telcoinwiki-react/src/components/cinematic/ColorMorphCard.tsx
@@ -19,16 +19,10 @@ export const ColorMorphCard = forwardRef<HTMLElement, ColorMorphCardProps>(funct
   const overlayAlpha = lerp(0.26, 0.64, clamped)
   const borderAlpha = lerp(0.28, 0.56, clamped)
   const shadowAlpha = lerp(0.18, 0.46, clamped)
-  const translateY = lerp(24, 0, clamped)
-  const scale = lerp(0.96, 1.0, clamped)
-  const opacity = lerp(0.82, 1, clamped)
-
   const styleWithMorph = {
     '--stage-card-overlay-alpha': overlayAlpha.toFixed(3),
     '--stage-card-border-alpha': borderAlpha.toFixed(3),
     '--stage-card-shadow-alpha': shadowAlpha.toFixed(3),
-    transform: `translateY(${translateY.toFixed(2)}px) scale(${scale.toFixed(3)})`,
-    opacity,
     ...style,
   } as CSSProperties
 

--- a/telcoinwiki-react/src/components/cinematic/SlidingStack.tsx
+++ b/telcoinwiki-react/src/components/cinematic/SlidingStack.tsx
@@ -76,55 +76,60 @@ export function SlidingStack({
           ? 1
           : Math.min(Math.max(1 - Math.max(relative, 0) * progressDampener, progressFloor), 1)
 
+        const morphTranslate = prefersReducedMotion ? 0 : (1 - cardProgress) * 24
+        const morphScale = prefersReducedMotion ? 1 : 0.96 + cardProgress * 0.04
+        const morphOpacity = prefersReducedMotion ? 1 : 0.82 + cardProgress * 0.18
+
+        const finalTranslate = translateY + morphTranslate
+        const finalScale = scale * morphScale
+        const finalOpacity = opacityBase * morphOpacity
+
         const style = {
-          '--stack-translate': `${formatNumber(translateY)}px`,
-          '--stack-scale': formatNumber(scale),
-          '--stack-opacity': formatNumber(opacityBase),
           '--stack-content-translate': `${formatNumber((1 - cardProgress) * 12)}px`,
           '--stack-content-opacity': formatNumber(0.75 + cardProgress * 0.25),
           zIndex: items.length - index,
         } as CSSProperties
 
+        if (!staticLayout) {
+          style.transform = `translateY(${formatNumber(finalTranslate)}px) scale(${formatNumber(finalScale)})`
+          style.opacity = formatNumber(finalOpacity)
+        }
+
         const ctaLabel = item.ctaLabel ?? 'Learn more'
 
-        const content = (
-          <ColorMorphCard
-            key={item.id}
-            progress={cardProgress}
-            className={cn('sliding-stack__card p-6 sm:p-8', cardClassName)}
-            style={style}
-          >
-            {item.eyebrow ? (
-              <span className="text-xs font-semibold uppercase tracking-[0.2em] text-telcoin-ink-subtle">
-                {item.eyebrow}
-              </span>
-            ) : null}
-            <div className="sliding-stack__content">
-              <h3 className="text-xl font-semibold text-telcoin-ink sm:text-2xl">{item.title}</h3>
-              <div className="text-base text-telcoin-ink-muted sm:text-lg">{item.body}</div>
-            </div>
-            {item.href ? (
-              isExternalLink(item.href) ? (
-                <a
-                  className="inline-flex items-center gap-2 text-sm font-semibold text-telcoin-accent"
-                  href={item.href}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  {ctaLabel}
-                  <span aria-hidden>→</span>
-                </a>
-              ) : (
-                <Link className="inline-flex items-center gap-2 text-sm font-semibold text-telcoin-accent" to={item.href}>
-                  {ctaLabel}
-                  <span aria-hidden>→</span>
-                </Link>
-              )
-            ) : null}
-          </ColorMorphCard>
+        return (
+          <div key={item.id} className="sliding-stack__card" style={style}>
+            <ColorMorphCard progress={cardProgress} className={cn('p-6 sm:p-8', cardClassName)}>
+              {item.eyebrow ? (
+                <span className="text-xs font-semibold uppercase tracking-[0.2em] text-telcoin-ink-subtle">
+                  {item.eyebrow}
+                </span>
+              ) : null}
+              <div className="sliding-stack__content">
+                <h3 className="text-xl font-semibold text-telcoin-ink sm:text-2xl">{item.title}</h3>
+                <div className="text-base text-telcoin-ink-muted sm:text-lg">{item.body}</div>
+              </div>
+              {item.href ? (
+                isExternalLink(item.href) ? (
+                  <a
+                    className="inline-flex items-center gap-2 text-sm font-semibold text-telcoin-accent"
+                    href={item.href}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    {ctaLabel}
+                    <span aria-hidden>→</span>
+                  </a>
+                ) : (
+                  <Link className="inline-flex items-center gap-2 text-sm font-semibold text-telcoin-accent" to={item.href}>
+                    {ctaLabel}
+                    <span aria-hidden>→</span>
+                  </Link>
+                )
+              ) : null}
+            </ColorMorphCard>
+          </div>
         )
-
-        return content
       })}
     </div>
   )

--- a/telcoinwiki-react/src/components/cinematic/__tests__/SlidingStack.test.tsx
+++ b/telcoinwiki-react/src/components/cinematic/__tests__/SlidingStack.test.tsx
@@ -38,13 +38,11 @@ describe('SlidingStack', () => {
 
     const cards = Array.from(document.querySelectorAll('.sliding-stack__card')) as HTMLElement[]
     expect(cards).toHaveLength(3)
-    expect(cards[0].style.getPropertyValue('--stack-translate')).toBe('-76.000px')
-    expect(cards[0].style.getPropertyValue('--stack-scale')).toBe('1.000')
-    expect(cards[0].style.getPropertyValue('--stack-opacity')).toBe('0.180')
+    expect(cards[0].style.transform).toBe('translateY(-76.000px) scale(1.000)')
+    expect(cards[0].style.opacity).toBe('0.18')
 
-    expect(cards[2].style.getPropertyValue('--stack-translate')).toBe('76.000px')
-    expect(cards[2].style.getPropertyValue('--stack-scale')).toBe('0.945')
-    expect(cards[2].style.getPropertyValue('--stack-opacity')).toBe('1.000')
+    expect(cards[2].style.transform).toBe('translateY(83.680px) scale(0.933)')
+    expect(cards[2].style.opacity).toBe('0.942')
   })
 
   it('switches to static layout on handheld breakpoints', () => {
@@ -60,9 +58,8 @@ describe('SlidingStack', () => {
     expect(container.style.minHeight).toBe('')
 
     const cards = Array.from(document.querySelectorAll('.sliding-stack__card')) as HTMLElement[]
-    // In static mode vars still compute, but CSS sets transform: none;
-    // For progress=0.25 (normalized 0.5) the first card is -28px, second is 28px at handheld translate unit 56
-    expect(cards[0].style.getPropertyValue('--stack-translate')).toBe('-28.000px')
-    expect(cards[1].style.getPropertyValue('--stack-translate')).toBe('28.000px')
+    // In static mode transforms and opacity are handled in CSS, so inline styles are cleared
+    expect(cards[0].style.transform).toBe('')
+    expect(cards[1].style.transform).toBe('')
   })
 })


### PR DESCRIPTION
## Summary
- move the SlidingStack transforms onto a wrapper element so the ColorMorphCard blur layer no longer flickers while scrolling
- keep morph styling on the card, combine scroll progress into the wrapper transform/opacity, and only apply inline transforms when the stack is animated
- update the SlidingStack tests to assert the new transform and opacity behaviour

## Testing
- npm run lint
- npm run test -- SlidingStack *(fails: jest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5f2e7c910833096a6764c8f43bfc3