### PR TITLE
Add /protocol reference page researched from telcoin.network documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,62 @@
 # Changelog
 
+## 2026-08-16 (3) – Protocol reference page
+
+New `/protocol` route: a working reference for Telcoin Network itself, researched
+from Telcoin's own published documentation (docs.telcoin.network and
+telcoin.org/documentation) rather than written from model knowledge.
+
+### Content — 13 sections
+
+Overview, modular architecture (the four layers as the docs frame them),
+transaction lifecycle, Narwhal/Bullshark consensus, the native token and the
+`0x7e1` TEL precompile, epochs and committee selection, the validator membership
+model and staking, fees and the gas limit penalty, EVM compatibility, the
+security model, validator hardware requirements, networks and endpoints, and a
+full index of every primary documentation source.
+
+Specifics captured that were not on the wiki before: mainnet chain ID 487 /
+testnet 2017, sub-half-second finality, the 30M gas limit per block, the 1M TEL
+launch stake, the `weight = stakeAmount x consensusHeaderCount` reward formula,
+the six validator lifecycle states, epoch-boundary base fee adjustment with base
+fees accruing to governance rather than being destroyed, the quadratic gas limit
+penalty below 10% utilisation (exempt at or below 210,000 gas), Axelar/wTEL
+bridging, Fisher-Yates committee shuffling seeded from an aggregated BLS
+signature, and the published node hardware specification.
+
+Contract addresses are deliberately *not* reproduced — the page says so and
+points at the primary source, because address substitution is a real attack and
+a community wiki is where someone would try it.
+
+### Design
+
+Built with the site's own system rather than a new one: `tc-card-glass` hero,
+`toc-chip` navigation, the existing deep-dive section chrome, and the telcoin-*
+tokens throughout. New elements (stat grid, spec tables, formula blocks,
+definition lists, source callouts) are all defined from existing tokens.
+Restored list markers on the new lists, which Tailwind preflight and
+`critical.css` both strip.
+
+### Integration
+
+- Lazy-loaded route so the reference stays off the main bundle (10.2 kB gzipped).
+- Added to header nav (desktop + mobile), NAV_ITEMS, PAGE_META and the mega menu.
+- Indexed by `tools/build-search-index.mjs`, which now renders both the deep-dive
+  and protocol content trees; the index grew from 17 to 31 documents. Verified
+  that "gas limit penalty", "validator hardware", "precompile", "Axelar",
+  "ConsensusNFT" and "epoch boundary" each resolve to the correct section.
+- Deep links now open the targeted section and scroll to it — the existing Deep
+  Dive drops you on a collapsed accordion, which made anchors from search
+  results much less useful.
+- New `protocol/__tests__/sections.test.ts` guards unique ids, the `proto-`
+  namespace, chip length, every `/protocol#` reference resolving, mega-menu
+  targets, and that the route, nav entry and header link all exist.
+
+Verified with tsc, 24 Jest tests across 4 suites, `npm run build`, and a real
+browser pass (rendering, deep linking, expand/collapse, search ranking, header
+navigation, no 404s, no console errors, no overflow at 390px). Lint unchanged at
+the pre-existing 10 problems.
+
 ## 2026-08-16 (2) – Fact-check pass against primary sources
 
 Cross-referenced the content added earlier the same day against Telcoin's own

--- a/telcoinwiki-react/public/data/search-index.json
+++ b/telcoinwiki-react/public/data/search-index.json
@@ -26,6 +26,73 @@
     "body": ""
   },
   {
+    "id": "protocol",
+    "kind": "page",
+    "title": "Protocol reference — Telcoin Network",
+    "summary": "Working reference for Telcoin Network: modular architecture, Narwhal/Bullshark consensus, transaction lifecycle and finality, the TEL native token and 0x7e1 precompile, epochs and committee selection, validator staking, fees and the gas limit penalty, EVM compatibility, hardware requirements, and an index of every primary documentation source.",
+    "url": "/protocol",
+    "tags": [
+      "Protocol",
+      "Reference",
+      "Developers"
+    ],
+    "headings": [
+      {
+        "id": "proto-overview",
+        "title": "What Telcoin Network is"
+      },
+      {
+        "id": "proto-architecture",
+        "title": "A modular blockchain, in four layers"
+      },
+      {
+        "id": "proto-lifecycle",
+        "title": "From signature to irreversible, in under half a second"
+      },
+      {
+        "id": "proto-consensus",
+        "title": "Narwhal and Bullshark"
+      },
+      {
+        "id": "proto-token",
+        "title": "TEL as a native token, and the 0x7e1 precompile"
+      },
+      {
+        "id": "proto-epochs",
+        "title": "Epochs and committee selection"
+      },
+      {
+        "id": "proto-staking",
+        "title": "The membership model and becoming a validator"
+      },
+      {
+        "id": "proto-fees",
+        "title": "Base fees, priority fees and the gas limit penalty"
+      },
+      {
+        "id": "proto-evm",
+        "title": "What is identical to Ethereum, and what is not"
+      },
+      {
+        "id": "proto-security",
+        "title": "The security model"
+      },
+      {
+        "id": "proto-node",
+        "title": "Validator hardware requirements"
+      },
+      {
+        "id": "proto-networks",
+        "title": "Networks and endpoints"
+      },
+      {
+        "id": "proto-sources",
+        "title": "The full documentation set"
+      }
+    ],
+    "body": ""
+  },
+  {
     "id": "deep-dive",
     "kind": "page",
     "title": "Deep Dive — Telcoin architecture, economics and risks",
@@ -278,5 +345,161 @@
     ],
     "headings": [],
     "body": "Core Terms TEL The native token of the Telcoin ecosystem. Fixed supply of 100 billion, 2 decimal places. Used for gas, staking, liquidity incentives, and governance. Telcoin Network Telcoin’s EVM-compatible Layer 1 blockchain, intended to be validated by GSMA-member mobile network operators. Digital Cash Telcoin’s family of fiat-backed digital currencies, named with an e prefix plus a currency code — usually the ISO 4217 code (eUSD, eEUR, eJPY), though not always: the West African CFA franc is branded eCFA rather than eXOF. Issued and redeemed through the bank entity. Telcoin Digital Asset Bank The regulated entity holding Nebraska’s first Digital Asset Depository Institution charter (finalized 12 November 2025). Issues and redeems Digital Cash, holds 100%-reserved fiat, and runs KYC/AML. Telcoin Association A Swiss nonprofit Verein , domiciled in Lugano, that stewards the protocol, emissions policy, and network governance through elected Miner Councils and the Miner Assembly. Miner Council / Miner Assembly Elected governance bodies within the Association. Miner Councils (Platform and Treasury, TAN, TELx, Compliance) handle domain-specific decisions; the Miner Assembly — all four miner groups together — holds constitutional-level authority over the governance system itself. TELx The liquidity layer that incentivizes market-making in TEL and Digital Cash, currently concentrated on Polygon and Base with a standardization effort extending to Ethereum. TAN — Telcoin Application Network The application layer of the platform: self-custodial mobile wallet apps, built by GSMA telecom members, that sit on top of Telcoin Network and TELx to serve end users. The Telcoin Wallet is a TAN application. GSMA The global industry association representing mobile network operators. Its membership defines the pool from which Telcoin Network validators are drawn. Technical Terms Narwhal A DAG-based mempool protocol that disseminates transaction data in parallel across validators, separating data availability from consensus ordering. From the 2021 paper by Danezis, Kogias, Sonnino, and Spiegelman; also used by the Sui blockchain. Bullshark A consensus protocol that derives a total ordering from Narwhal’s DAG deterministically, requiring no additional messages between validators. From the 2022 paper by Giridharan, Kokoris-Kogias, Sonnino, and Spiegelman. Deterministic finality The property that a committed transaction can never be reversed — as opposed to probabilistic finality, where confidence grows with each confirmation but never reaches certainty. Modular architecture A design separating consensus, execution, and data availability into independent layers that scale separately rather than competing for one pipeline. BFT — Byzantine Fault Tolerance The ability of a distributed system to operate correctly while some participants fail arbitrarily or act maliciously, typically tolerating up to one third of the network. EVM — Ethereum Virtual Machine The execution environment Ethereum smart contracts run in. EVM compatibility means existing Solidity tooling works largely unchanged. Self-custody An arrangement where a user’s assets are not held by a custodian. The Telcoin Wallet implements ”assisted self-custody” — a 2-of-3 key scheme, not a pure single-signer model — see the Wallet section for the distinction. Impermanent loss The shortfall a liquidity provider experiences relative to simply holding the two assets, caused by the pool automatically rebalancing as prices diverge. Corridor A directional country pair for remittances. Each requires its own licensing, partners, and compliance work. Checking Anything Here Against Primary Sources This wiki is written and maintained by the community. It is not published, reviewed, or endorsed by Telcoin, and it can be wrong or out of date. Anything that would affect a real decision should be verified against a primary source: Telcoin’s official site and documentation — for product status, supported corridors, and available currencies. Telcoin Association governance forums — for proposals, council composition, and emissions decisions. The Nebraska Department of Banking and Finance — for the bank entity’s charter status. Block explorers — for contract addresses, balances, and transaction history you can verify yourself. The Telcoin app itself — for what is actually live in your market today. Contract addresses in particular should always be confirmed through an official channel before use. Address substitution is a common attack, and a wiki is exactly the kind of place an attacker would like to plant a wrong one. Content last reviewed: 16 August 2026. On-chain figures cited in the Tokenomics section come from the community-run Telcoin Proposal Tracker snapshot of the same date."
+  },
+  {
+    "id": "proto-overview",
+    "kind": "section",
+    "title": "What Telcoin Network is",
+    "summary": "Telcoin Network is an EVM-compatible Layer 1 blockchain, secured by proof of stake and validated by GSMA Operator Member mobile network operators. TEL is the native gas token. The network is governed by the Telcoin Association, a non-profit",
+    "url": "/protocol#proto-overview",
+    "tags": [
+      "Protocol"
+    ],
+    "headings": [],
+    "body": "Telcoin Network is an EVM-compatible Layer 1 blockchain, secured by proof of stake and validated by GSMA Operator Member mobile network operators. TEL is the native gas token. The network is governed by the Telcoin Association, a non-profit Swiss Verein. The documented use cases are deliberately payments-shaped rather than general-purpose speculation: DeFi payments and services, stablecoin remittances, inter-carrier settlement, and games and loyalty programmes. Node operation rights are reserved for GSMA Full Member MNOs, who earn network fees and TEL issuance for securing blocks. 487 mainnet chain ID 2017 testnet chain ID < 0.5s documented finality 30M gas limit per block 1M TEL validator stake at launch > 2/3 honest stake required"
+  },
+  {
+    "id": "proto-architecture",
+    "kind": "section",
+    "title": "A modular blockchain, in four layers",
+    "summary": "The documentation frames Telcoin Network as modular rather than monolithic — “a modular blockchain separates the blockchain’s services into separate modules, each specializing in one aspect.” Four layers are named. Consensus layer Validates",
+    "url": "/protocol#proto-architecture",
+    "tags": [
+      "Protocol"
+    ],
+    "headings": [],
+    "body": "The documentation frames Telcoin Network as modular rather than monolithic — “a modular blockchain separates the blockchain’s services into separate modules, each specializing in one aspect.” Four layers are named. Consensus layer Validates and orders transactions across validator nodes. Narwhal handles the mempool; Bullshark finalises and records transactions into the settlement layer. Execution layer Described as the chain’s processing unit, analogous to a CPU. Runs everything from simple transfers to smart contracts on the EVM, which is what gives cross-chain tooling compatibility. Data availability layer Keeps the data needed for validation reachable across the network, using “a scalable number of workers which share collections of transactions” so any node can obtain what it needs to process and verify. Settlement layer The permanent ledger. Bullshark’s Byzantine fault tolerant consensus prevents forks and reorganisations, so committed transactions are irrevocably settled. This is the conceptual framing used by the protocol documentation. The implementation in the telcoin-network repository organises the same work differently again — an EpochManager orchestrating consensus, execution, networking and storage — which is a view of the same system at a different altitude, not a contradiction."
+  },
+  {
+    "id": "proto-lifecycle",
+    "kind": "section",
+    "title": "From signature to irreversible, in under half a second",
+    "summary": "Creation. A user initiates a transfer from a wallet or dApp and signs it with their private key, producing an immutable, signature-protected message ready for submission to validators. Certification. Validators check the signature, that the",
+    "url": "/protocol#proto-lifecycle",
+    "tags": [
+      "Protocol"
+    ],
+    "headings": [],
+    "body": "Creation. A user initiates a transfer from a wallet or dApp and signs it with their private key, producing an immutable, signature-protected message ready for submission to validators. Certification. Validators check the signature, that the sender holds enough funds plus gas, that any contract call data is correctly encoded, and that sufficient gas was supplied. Valid transactions enter the pending pool. When proposing, a validator draws transactions until it reaches the 30 million gas limit or runs out. Finalisation. A transaction certificate is broadcast to all validators, who verify and execute it, then compare effects — the node confirms that the state changes reported by each validator are identical. Once a supermajority of signatures is collected it produces an EffectsCertificate , and the transaction is executed, irreversible and final. The documentation puts the whole process at less than half a second , which is why the architecture has no notion of a pending block — there is no probabilistic waiting period to sit through."
+  },
+  {
+    "id": "proto-consensus",
+    "kind": "section",
+    "title": "Narwhal and Bullshark",
+    "summary": "Narwhal — a DAG-based mempool Narwhal structures transaction dissemination as a directed acyclic graph. The documentation credits it with three properties: parallel processing — “the DAG structure allows for concurrent transaction processin",
+    "url": "/protocol#proto-consensus",
+    "tags": [
+      "Protocol"
+    ],
+    "headings": [],
+    "body": "Narwhal — a DAG-based mempool Narwhal structures transaction dissemination as a directed acyclic graph. The documentation credits it with three properties: parallel processing — “the DAG structure allows for concurrent transaction processing, significantly boosting throughput”; efficiency , by removing the bottlenecks of a traditional sequential mempool; and scalability under substantial transaction volume. Bullshark — asynchronous consensus Bullshark is a DAG-based Byzantine Atomic Broadcast protocol. It operates asynchronously , meaning it stays correct without timing assumptions and so resists network delays and timing-based exploits, while being “optimized for the more common synchronous cases, ensuring high throughput and low latency.” Together they give the settlement layer its defining property: no forks, no reorganisations, and deterministic finality rather than confirmations that only ever approach certainty."
+  },
+  {
+    "id": "proto-token",
+    "kind": "section",
+    "title": "TEL as a native token, and the 0x7e1 precompile",
+    "summary": "TEL began as an ERC-20 on Ethereum and became the native gas token of Telcoin Network — an unusual direction of travel. Most chains launch a new native token and wrap it afterwards. Telcoin explicitly avoids the Polygon-style approach of ke",
+    "url": "/protocol#proto-token",
+    "tags": [
+      "Protocol"
+    ],
+    "headings": [],
+    "body": "TEL began as an ERC-20 on Ethereum and became the native gas token of Telcoin Network — an unusual direction of travel. Most chains launch a new native token and wrap it afterwards. Telcoin explicitly avoids the Polygon-style approach of keeping state synchronised between Ethereum and the chain through mechanisms like StateSender and checkpoints; core state lives on Telcoin Network itself. Because TEL exists on Ethereum, it has to be bridged. The protocol uses Axelar to bridge ERC-20 TEL across as wrapped TEL ( wTEL ), which users then unwrap into native TEL much as WETH9 works. Managing balances at the protocol level rather than inside a contract is what lets multiple TEL transfers execute in parallel without synchronous state conflicts. The documentation is candid that bridge dependencies are a risk for an early-stage chain, and points at recoverable token standards such as ERC-20R as a mitigation worth exploring. One balance, two interfaces The most distinctive divergence from Ethereum is a native ERC-20 interface for TEL exposed at precompile address 0x7e1 . Where Ethereum needs WETH to make ETH behave like a token, TEL is both the gas token and a standard ERC-20 at once: balanceOf() returns the native account balance — there is one balance, not two. Native transfers and ERC-20 transfers move the same underlying funds. Full ERC-20 support plus EIP-2612 gasless approvals via permit() . Infinite allowances do not decrement on repeated transfers, as a gas optimisation. Transfers to address(0) revert. Native transfers emit no Transfer event; only ERC-20 calls do."
+  },
+  {
+    "id": "proto-epochs",
+    "kind": "section",
+    "title": "Epochs and committee selection",
+    "summary": "Consensus is organised into fixed-duration epochs , each run by a stable validator committee. Committee selection at an epoch boundary is deterministic but seeded by verifiable randomness: Active validators are queried from the ConsensusReg",
+    "url": "/protocol#proto-epochs",
+    "tags": [
+      "Protocol"
+    ],
+    "headings": [],
+    "body": "Consensus is organised into fixed-duration epochs , each run by a stable validator committee. Committee selection at an epoch boundary is deterministic but seeded by verifiable randomness: Active validators are queried from the ConsensusRegistry contract. If there are too few, validators with PendingExit status are drawn on at random to fill the gaps. A 32-byte seed is derived as keccak256(aggregated BLS signature) of the final leader certificate. The list is shuffled with Fisher–Yates using that seed. The result is sorted by address for deterministic ordering. The committee is truncated to the target size and committed on-chain. Three operations run as system calls inside the final block of an epoch: validator reward distribution based on leader block counts, committee selection and shuffling , and base fee adjustment . They consume no block gas and surface only as state changes and modified header fields ( extra_data and withdrawals )."
+  },
+  {
+    "id": "proto-staking",
+    "kind": "section",
+    "title": "The membership model and becoming a validator",
+    "summary": "Why membership rather than stake-weighting The model is designed to grow the network by adding nodes rather than enlarging them . Under conventional stake-weighting an operator has no reason to run several nodes when concentrating stake on ",
+    "url": "/protocol#proto-staking",
+    "tags": [
+      "Protocol"
+    ],
+    "headings": [],
+    "body": "Why membership rather than stake-weighting The model is designed to grow the network by adding nodes rather than enlarging them . Under conventional stake-weighting an operator has no reason to run several nodes when concentrating stake on one earns the same. Requiring a fixed stake per node means an operator deploying more capital must launch more validators, each with “its own keys, its own infrastructure, and its own ConsensusNFT.” Rewards are weighted by header production, so uptime and reliability — not just capital — determine earnings. Because validators are mobile network operators vetted by governance, the ConsensusNFT whitelist supplies sybil resistance that a fixed stake alone could not. Stake versions Validators join under a stake version , each defining a StakeConfig : stakeAmount , minWithdrawAmount , epochIssuance and epochDuration . Governance can publish a new version with upgradeStakeVersion() , effective the next epoch. A validator’s version is fixed at stake time — there is no in-place upgrade, only exit and rejoin. Rewards are settled at each epoch boundary: weight = stakeAmount × consensusHeaderCount reward = (epochIssuance × weight) / totalWeight In a single-version committee the stake amount cancels out and rewards track header production alone. In a mixed committee a larger stake earns proportionally more per header, but a reliable smaller-stake validator can still out-earn an underperforming larger one. Joining, in three transactions Keys are generated with the telcoin-network keytool , producing a BLS keypair, network keypairs and a node-info.yaml carrying the public keys and proof of possession. Then, against the ConsensusRegistry system contract: Governance approval. Governance mints a ConsensusNFT to the validator’s ECDSA address via mint(validatorAddress) , whitelisting it. Stake. Call stake() with a 96-byte compressed BLS public key and a proof of possession (192-byte uncompressed key plus signature), sending 1,000,000 TEL — the launch stake amount. Activate. Once the node has synced (checked with the tn_syncing RPC method), call activate() . The validator becomes eligible for committee selection at the next epoch boundary. Validator lifecycle states Status Meaning Undefined Holds a ConsensusNFT but has not staked Staked Staked but not yet activated PendingActivation Called activate() , awaiting the epoch boundary Active Eligible for committee selection PendingExit Exit requested, outstanding committee obligations remain Exited Can unstake after one epoch Exiting is beginExit() , then unstake(validatorAddress) after a full epoch to reclaim stake plus rewards. Contract addresses are deliberately not reproduced here. Always take them from the official documentation or an explorer immediately before use — address substitution is a common attack, and a community wiki is exactly where someone would try to plant a wrong one."
+  },
+  {
+    "id": "proto-fees",
+    "kind": "section",
+    "title": "Base fees, priority fees and the gas limit penalty",
+    "summary": "An EIP-1559 fee market on an epoch clock Telcoin Network uses an EIP-1559-style base fee, but adjusts it at epoch boundaries rather than per block . Within an epoch the base fee is static across every batch and transaction. At the boundary ",
+    "url": "/protocol#proto-fees",
+    "tags": [
+      "Protocol"
+    ],
+    "headings": [],
+    "body": "An EIP-1559 fee market on an epoch clock Telcoin Network uses an EIP-1559-style base fee, but adjusts it at epoch boundaries rather than per block . Within an epoch the base fee is static across every batch and transaction. At the boundary the protocol measures aggregate gas usage and recalibrates: unchanged if the target was met, up if exceeded, down if under, with MAX_CHANGE_DENOMINATOR capping the rate of change and a protocol-defined floor below which it cannot fall. The practical effect is fee stability: one eth_gasPrice call gives you the definitive base fee for the rest of the epoch, with none of Ethereum’s block-to-block volatility. Where the money goes Transactions specify maxFeePerGas and maxPriorityFeePerGas exactly as on Ethereum. Priority fees go to batch producers whose transactions land in the final block. The base fee does not leave the system the way Ethereum’s does — it is burned with an equivalent amount minted to the governance safe, so in net terms 100% of base fees accrue to governance reserves that fund future rewards. The gas limit penalty Because consensus orders transactions before they execute, actual gas usage is unknown at submission — which opens the door to declaring an enormous gas limit on a cheap transaction and wasting batch capacity. The penalty targets exactly that. It applies only when a transaction consumes less than 10% of its declared limit , and never to transactions with a gas limit of 210,000 or below . usage_ratio = gas_used / gas_limit inefficiency = 0.10 - usage_ratio penalty_gas = (inefficiency² / 0.10²) × unused_gas Penalty applied to unused gas Gas limit actually used Penalty on the unused portion 9.9% Negligible 5% ~25% 2% ~62% 0.1% > 95% The curve ramps gently near the threshold and steeply for extreme over-estimation. Penalties are deducted from the refund rather than added to the bill, so they never increase the total fee paid, and they go to the governance address."
+  },
+  {
+    "id": "proto-evm",
+    "kind": "section",
+    "title": "What is identical to Ethereum, and what is not",
+    "summary": "Compatibility is close to total: “There are no custom opcodes, no modified gas costs, and no disabled instructions.” Contracts deploy as they would on Ethereum, and Hardhat, Foundry, ethers.js and viem work unmodified. Documented divergence",
+    "url": "/protocol#proto-evm",
+    "tags": [
+      "Protocol"
+    ],
+    "headings": [],
+    "body": "Compatibility is close to total: “There are no custom opcodes, no modified gas costs, and no disabled instructions.” Contracts deploy as they would on Ethereum, and Hardhat, Foundry, ethers.js and viem work unmodified. Documented divergences Area Difference TEL precompile Native ERC-20 interface at 0x7e1 ; gas token and token share one balance Base fee Collected by the governance address for protocol use rather than destroyed Transaction types Legacy, EIP-2930 and EIP-1559 supported; blob transactions (EIP-4844) not yet implemented Header fields nonce encodes epoch and round, difficulty packs batch index and worker ID, mix_hash carries consensus digests Chain IDs Mainnet 487 , testnet 2017 The header fields matter if you are writing indexers or explorers: those slots carry consensus-layer metadata on Telcoin Network, not the proof-of-work values their names imply."
+  },
+  {
+    "id": "proto-security",
+    "kind": "section",
+    "title": "The security model",
+    "summary": "The network “remains secure so long as over 2/3 of the network’s total stake is controlled by honest and non adversarial validators” — the standard Byzantine fault tolerant threshold, here resting on a validator set of vetted mobile network",
+    "url": "/protocol#proto-security",
+    "tags": [
+      "Protocol"
+    ],
+    "headings": [],
+    "body": "The network “remains secure so long as over 2/3 of the network’s total stake is controlled by honest and non adversarial validators” — the standard Byzantine fault tolerant threshold, here resting on a validator set of vetted mobile network operators. Private signature keys are required to authorise any transaction, and only asset owners can move their own holdings. Assets follow the rules written into their Solidity contracts by the contract creator. Finalised transactions create a permanent record that later operations build on. All network actions are publicly visible; users manage privacy by using multiple addresses. Aborted transactions still consume gas but leave state unchanged, which is what makes spam expensive. Smart contract deployment is permissionless, so the usual caution applies in full: interact only with contracts you trust and understand."
+  },
+  {
+    "id": "proto-node",
+    "kind": "section",
+    "title": "Validator hardware requirements",
+    "summary": "These are carrier-grade requirements, and a fair signal of what the network expects of the operators securing it. Published validator node specification Component Minimum Recommended CPU x86/x64, 16 cores / 32 threads, 4000+ PassMark single",
+    "url": "/protocol#proto-node",
+    "tags": [
+      "Protocol"
+    ],
+    "headings": [],
+    "body": "These are carrier-grade requirements, and a fair signal of what the network expects of the operators securing it. Published validator node specification Component Minimum Recommended CPU x86/x64, 16 cores / 32 threads, 4000+ PassMark single-thread 32 cores, higher clock prioritised Memory 128 GB DDR4/DDR5 ECC registered DIMM 128 GB or more at maximum speed Storage 4 TB TLC NVMe SSD 7.5 TB TLC NVMe SSD Bandwidth 1000 Mb/s sustained, 1-Gigabit Ethernet 1000+ Mb/s sustained, 10-Gigabit interface Operating system Linux LTS — Debian 11+, Ubuntu 20.04+, RHEL 8; kernel 3.10 or newer Operators are asked to submit their specification to the Telcoin DevOps team for approval before installation, so the list above is a starting point for a conversation rather than a self-serve checklist."
+  },
+  {
+    "id": "proto-networks",
+    "kind": "section",
+    "title": "Networks and endpoints",
+    "summary": "Published network parameters Parameter Adiri testnet Chain ID 0x7e1 (2017) Currency symbol TEL Public RPC https://rpc.adiri.tel Explorer https://telscan.io Adiri is currently the only deployed network. The public RPC endpoint sits behind a ",
+    "url": "/protocol#proto-networks",
+    "tags": [
+      "Protocol"
+    ],
+    "headings": [],
+    "body": "Published network parameters Parameter Adiri testnet Chain ID 0x7e1 (2017) Currency symbol TEL Public RPC https://rpc.adiri.tel Explorer https://telscan.io Adiri is currently the only deployed network. The public RPC endpoint sits behind a load balancer and is intended for single transactions and read queries; sustained development work should connect to a node directly. The documentation warns the testnet may be reset before mainnet to accommodate protocol changes, so treat any state there as disposable. Chain ID 0x7e1 is 2017 in decimal — the year Telcoin was founded — and the same value appears again as the address of the TEL precompile."
+  },
+  {
+    "id": "proto-sources",
+    "kind": "section",
+    "title": "The full documentation set",
+    "summary": "Everything above is drawn from Telcoin’s own published documentation. The index below maps the ecosystem’s documentation surface so you can go to the primary source for anything that matters — this wiki is a community summary and can lag be",
+    "url": "/protocol#proto-sources",
+    "tags": [
+      "Protocol"
+    ],
+    "headings": [],
+    "body": "Everything above is drawn from Telcoin’s own published documentation. The index below maps the ecosystem’s documentation surface so you can go to the primary source for anything that matters — this wiki is a community summary and can lag behind or get things wrong. Protocol documentation — docs.telcoin.network Architecture — overview, native token, security, transaction lifecycle, consensus layer Getting started — reading chain data (cURL, programmatic, libraries), dapp development, development tools, faucet, hardware requirements Networks and RPC endpoints — endpoint and chain parameters RPC methods — the full eth_* and net_* surface: accounts, chain info, contract and state reads, balances and gas, blocks, transactions, submission, logs Filter methods — eth_newFilter , eth_newBlockFilter , eth_newPendingTransactionFilter , eth_getFilterChanges , eth_getFilterLogs , eth_uninstallFilter Staking — how staking works, why the membership model, how to stake, future direction Reference — constants, stablecoin contracts, Adiri testnet Protocol topics — basefees, gas limit penalty, EVM compatibility, epoch boundaries, canonical updates FAQs — economic incentives and rewards Governance documentation — telcoin.org Association — the non-profit Swiss Verein that governs the platform, and Telcoin Autonomous Ops (TAO) Participation — how to take part, including the route for GSMA mobile networks Platform — Telcoin Network, the TEL token, the TELx DeFi exchange, and the Telcoin Application Network Miners — validators, liquidity miners, developers and stakers Association governance — governance organisations, Miner Councils, the Miner Assembly, and association rules including harvesting rules Other primary surfaces telcoin.network — network overview and faucet tnips.telcoin.network — Telcoin Network Improvement Proposals roadmap.telcoin.network — published roadmap forum.telcoin.org — governance forum, proposals and council discussion github.com/Telcoin-Association — telcoin-network (protocol) and tn-contracts (smart contracts) telscan.io — block explorer Reviewed 16 August 2026 against docs.telcoin.network and telcoin.org. Figures such as the launch stake amount, chain IDs and hardware requirements are the values published at that date and are exactly the kind of thing that changes — check the source before relying on any of them."
   }
 ]

--- a/telcoinwiki-react/src/App.tsx
+++ b/telcoinwiki-react/src/App.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Suspense, lazy } from 'react'
 import { Route, Routes } from 'react-router-dom'
 
 import { CinematicLayout } from './components/layout/CinematicLayout'
@@ -8,6 +9,11 @@ import { SEARCH_CONFIG } from './config/search'
 import { HomePage } from './pages/HomePage'
 import { DeepDivePage } from './pages/DeepDivePage'
 import { NotFoundPage } from './pages/NotFoundPage'
+
+// Reference content is long and rarely the entry point; keep it off the main bundle.
+const ProtocolPage = lazy(() =>
+  import('./pages/ProtocolPage').then((m) => ({ default: m.ProtocolPage })),
+)
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -46,6 +52,21 @@ function App() {
               searchConfig={SEARCH_CONFIG}
             >
               <DeepDivePage />
+            </CinematicLayout>
+          }
+        />
+        <Route
+          path="/protocol"
+          element={
+            <CinematicLayout
+              pageId="protocol"
+              navItems={NAV_ITEMS}
+              pageMeta={PAGE_META}
+              searchConfig={SEARCH_CONFIG}
+            >
+              <Suspense fallback={<div className="min-h-screen" />}>
+                <ProtocolPage />
+              </Suspense>
             </CinematicLayout>
           }
         />

--- a/telcoinwiki-react/src/components/layout/Header.tsx
+++ b/telcoinwiki-react/src/components/layout/Header.tsx
@@ -81,6 +81,9 @@ export function Header({
             <Link to="/deep-dive" className="header-nav-link">
               Deep Dive
             </Link>
+            <Link to="/protocol" className="header-nav-link">
+              Protocol
+            </Link>
             <Link to="/#faq-section" className="header-nav-link">
               FAQ
             </Link>
@@ -179,6 +182,7 @@ export function Header({
               <Link to="/deep-dive" onClick={handleMobileLinkClick}>Deep Dive</Link>
             </li>
             <li className="nav-item">
+              <Link to="/protocol" onClick={handleMobileLinkClick}>Protocol</Link>
               <Link to="/#faq-section" onClick={handleMobileLinkClick}>FAQ</Link>
             </li>
           </ul>

--- a/telcoinwiki-react/src/components/protocol/__tests__/sections.test.ts
+++ b/telcoinwiki-react/src/components/protocol/__tests__/sections.test.ts
@@ -1,0 +1,77 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { PROTOCOL_SECTIONS } from '../sections'
+import { megaMenuSections } from '../../../config/megaMenu'
+import { NAV_ITEMS } from '../../../config/navigation'
+import { PAGE_META } from '../../../config/pageMeta'
+
+const SRC_ROOT = join(__dirname, '..', '..', '..')
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      return entry === '__tests__' || entry === '__mocks__' ? [] : sourceFiles(full)
+    }
+    return /\.tsx?$/.test(entry) ? [full] : []
+  })
+}
+
+describe('protocol reference sections', () => {
+  const ids = new Set(PROTOCOL_SECTIONS.map((s) => s.id))
+
+  it('defines unique section ids', () => {
+    expect(ids.size).toBe(PROTOCOL_SECTIONS.length)
+  })
+
+  it('gives every section a title and a short TOC chip label', () => {
+    PROTOCOL_SECTIONS.forEach((s) => {
+      expect(s.title.trim().length).toBeGreaterThan(3)
+      expect(s.chip.trim().length).toBeGreaterThan(1)
+      // Chips sit in a single wrapping row; long labels wreck that layout.
+      expect(s.chip.length).toBeLessThanOrEqual(22)
+      expect(s.content).toBeTruthy()
+    })
+  })
+
+  it('namespaces every id so it cannot collide with a deep-dive anchor', () => {
+    PROTOCOL_SECTIONS.forEach((s) => expect(s.id.startsWith('proto-')).toBe(true))
+  })
+
+  /** Same guard as the deep dive: anchors are invisible to the type system. */
+  it('has no reference to an undefined /protocol anchor', () => {
+    const broken: string[] = []
+    for (const file of sourceFiles(SRC_ROOT)) {
+      const contents = readFileSync(file, 'utf8')
+      for (const m of contents.matchAll(/\/protocol#([a-z0-9-]+)/g)) {
+        if (!ids.has(m[1])) broken.push(`${file.replace(SRC_ROOT, 'src')} → #${m[1]}`)
+      }
+    }
+    expect(broken).toEqual([])
+  })
+
+  it('points every mega-menu protocol item at a real section', () => {
+    const broken = megaMenuSections
+      .flatMap((s) => s.items)
+      .filter((i) => i.href.startsWith('/protocol#'))
+      .map((i) => i.href.replace('/protocol#', ''))
+      .filter((a) => !ids.has(a))
+    expect(broken).toEqual([])
+  })
+
+  it('is reachable from navigation and described in page meta', () => {
+    expect(NAV_ITEMS.some((n) => n.href === '/protocol')).toBe(true)
+    expect(PAGE_META.protocol).toBeDefined()
+    expect(PAGE_META.protocol.url).toBe('/protocol')
+  })
+
+  it('has a route registered for /protocol', () => {
+    const app = readFileSync(join(SRC_ROOT, 'App.tsx'), 'utf8')
+    expect(app).toContain('path="/protocol"')
+  })
+
+  it('is linked from the site header', () => {
+    const header = readFileSync(join(SRC_ROOT, 'components', 'layout', 'Header.tsx'), 'utf8')
+    expect(header).toContain('to="/protocol"')
+  })
+})

--- a/telcoinwiki-react/src/components/protocol/sections.tsx
+++ b/telcoinwiki-react/src/components/protocol/sections.tsx
@@ -1,0 +1,607 @@
+import type { ReactNode } from 'react'
+
+export type ProtocolSection = {
+  id: string
+  title: string
+  /** Short label used by the table-of-contents chips. */
+  chip: string
+  content: ReactNode
+}
+
+/**
+ * Telcoin Network protocol reference.
+ *
+ * Sourced from the official documentation at docs.telcoin.network (see the
+ * "Documentation index" section for the full page list). Kept out of the page
+ * component so `tools/build-search-index.mjs` can render it to text and the
+ * anchor test can verify every chip target resolves.
+ */
+export const PROTOCOL_SECTIONS: ProtocolSection[] = [
+  {
+    id: 'proto-overview',
+    chip: 'Overview',
+    title: 'What Telcoin Network is',
+    content: (
+      <>
+        <p>
+          Telcoin Network is an EVM-compatible Layer 1 blockchain, secured by proof of stake and
+          validated by GSMA Operator Member mobile network operators. TEL is the native gas token.
+          The network is governed by the Telcoin Association, a non-profit Swiss Verein.
+        </p>
+        <p>
+          The documented use cases are deliberately payments-shaped rather than general-purpose
+          speculation: DeFi payments and services, stablecoin remittances, inter-carrier settlement,
+          and games and loyalty programmes. Node operation rights are reserved for GSMA Full Member
+          MNOs, who earn network fees and TEL issuance for securing blocks.
+        </p>
+        <div className="proto-stats" role="list">
+          <div className="proto-stat" role="listitem">
+            <b>487</b>
+            <i>mainnet chain ID</i>
+          </div>
+          <div className="proto-stat" role="listitem">
+            <b>2017</b>
+            <i>testnet chain ID</i>
+          </div>
+          <div className="proto-stat" role="listitem">
+            <b>&lt; 0.5s</b>
+            <i>documented finality</i>
+          </div>
+          <div className="proto-stat" role="listitem">
+            <b>30M</b>
+            <i>gas limit per block</i>
+          </div>
+          <div className="proto-stat" role="listitem">
+            <b>1M TEL</b>
+            <i>validator stake at launch</i>
+          </div>
+          <div className="proto-stat" role="listitem">
+            <b>&gt; 2/3</b>
+            <i>honest stake required</i>
+          </div>
+        </div>
+      </>
+    ),
+  },
+  {
+    id: 'proto-architecture',
+    chip: 'Architecture',
+    title: 'A modular blockchain, in four layers',
+    content: (
+      <>
+        <p>
+          The documentation frames Telcoin Network as modular rather than monolithic — &ldquo;a modular
+          blockchain separates the blockchain&rsquo;s services into separate modules, each specializing in
+          one aspect.&rdquo; Four layers are named.
+        </p>
+        <dl className="proto-deflist">
+          <dt>Consensus layer</dt>
+          <dd>
+            Validates and orders transactions across validator nodes. Narwhal handles the mempool;
+            Bullshark finalises and records transactions into the settlement layer.
+          </dd>
+
+          <dt>Execution layer</dt>
+          <dd>
+            Described as the chain&rsquo;s processing unit, analogous to a CPU. Runs everything from simple
+            transfers to smart contracts on the EVM, which is what gives cross-chain tooling
+            compatibility.
+          </dd>
+
+          <dt>Data availability layer</dt>
+          <dd>
+            Keeps the data needed for validation reachable across the network, using &ldquo;a scalable number
+            of workers which share collections of transactions&rdquo; so any node can obtain what it needs to
+            process and verify.
+          </dd>
+
+          <dt>Settlement layer</dt>
+          <dd>
+            The permanent ledger. Bullshark&rsquo;s Byzantine fault tolerant consensus prevents forks and
+            reorganisations, so committed transactions are irrevocably settled.
+          </dd>
+        </dl>
+        <p className="proto-note">
+          This is the conceptual framing used by the protocol documentation. The implementation in the
+          <code> telcoin-network</code> repository organises the same work differently again — an
+          EpochManager orchestrating consensus, execution, networking and storage — which is a view of
+          the same system at a different altitude, not a contradiction.
+        </p>
+      </>
+    ),
+  },
+  {
+    id: 'proto-lifecycle',
+    chip: 'Transaction lifecycle',
+    title: 'From signature to irreversible, in under half a second',
+    content: (
+      <>
+        <ol className="proto-steps">
+          <li>
+            <b>Creation.</b> A user initiates a transfer from a wallet or dApp and signs it with their
+            private key, producing an immutable, signature-protected message ready for submission to
+            validators.
+          </li>
+          <li>
+            <b>Certification.</b> Validators check the signature, that the sender holds enough funds
+            plus gas, that any contract call data is correctly encoded, and that sufficient gas was
+            supplied. Valid transactions enter the pending pool. When proposing, a validator draws
+            transactions until it reaches the <b>30 million gas limit</b> or runs out.
+          </li>
+          <li>
+            <b>Finalisation.</b> A transaction certificate is broadcast to all validators, who verify
+            and execute it, then compare effects — the node confirms that the state changes reported by
+            each validator are identical. Once a supermajority of signatures is collected it produces an
+            <code> EffectsCertificate</code>, and the transaction is executed, irreversible and final.
+          </li>
+        </ol>
+        <p>
+          The documentation puts the whole process at <b>less than half a second</b>, which is why the
+          architecture has no notion of a pending block — there is no probabilistic waiting period to
+          sit through.
+        </p>
+      </>
+    ),
+  },
+  {
+    id: 'proto-consensus',
+    chip: 'Consensus',
+    title: 'Narwhal and Bullshark',
+    content: (
+      <>
+        <h4>Narwhal — a DAG-based mempool</h4>
+        <p>
+          Narwhal structures transaction dissemination as a directed acyclic graph. The documentation
+          credits it with three properties: <b>parallel processing</b> — &ldquo;the DAG structure allows for
+          concurrent transaction processing, significantly boosting throughput&rdquo;; <b>efficiency</b>,
+          by removing the bottlenecks of a traditional sequential mempool; and <b>scalability</b> under
+          substantial transaction volume.
+        </p>
+        <h4>Bullshark — asynchronous consensus</h4>
+        <p>
+          Bullshark is a DAG-based Byzantine Atomic Broadcast protocol. It operates{' '}
+          <b>asynchronously</b>, meaning it stays correct without timing assumptions and so resists
+          network delays and timing-based exploits, while being &ldquo;optimized for the more common
+          synchronous cases, ensuring high throughput and low latency.&rdquo;
+        </p>
+        <p>
+          Together they give the settlement layer its defining property: no forks, no reorganisations,
+          and deterministic finality rather than confirmations that only ever approach certainty.
+        </p>
+      </>
+    ),
+  },
+  {
+    id: 'proto-token',
+    chip: 'Native token',
+    title: 'TEL as a native token, and the 0x7e1 precompile',
+    content: (
+      <>
+        <p>
+          TEL began as an ERC-20 on Ethereum and became the native gas token of Telcoin Network — an
+          unusual direction of travel. Most chains launch a new native token and wrap it afterwards.
+          Telcoin explicitly avoids the Polygon-style approach of keeping state synchronised between
+          Ethereum and the chain through mechanisms like StateSender and checkpoints; core state lives
+          on Telcoin Network itself.
+        </p>
+        <p>
+          Because TEL exists on Ethereum, it has to be bridged. The protocol uses <b>Axelar</b> to bridge
+          ERC-20 TEL across as wrapped TEL (<code>wTEL</code>), which users then unwrap into native TEL
+          much as WETH9 works. Managing balances at the protocol level rather than inside a contract is
+          what lets multiple TEL transfers execute in parallel without synchronous state conflicts.
+        </p>
+        <p className="proto-note">
+          The documentation is candid that bridge dependencies are a risk for an early-stage chain, and
+          points at recoverable token standards such as ERC-20R as a mitigation worth exploring.
+        </p>
+
+        <h4>One balance, two interfaces</h4>
+        <p>
+          The most distinctive divergence from Ethereum is a native ERC-20 interface for TEL exposed at
+          precompile address <code>0x7e1</code>. Where Ethereum needs WETH to make ETH behave like a
+          token, TEL is both the gas token and a standard ERC-20 at once:
+        </p>
+        <ul>
+          <li><code>balanceOf()</code> returns the native account balance — there is one balance, not two.</li>
+          <li>Native transfers and ERC-20 transfers move the same underlying funds.</li>
+          <li>Full ERC-20 support plus EIP-2612 gasless approvals via <code>permit()</code>.</li>
+          <li>Infinite allowances do not decrement on repeated transfers, as a gas optimisation.</li>
+          <li>Transfers to <code>address(0)</code> revert.</li>
+          <li>Native transfers emit no <code>Transfer</code> event; only ERC-20 calls do.</li>
+        </ul>
+      </>
+    ),
+  },
+  {
+    id: 'proto-epochs',
+    chip: 'Epochs',
+    title: 'Epochs and committee selection',
+    content: (
+      <>
+        <p>
+          Consensus is organised into fixed-duration <b>epochs</b>, each run by a stable validator
+          committee. Committee selection at an epoch boundary is deterministic but seeded by verifiable
+          randomness:
+        </p>
+        <ol className="proto-steps">
+          <li>Active validators are queried from the <code>ConsensusRegistry</code> contract.</li>
+          <li>If there are too few, validators with <code>PendingExit</code> status are drawn on at random to fill the gaps.</li>
+          <li>A 32-byte seed is derived as <code>keccak256(aggregated BLS signature)</code> of the final leader certificate.</li>
+          <li>The list is shuffled with Fisher–Yates using that seed.</li>
+          <li>The result is sorted by address for deterministic ordering.</li>
+          <li>The committee is truncated to the target size and committed on-chain.</li>
+        </ol>
+        <p>
+          Three operations run as system calls inside the final block of an epoch: <b>validator reward
+          distribution</b> based on leader block counts, <b>committee selection and shuffling</b>, and
+          <b> base fee adjustment</b>. They consume no block gas and surface only as state changes and
+          modified header fields (<code>extra_data</code> and <code>withdrawals</code>).
+        </p>
+      </>
+    ),
+  },
+  {
+    id: 'proto-staking',
+    chip: 'Staking',
+    title: 'The membership model and becoming a validator',
+    content: (
+      <>
+        <h4>Why membership rather than stake-weighting</h4>
+        <p>
+          The model is designed to grow the network by <b>adding nodes rather than enlarging them</b>.
+          Under conventional stake-weighting an operator has no reason to run several nodes when
+          concentrating stake on one earns the same. Requiring a fixed stake per node means an operator
+          deploying more capital must launch more validators, each with &ldquo;its own keys, its own
+          infrastructure, and its own ConsensusNFT.&rdquo;
+        </p>
+        <p>
+          Rewards are weighted by header production, so uptime and reliability — not just capital —
+          determine earnings. Because validators are mobile network operators vetted by governance, the
+          ConsensusNFT whitelist supplies sybil resistance that a fixed stake alone could not.
+        </p>
+
+        <h4>Stake versions</h4>
+        <p>
+          Validators join under a <b>stake version</b>, each defining a <code>StakeConfig</code>:
+          <code> stakeAmount</code>, <code>minWithdrawAmount</code>, <code>epochIssuance</code> and
+          <code> epochDuration</code>. Governance can publish a new version with
+          <code> upgradeStakeVersion()</code>, effective the next epoch. A validator&rsquo;s version is fixed
+          at stake time — there is no in-place upgrade, only exit and rejoin.
+        </p>
+        <p>Rewards are settled at each epoch boundary:</p>
+        <pre className="proto-code">{`weight = stakeAmount × consensusHeaderCount
+reward = (epochIssuance × weight) / totalWeight`}</pre>
+        <p>
+          In a single-version committee the stake amount cancels out and rewards track header production
+          alone. In a mixed committee a larger stake earns proportionally more per header, but a
+          reliable smaller-stake validator can still out-earn an underperforming larger one.
+        </p>
+
+        <h4>Joining, in three transactions</h4>
+        <p>
+          Keys are generated with the <code>telcoin-network keytool</code>, producing a BLS keypair,
+          network keypairs and a <code>node-info.yaml</code> carrying the public keys and proof of
+          possession. Then, against the <code>ConsensusRegistry</code> system contract:
+        </p>
+        <ol className="proto-steps">
+          <li>
+            <b>Governance approval.</b> Governance mints a <code>ConsensusNFT</code> to the validator&rsquo;s
+            ECDSA address via <code>mint(validatorAddress)</code>, whitelisting it.
+          </li>
+          <li>
+            <b>Stake.</b> Call <code>stake()</code> with a 96-byte compressed BLS public key and a proof
+            of possession (192-byte uncompressed key plus signature), sending <b>1,000,000 TEL</b> —
+            the launch stake amount.
+          </li>
+          <li>
+            <b>Activate.</b> Once the node has synced (checked with the <code>tn_syncing</code> RPC
+            method), call <code>activate()</code>. The validator becomes eligible for committee selection
+            at the next epoch boundary.
+          </li>
+        </ol>
+
+        <div className="proto-table-wrap">
+          <table className="proto-table">
+            <caption>Validator lifecycle states</caption>
+            <thead>
+              <tr><th scope="col">Status</th><th scope="col">Meaning</th></tr>
+            </thead>
+            <tbody>
+              <tr><td><code>Undefined</code></td><td>Holds a ConsensusNFT but has not staked</td></tr>
+              <tr><td><code>Staked</code></td><td>Staked but not yet activated</td></tr>
+              <tr><td><code>PendingActivation</code></td><td>Called <code>activate()</code>, awaiting the epoch boundary</td></tr>
+              <tr><td><code>Active</code></td><td>Eligible for committee selection</td></tr>
+              <tr><td><code>PendingExit</code></td><td>Exit requested, outstanding committee obligations remain</td></tr>
+              <tr><td><code>Exited</code></td><td>Can unstake after one epoch</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p>
+          Exiting is <code>beginExit()</code>, then <code>unstake(validatorAddress)</code> after a full
+          epoch to reclaim stake plus rewards.
+        </p>
+        <p className="proto-note">
+          Contract addresses are deliberately not reproduced here. Always take them from the official
+          documentation or an explorer immediately before use — address substitution is a common attack,
+          and a community wiki is exactly where someone would try to plant a wrong one.
+        </p>
+      </>
+    ),
+  },
+  {
+    id: 'proto-fees',
+    chip: 'Fees',
+    title: 'Base fees, priority fees and the gas limit penalty',
+    content: (
+      <>
+        <h4>An EIP-1559 fee market on an epoch clock</h4>
+        <p>
+          Telcoin Network uses an EIP-1559-style base fee, but adjusts it <b>at epoch boundaries rather
+          than per block</b>. Within an epoch the base fee is static across every batch and transaction.
+          At the boundary the protocol measures aggregate gas usage and recalibrates: unchanged if the
+          target was met, up if exceeded, down if under, with <code>MAX_CHANGE_DENOMINATOR</code> capping
+          the rate of change and a protocol-defined floor below which it cannot fall.
+        </p>
+        <p>
+          The practical effect is fee stability: one <code>eth_gasPrice</code> call gives you the
+          definitive base fee for the rest of the epoch, with none of Ethereum&rsquo;s block-to-block
+          volatility.
+        </p>
+
+        <h4>Where the money goes</h4>
+        <p>
+          Transactions specify <code>maxFeePerGas</code> and <code>maxPriorityFeePerGas</code> exactly as
+          on Ethereum. <b>Priority fees go to batch producers</b> whose transactions land in the final
+          block. The <b>base fee does not leave the system</b> the way Ethereum&rsquo;s does — it is burned
+          with an equivalent amount minted to the governance safe, so in net terms 100% of base fees
+          accrue to governance reserves that fund future rewards.
+        </p>
+
+        <h4>The gas limit penalty</h4>
+        <p>
+          Because consensus orders transactions before they execute, actual gas usage is unknown at
+          submission — which opens the door to declaring an enormous gas limit on a cheap transaction
+          and wasting batch capacity. The penalty targets exactly that. It applies only when a
+          transaction consumes <b>less than 10% of its declared limit</b>, and never to transactions with
+          a gas limit of <b>210,000 or below</b>.
+        </p>
+        <pre className="proto-code">{`usage_ratio  = gas_used / gas_limit
+inefficiency = 0.10 - usage_ratio
+penalty_gas  = (inefficiency² / 0.10²) × unused_gas`}</pre>
+        <div className="proto-table-wrap">
+          <table className="proto-table">
+            <caption>Penalty applied to unused gas</caption>
+            <thead>
+              <tr><th scope="col">Gas limit actually used</th><th scope="col">Penalty on the unused portion</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>9.9%</td><td>Negligible</td></tr>
+              <tr><td>5%</td><td>~25%</td></tr>
+              <tr><td>2%</td><td>~62%</td></tr>
+              <tr><td>0.1%</td><td>&gt; 95%</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p>
+          The curve ramps gently near the threshold and steeply for extreme over-estimation. Penalties
+          are deducted from the refund rather than added to the bill, so they never increase the total
+          fee paid, and they go to the governance address.
+        </p>
+      </>
+    ),
+  },
+  {
+    id: 'proto-evm',
+    chip: 'EVM compatibility',
+    title: 'What is identical to Ethereum, and what is not',
+    content: (
+      <>
+        <p>
+          Compatibility is close to total: &ldquo;There are no custom opcodes, no modified gas costs, and no
+          disabled instructions.&rdquo; Contracts deploy as they would on Ethereum, and Hardhat, Foundry,
+          ethers.js and viem work unmodified.
+        </p>
+        <div className="proto-table-wrap">
+          <table className="proto-table">
+            <caption>Documented divergences</caption>
+            <thead>
+              <tr><th scope="col">Area</th><th scope="col">Difference</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>TEL precompile</td>
+                <td>Native ERC-20 interface at <code>0x7e1</code>; gas token and token share one balance</td>
+              </tr>
+              <tr>
+                <td>Base fee</td>
+                <td>Collected by the governance address for protocol use rather than destroyed</td>
+              </tr>
+              <tr>
+                <td>Transaction types</td>
+                <td>Legacy, EIP-2930 and EIP-1559 supported; blob transactions (EIP-4844) not yet implemented</td>
+              </tr>
+              <tr>
+                <td>Header fields</td>
+                <td>
+                  <code>nonce</code> encodes epoch and round, <code>difficulty</code> packs batch index
+                  and worker ID, <code>mix_hash</code> carries consensus digests
+                </td>
+              </tr>
+              <tr>
+                <td>Chain IDs</td>
+                <td>Mainnet <code>487</code>, testnet <code>2017</code></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p className="proto-note">
+          The header fields matter if you are writing indexers or explorers: those slots carry
+          consensus-layer metadata on Telcoin Network, not the proof-of-work values their names imply.
+        </p>
+      </>
+    ),
+  },
+  {
+    id: 'proto-security',
+    chip: 'Security',
+    title: 'The security model',
+    content: (
+      <>
+        <p>
+          The network &ldquo;remains secure so long as over 2/3 of the network&rsquo;s total stake is controlled
+          by honest and non adversarial validators&rdquo; — the standard Byzantine fault tolerant threshold,
+          here resting on a validator set of vetted mobile network operators.
+        </p>
+        <ul>
+          <li>Private signature keys are required to authorise any transaction, and only asset owners can move their own holdings.</li>
+          <li>Assets follow the rules written into their Solidity contracts by the contract creator.</li>
+          <li>Finalised transactions create a permanent record that later operations build on.</li>
+          <li>All network actions are publicly visible; users manage privacy by using multiple addresses.</li>
+          <li>Aborted transactions still consume gas but leave state unchanged, which is what makes spam expensive.</li>
+        </ul>
+        <p>
+          Smart contract deployment is permissionless, so the usual caution applies in full: interact
+          only with contracts you trust and understand.
+        </p>
+      </>
+    ),
+  },
+  {
+    id: 'proto-node',
+    chip: 'Running a node',
+    title: 'Validator hardware requirements',
+    content: (
+      <>
+        <p>
+          These are carrier-grade requirements, and a fair signal of what the network expects of the
+          operators securing it.
+        </p>
+        <div className="proto-table-wrap">
+          <table className="proto-table">
+            <caption>Published validator node specification</caption>
+            <thead>
+              <tr><th scope="col">Component</th><th scope="col">Minimum</th><th scope="col">Recommended</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>CPU</td>
+                <td>x86/x64, 16 cores / 32 threads, 4000+ PassMark single-thread</td>
+                <td>32 cores, higher clock prioritised</td>
+              </tr>
+              <tr>
+                <td>Memory</td>
+                <td>128 GB DDR4/DDR5 ECC registered DIMM</td>
+                <td>128 GB or more at maximum speed</td>
+              </tr>
+              <tr>
+                <td>Storage</td>
+                <td>4 TB TLC NVMe SSD</td>
+                <td>7.5 TB TLC NVMe SSD</td>
+              </tr>
+              <tr>
+                <td>Bandwidth</td>
+                <td>1000 Mb/s sustained, 1-Gigabit Ethernet</td>
+                <td>1000+ Mb/s sustained, 10-Gigabit interface</td>
+              </tr>
+              <tr>
+                <td>Operating system</td>
+                <td colSpan={2}>Linux LTS — Debian 11+, Ubuntu 20.04+, RHEL 8; kernel 3.10 or newer</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p className="proto-note">
+          Operators are asked to submit their specification to the Telcoin DevOps team for approval
+          before installation, so the list above is a starting point for a conversation rather than a
+          self-serve checklist.
+        </p>
+      </>
+    ),
+  },
+  {
+    id: 'proto-networks',
+    chip: 'Networks',
+    title: 'Networks and endpoints',
+    content: (
+      <>
+        <div className="proto-table-wrap">
+          <table className="proto-table">
+            <caption>Published network parameters</caption>
+            <thead>
+              <tr><th scope="col">Parameter</th><th scope="col">Adiri testnet</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>Chain ID</td><td><code>0x7e1</code> (2017)</td></tr>
+              <tr><td>Currency symbol</td><td>TEL</td></tr>
+              <tr><td>Public RPC</td><td><code>https://rpc.adiri.tel</code></td></tr>
+              <tr><td>Explorer</td><td><code>https://telscan.io</code></td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p>
+          Adiri is currently the only deployed network. The public RPC endpoint sits behind a load
+          balancer and is intended for single transactions and read queries; sustained development work
+          should connect to a node directly. The documentation warns the testnet may be reset before
+          mainnet to accommodate protocol changes, so treat any state there as disposable.
+        </p>
+        <p className="proto-note">
+          Chain ID <code>0x7e1</code> is 2017 in decimal — the year Telcoin was founded — and the same
+          value appears again as the address of the TEL precompile.
+        </p>
+      </>
+    ),
+  },
+  {
+    id: 'proto-sources',
+    chip: 'Documentation index',
+    title: 'The full documentation set',
+    content: (
+      <>
+        <p>
+          Everything above is drawn from Telcoin&rsquo;s own published documentation. The index below maps the
+          ecosystem&rsquo;s documentation surface so you can go to the primary source for anything that
+          matters — this wiki is a community summary and can lag behind or get things wrong.
+        </p>
+
+        <h4>Protocol documentation — docs.telcoin.network</h4>
+        <ul className="proto-links">
+          <li><b>Architecture</b> — overview, native token, security, transaction lifecycle, consensus layer</li>
+          <li><b>Getting started</b> — reading chain data (cURL, programmatic, libraries), dapp development, development tools, faucet, hardware requirements</li>
+          <li><b>Networks and RPC endpoints</b> — endpoint and chain parameters</li>
+          <li><b>RPC methods</b> — the full <code>eth_*</code> and <code>net_*</code> surface: accounts, chain info, contract and state reads, balances and gas, blocks, transactions, submission, logs</li>
+          <li><b>Filter methods</b> — <code>eth_newFilter</code>, <code>eth_newBlockFilter</code>, <code>eth_newPendingTransactionFilter</code>, <code>eth_getFilterChanges</code>, <code>eth_getFilterLogs</code>, <code>eth_uninstallFilter</code></li>
+          <li><b>Staking</b> — how staking works, why the membership model, how to stake, future direction</li>
+          <li><b>Reference</b> — constants, stablecoin contracts, Adiri testnet</li>
+          <li><b>Protocol topics</b> — basefees, gas limit penalty, EVM compatibility, epoch boundaries, canonical updates</li>
+          <li><b>FAQs</b> — economic incentives and rewards</li>
+        </ul>
+
+        <h4>Governance documentation — telcoin.org</h4>
+        <ul className="proto-links">
+          <li><b>Association</b> — the non-profit Swiss Verein that governs the platform, and Telcoin Autonomous Ops (TAO)</li>
+          <li><b>Participation</b> — how to take part, including the route for GSMA mobile networks</li>
+          <li><b>Platform</b> — Telcoin Network, the TEL token, the TELx DeFi exchange, and the Telcoin Application Network</li>
+          <li><b>Miners</b> — validators, liquidity miners, developers and stakers</li>
+          <li><b>Association governance</b> — governance organisations, Miner Councils, the Miner Assembly, and association rules including harvesting rules</li>
+        </ul>
+
+        <h4>Other primary surfaces</h4>
+        <ul className="proto-links">
+          <li><b>telcoin.network</b> — network overview and faucet</li>
+          <li><b>tnips.telcoin.network</b> — Telcoin Network Improvement Proposals</li>
+          <li><b>roadmap.telcoin.network</b> — published roadmap</li>
+          <li><b>forum.telcoin.org</b> — governance forum, proposals and council discussion</li>
+          <li><b>github.com/Telcoin-Association</b> — <code>telcoin-network</code> (protocol) and <code>tn-contracts</code> (smart contracts)</li>
+          <li><b>telscan.io</b> — block explorer</li>
+        </ul>
+
+        <p className="proto-note">
+          Reviewed 16 August 2026 against docs.telcoin.network and telcoin.org. Figures such as the
+          launch stake amount, chain IDs and hardware requirements are the values published at that
+          date and are exactly the kind of thing that changes — check the source before relying on any
+          of them.
+        </p>
+      </>
+    ),
+  },
+]

--- a/telcoinwiki-react/src/config/megaMenu.ts
+++ b/telcoinwiki-react/src/config/megaMenu.ts
@@ -53,6 +53,18 @@ export const megaMenuSections: MegaSection[] = [
     ],
   },
   {
+    id: 'protocol',
+    label: 'Protocol',
+    items: [
+      { label: 'Protocol reference', href: '/protocol', description: 'How the chain itself is built and run.' },
+      { label: 'Architecture', href: '/protocol#proto-architecture', description: 'The four modular layers.' },
+      { label: 'Transaction lifecycle', href: '/protocol#proto-lifecycle', description: 'Signature to finality in under half a second.' },
+      { label: 'Staking a validator', href: '/protocol#proto-staking', description: 'The membership model and the three transactions.' },
+      { label: 'Fees', href: '/protocol#proto-fees', description: 'Epoch-based base fees and the gas limit penalty.' },
+      { label: 'Documentation index', href: '/protocol#proto-sources', description: 'Every primary source, mapped.' },
+    ],
+  },
+  {
     id: 'evaluate',
     label: 'Evaluate',
     items: [

--- a/telcoinwiki-react/src/config/navigation.ts
+++ b/telcoinwiki-react/src/config/navigation.ts
@@ -5,5 +5,6 @@ export const NAV_ITEMS: NavItems = [
   { id: 'home', label: 'Home', href: '/' },
   { id: 'story', label: 'Story', href: '/#home-story-cards' },
   { id: 'deep-dive', label: 'Deep Dive', href: '/deep-dive' },
+  { id: 'protocol', label: 'Protocol', href: '/protocol' },
   { id: 'faq', label: 'FAQ', href: '/#faq-section' },
 ]

--- a/telcoinwiki-react/src/config/pageMeta.ts
+++ b/telcoinwiki-react/src/config/pageMeta.ts
@@ -3,5 +3,6 @@ import type { PageMetaMap } from './types'
 export const PAGE_META: PageMetaMap = {
   home: { label: 'Home', url: '/', parent: null, navId: 'home' },
   'deep-dive': { label: 'Deep Dive', url: '/deep-dive', parent: 'home', navId: 'deep-dive' },
+  protocol: { label: 'Protocol', url: '/protocol', parent: 'home', navId: 'protocol' },
   '404': { label: 'Page not found', url: '/404', parent: 'home', navId: null },
 }

--- a/telcoinwiki-react/src/pages/ProtocolPage.tsx
+++ b/telcoinwiki-react/src/pages/ProtocolPage.tsx
@@ -1,0 +1,153 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useLocation } from 'react-router-dom'
+import { PROTOCOL_SECTIONS } from '../components/protocol/sections'
+import type { ProtocolSection } from '../components/protocol/sections'
+
+interface PanelProps {
+  section: ProtocolSection
+  open: boolean
+  onToggle: () => void
+}
+
+function Panel({ section, open, onToggle }: PanelProps) {
+  const bodyRef = useRef<HTMLDivElement | null>(null)
+  const [height, setHeight] = useState(0)
+
+  useEffect(() => {
+    if (!bodyRef.current) return
+    setHeight(open ? bodyRef.current.scrollHeight : 0)
+  }, [open, section.content])
+
+  // Tables and long lists can reflow after fonts settle; keep the panel sized to
+  // its content while it is open rather than trusting one measurement.
+  useEffect(() => {
+    if (!open || !bodyRef.current || typeof ResizeObserver === 'undefined') return
+    const el = bodyRef.current
+    const ro = new ResizeObserver(() => setHeight(el.scrollHeight))
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [open])
+
+  return (
+    <section id={section.id} className="deep-dive-section anchor-offset">
+      <h2 className="deep-dive-section-header">
+        <button
+          type="button"
+          aria-expanded={open}
+          aria-controls={`${section.id}-panel`}
+          onClick={onToggle}
+          className="deep-dive-section-button"
+        >
+          <span>{section.title}</span>
+          <svg
+            className={`deep-dive-section-icon ${open ? 'open' : ''}`}
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            aria-hidden
+          >
+            <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </button>
+      </h2>
+      <div
+        id={`${section.id}-panel`}
+        role="region"
+        aria-labelledby={section.id}
+        className="deep-dive-content-wrapper"
+        style={{ overflow: 'hidden', maxHeight: open ? height : 0, transition: 'max-height 300ms ease' }}
+        ref={bodyRef}
+      >
+        <div className="deep-dive-content proto-content">{section.content}</div>
+      </div>
+    </section>
+  )
+}
+
+const IDS = PROTOCOL_SECTIONS.map((s) => s.id)
+
+export function ProtocolPage() {
+  const location = useLocation()
+  const [open, setOpen] = useState<Set<string>>(() => new Set([PROTOCOL_SECTIONS[0].id]))
+
+  const toggle = useCallback((id: string) => {
+    setOpen((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
+
+  /**
+   * Deep links land on a collapsed accordion otherwise: opening the targeted
+   * section (and scrolling to it) is what makes an anchor into this page useful
+   * from search results and from the rest of the wiki.
+   */
+  useEffect(() => {
+    const id = location.hash.replace(/^#/, '')
+    if (!id || !IDS.includes(id)) return
+    setOpen((prev) => (prev.has(id) ? prev : new Set(prev).add(id)))
+    const node = document.getElementById(id)
+    if (!node) return
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    window.requestAnimationFrame(() => {
+      node.scrollIntoView({ behavior: reduced ? 'auto' : 'smooth', block: 'start' })
+    })
+  }, [location.hash])
+
+  const expandAll = () => setOpen(new Set(IDS))
+  const collapseAll = () => setOpen(new Set())
+  const allOpen = open.size === IDS.length
+
+  return (
+    <>
+      <section id="protocol-hero" aria-labelledby="protocol-hero-heading" className="anchor-offset">
+        <div className="mx-auto w-full max-w-[min(1600px,95vw)] px-4 sm:px-8 lg:px-12 xl:px-16 pt-[calc(var(--header-height)+4rem)] pb-8 sm:pb-10 lg:pb-12">
+          <div className="tc-card-glass p-10 sm:p-12 lg:p-16 text-center">
+            <div className="flex flex-col items-center gap-4 mb-6 sm:mb-8 pt-4 sm:pt-6 lg:pt-8">
+              <p className="proto-eyebrow">Protocol reference</p>
+              <h1
+                id="protocol-hero-heading"
+                className="font-semibold text-telcoin-ink text-4xl sm:text-5xl lg:text-6xl"
+              >
+                Telcoin Network
+              </h1>
+              <p className="w-full max-w-4xl text-telcoin-ink-muted mt-2 mx-auto text-center text-base sm:text-lg">
+                A working reference for the chain itself — how it is built, how consensus reaches
+                finality, what it costs, and what it takes to run a validator. Compiled from Telcoin&rsquo;s
+                own published documentation, with an index of every source at the end.
+              </p>
+            </div>
+
+            <nav className="toc-chips flex flex-wrap justify-center gap-2" aria-label="Protocol reference sections">
+              {PROTOCOL_SECTIONS.map((s) => (
+                <a className="toc-chip" key={s.id} href={`#${s.id}`}>
+                  {s.chip}
+                </a>
+              ))}
+            </nav>
+          </div>
+        </div>
+      </section>
+
+      <div className="mx-auto w-full max-w-[min(1600px,95vw)] px-4 sm:px-8 lg:px-12 xl:px-16 flex justify-end">
+        <button type="button" className="proto-toggle-all" onClick={allOpen ? collapseAll : expandAll}>
+          {allOpen ? 'Collapse all' : 'Expand all'}
+        </button>
+      </div>
+
+      <div className="deep-dive-grid">
+        {PROTOCOL_SECTIONS.map((section) => (
+          <Panel
+            key={section.id}
+            section={section}
+            open={open.has(section.id)}
+            onToggle={() => toggle(section.id)}
+          />
+        ))}
+      </div>
+    </>
+  )
+}

--- a/telcoinwiki-react/src/styles/site.css
+++ b/telcoinwiki-react/src/styles/site.css
@@ -2715,6 +2715,170 @@ html.intro-lock-sections .site-main > :not(#home-hero) {
   overflow-wrap: anywhere;
 }
 
+/* ============================================================
+   Protocol reference page
+   Built on the existing deep-dive chrome; only the elements that
+   page does not already have are defined here, all from tokens.
+   ============================================================ */
+.proto-eyebrow {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--tc-accent);
+  margin: 0;
+}
+
+.proto-toggle-all {
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--tc-ink-muted);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--tc-border);
+  border-radius: 999px;
+  padding: 0.4rem 0.95rem;
+  margin-bottom: var(--space-4);
+  cursor: pointer;
+  transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+.proto-toggle-all:hover,
+.proto-toggle-all:focus-visible {
+  color: var(--tc-ink);
+  border-color: var(--tc-border-strong);
+  background: rgba(255, 255, 255, 0.07);
+}
+
+/* Headline figures */
+.proto-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: var(--space-3);
+  margin: var(--space-6) 0 var(--space-2);
+}
+.proto-stat {
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius);
+  background: rgba(255, 255, 255, 0.03);
+  padding: var(--space-4);
+}
+.proto-stat b {
+  display: block;
+  font-size: clamp(1.15rem, 2.2vw, 1.5rem);
+  font-weight: 700;
+  color: var(--tc-ink);
+  line-height: 1.15;
+  font-variant-numeric: tabular-nums;
+}
+.proto-stat i {
+  display: block;
+  margin-top: 0.3rem;
+  font-style: normal;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.66rem;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  color: var(--tc-ink-subtle);
+}
+
+.proto-content h4 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--tc-ink);
+  margin: var(--space-6) 0 var(--space-3);
+}
+.proto-content h4:first-child { margin-top: 0; }
+
+.proto-content ul:not(.proto-links) { list-style: disc outside; padding-left: 1.25rem; }
+.proto-content ul:not(.proto-links) li::marker { color: var(--tc-accent); }
+
+/* Definition list for the layer breakdown */
+.proto-deflist { margin: 0 0 var(--space-6); display: grid; gap: var(--space-4); }
+.proto-deflist dt { color: var(--tc-ink); font-weight: 600; }
+.proto-deflist dd {
+  margin: 0.3rem 0 0;
+  padding-left: var(--space-4);
+  border-left: 2px solid var(--tc-border);
+  color: var(--tc-ink-muted);
+}
+
+/* Ordered process steps */
+.proto-steps {
+  margin: 0 0 var(--space-6);
+  padding-left: 1.45rem;
+  display: grid;
+  gap: var(--space-3);
+  /* Tailwind preflight and critical.css both strip markers; restore them. */
+  list-style: decimal outside;
+}
+.proto-steps li::marker { color: var(--tc-accent); font-variant-numeric: tabular-nums; }
+.proto-steps li { color: var(--tc-ink-muted); line-height: 1.75; }
+.proto-steps li b { color: var(--tc-ink); font-weight: 600; }
+
+/* Formulae / snippets */
+.proto-code {
+  margin: 0 0 var(--space-6);
+  padding: var(--space-4);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius);
+  background: rgba(0, 0, 0, 0.22);
+  color: var(--tc-ink);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.82rem;
+  line-height: 1.65;
+  overflow-x: auto;
+  white-space: pre;
+}
+
+/* Specification tables */
+.proto-table-wrap { margin: 0 0 var(--space-6); overflow-x: auto; border-radius: var(--tc-radius); border: 1px solid var(--tc-border); }
+.proto-table { width: 100%; border-collapse: collapse; font-size: 0.86rem; min-width: 420px; }
+.proto-table caption {
+  caption-side: top;
+  text-align: left;
+  padding: var(--space-3) var(--space-4) 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.66rem;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  color: var(--tc-ink-subtle);
+}
+.proto-table th,
+.proto-table td { text-align: left; padding: 0.62rem var(--space-4); vertical-align: top; }
+.proto-table thead th {
+  color: var(--tc-ink);
+  font-weight: 600;
+  font-size: 0.78rem;
+  letter-spacing: 0.02em;
+  border-bottom: 1px solid var(--tc-border-strong);
+}
+.proto-table tbody tr + tr td { border-top: 1px solid var(--tc-border); }
+.proto-table td { color: var(--tc-ink-muted); }
+.proto-table td:first-child { color: var(--tc-ink); }
+
+.proto-links {
+  margin: 0 0 var(--space-6);
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.45rem;
+  list-style: disc outside;
+}
+.proto-links li::marker { color: var(--tc-accent); }
+.proto-links li { color: var(--tc-ink-muted); line-height: 1.7; }
+.proto-links li b { color: var(--tc-ink); font-weight: 600; }
+
+/* Sourcing / caveat callout */
+.proto-note {
+  margin: 0 0 var(--space-6);
+  padding: var(--space-4);
+  border: 1px dashed var(--tc-border-strong);
+  border-radius: var(--tc-radius);
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--tc-ink-subtle);
+  font-size: 0.87rem;
+}
+.proto-note:last-child { margin-bottom: 0; }
+
 /* FAQ answers use the same inline-code convention as the Deep Dive. */
 .tc-card-glass code {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;

--- a/telcoinwiki-react/tools/build-search-index.mjs
+++ b/telcoinwiki-react/tools/build-search-index.mjs
@@ -66,6 +66,7 @@ async function loadContentModules() {
       contents: `
         export { faqItems, faqGroups } from ${JSON.stringify(join(projectRoot, 'src/components/faq/data.tsx'))}
         export { SECTIONS } from ${JSON.stringify(join(projectRoot, 'src/components/deepDive/sections.tsx'))}
+        export { PROTOCOL_SECTIONS } from ${JSON.stringify(join(projectRoot, 'src/components/protocol/sections.tsx'))}
       `,
       resolveDir: projectRoot,
       loader: 'ts',
@@ -101,12 +102,12 @@ function buildFaqDocs(faqItems, faqGroups) {
   })
 }
 
-function buildSectionDocs(sections) {
+function buildSectionDocs(sections, route) {
   return sections.map((section) => ({
     id: section.id,
     title: section.title,
     body: toText(section.content),
-    url: `/deep-dive#${section.id}`,
+    url: `${route}#${section.id}`,
   }))
 }
 
@@ -130,6 +131,15 @@ const PAGE_DOCS = [
     ],
   },
   {
+    id: 'protocol',
+    title: 'Protocol reference — Telcoin Network',
+    summary:
+      'Working reference for Telcoin Network: modular architecture, Narwhal/Bullshark consensus, transaction lifecycle and finality, the TEL native token and 0x7e1 precompile, epochs and committee selection, validator staking, fees and the gas limit penalty, EVM compatibility, hardware requirements, and an index of every primary documentation source.',
+    url: '/protocol',
+    tags: ['Protocol', 'Reference', 'Developers'],
+    headings: [],
+  },
+  {
     id: 'deep-dive',
     title: 'Deep Dive — Telcoin architecture, economics and risks',
     summary:
@@ -144,18 +154,21 @@ async function main() {
   const { modules, cleanup } = await loadContentModules()
 
   try {
-    const { faqItems, faqGroups, SECTIONS } = modules
+    const { faqItems, faqGroups, SECTIONS, PROTOCOL_SECTIONS } = modules
 
-    if (!Array.isArray(faqItems) || !Array.isArray(SECTIONS)) {
+    if (!Array.isArray(faqItems) || !Array.isArray(SECTIONS) || !Array.isArray(PROTOCOL_SECTIONS)) {
       throw new Error('content modules did not export the expected arrays')
     }
 
     const faqDocs = buildFaqDocs(faqItems, faqGroups)
-    const sectionDocs = buildSectionDocs(SECTIONS)
+    const deepDocs = buildSectionDocs(SECTIONS, '/deep-dive')
+    const protoDocs = buildSectionDocs(PROTOCOL_SECTIONS, '/protocol')
+    const sectionDocs = [...deepDocs, ...protoDocs]
 
+    const headingsFor = { 'deep-dive': deepDocs, protocol: protoDocs }
     const pageDocs = PAGE_DOCS.map((page) =>
-      page.id === 'deep-dive'
-        ? { ...page, headings: sectionDocs.map((s) => ({ id: s.id, title: s.title })) }
+      headingsFor[page.id]
+        ? { ...page, headings: headingsFor[page.id].map((s) => ({ id: s.id, title: s.title })) }
         : page,
     )
 
@@ -176,7 +189,7 @@ async function main() {
         title: section.title,
         summary: section.body.slice(0, 240),
         url: section.url,
-        tags: ['Deep Dive'],
+        tags: [section.url.startsWith('/protocol') ? 'Protocol' : 'Deep Dive'],
         headings: [],
         body: section.body,
       })),
@@ -188,7 +201,7 @@ async function main() {
 
     const bytes = (o) => (JSON.stringify(o).length / 1024).toFixed(1)
     console.log(
-      `[search-index] ${searchIndex.length} docs (${pageDocs.length} pages, ${sectionDocs.length} sections, ${bytes(searchIndex)} kB) + ${faqDocs.length} FAQ entries (${bytes(faqDocs)} kB)`,
+      `[search-index] ${searchIndex.length} docs (${pageDocs.length} pages, ${deepDocs.length} deep-dive + ${protoDocs.length} protocol sections, ${bytes(searchIndex)} kB) + ${faqDocs.length} FAQ entries (${bytes(faqDocs)} kB)`,
     )
   } finally {
     await cleanup()


### PR DESCRIPTION
## Summary

New `/protocol` route: a working reference for Telcoin Network itself, compiled from Telcoin's **own published documentation** (`docs.telcoin.network` and `telcoin.org/documentation`) rather than written from model knowledge.

**13 sections** — overview, the four-layer modular architecture, transaction lifecycle, Narwhal/Bullshark consensus, the native token and `0x7e1` TEL precompile, epochs and committee selection, the validator membership model and staking, fees and the gas limit penalty, EVM compatibility, security model, node hardware requirements, networks and endpoints, and an index of every primary documentation source.

Facts newly on the wiki include mainnet chain ID `487` / testnet `2017`, sub-half-second finality, the 30M per-block gas limit, the 1M TEL launch stake, the header-weighted reward formula, the six validator lifecycle states, epoch-boundary base fee adjustment (base fees accrue to governance rather than being destroyed), the quadratic gas limit penalty below 10% utilisation, Axelar/wTEL bridging, and Fisher–Yates committee shuffling seeded from an aggregated BLS signature.

Contract addresses are deliberately **not** reproduced — the page says so and points at the primary source, because address substitution is a real attack and a community wiki is exactly where someone would try to plant a wrong one.

## Design

Built with the site's existing system rather than a new one: `tc-card-glass` hero, `toc-chip` navigation, the established deep-dive section chrome, and the `telcoin-*` tokens throughout. New elements (stat grid, spec tables, formula blocks, definition lists, source callouts) are all derived from those tokens. List markers are restored on the new lists, which Tailwind preflight and `critical.css` both strip.

## Integration

- Lazy-loaded route — 10.2 kB gzipped, off the main bundle
- Added to header nav (desktop + mobile), `NAV_ITEMS`, `PAGE_META`, and the mega menu
- Indexed by `tools/build-search-index.mjs`, which now renders both the deep-dive and protocol content trees; index grew from 17 → 31 documents
- Deep links open and scroll to the targeted section — the existing Deep Dive drops you on a collapsed accordion, which made anchors from search results much less useful

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npx jest` — 24 tests across 4 suites, including a new `protocol/__tests__/sections.test.ts` guarding unique ids, the `proto-` namespace, chip length, every `/protocol#` reference resolving, mega-menu targets, and the route/nav/header links existing
- [x] `npm run lint` — unchanged at the pre-existing 10 problems, none new
- [x] `npm run build` clean
- [x] Browser pass: rendering, deep linking into collapsed sections, expand/collapse all, header navigation, no 404s, no console errors, no overflow at 390px
- [x] Search ranking verified — "gas limit penalty", "validator hardware", "precompile", "Axelar", "ConsensusNFT", "epoch boundary" each resolve to the correct section


---
_Generated by [Claude Code](https://claude.ai/code/session_01UucW9gAXvDRmDDD8SQpyzC)_