### PR TITLE
Fix sliding stack animation for handheld devices

### DIFF
--- a/telcoinwiki-react/src/hooks/useHomeScrollSections.ts
+++ b/telcoinwiki-react/src/hooks/useHomeScrollSections.ts
@@ -149,9 +149,10 @@ function createStackSectionHook(
 ): () => SlidingSectionState {
   return function useHomeStackSection(): SlidingSectionState {
     const sectionRef = useRef<HTMLElement | null>(null)
-    const prefersReducedMotion = usePrefersReducedMotion()
+    const systemPrefersReducedMotion = usePrefersReducedMotion()
     const isCompact = useMediaQuery('(max-width: 62rem)')
     const isHandheld = useMediaQuery('(max-width: 40rem)')
+    const prefersReducedMotion = systemPrefersReducedMotion || isHandheld
 
     const stageStart = isHandheld ? 'top 86%' : isCompact ? 'top 80%' : 'top 76%'
     const stageEnd = isHandheld ? 'bottom 18%' : isCompact ? 'bottom 24%' : 'bottom 30%'


### PR DESCRIPTION
## Summary
- treat handheld home sections as reduced-motion to avoid GSAP scroll timelines hiding the stack
- reuse the reduced-motion styles for handheld layouts so cards stay visible while scrolling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5f5b6d3c48330b5620daa103024d8