### PR TITLE
Adapt the Network Atlas 3D model into the site as /atlas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,85 @@
 # Changelog
 
+## 2026-08-16 (4) – Network Atlas: the 3D model, adapted into the site
+
+Ported the standalone WebGL "Telcoin Network Atlas" artifact into a real
+`/atlas` route, rebuilt for the site rather than dropped in as-is.
+
+### What changed from the artifact
+
+- **Rewritten as typed, per-instance TypeScript**, not a page-scoped IIFE:
+  `lib/atlas/mat4.ts` (matrix math), `lib/atlas/data.ts` (ecosystem/consensus
+  data), `lib/atlas/engine.ts` (the WebGL engine), `components/atlas/NetworkAtlas.tsx`
+  (the React shell). All simulation/camera/picking state lives inside the
+  engine's closure — nothing at module scope — so multiple mounts can never
+  share state.
+- **Full lifecycle correctness for an SPA.** The artifact was a single static
+  page that never unmounted; this route can mount and unmount many times per
+  session. `destroy()` now cancels the rAF handle, aborts every listener via
+  a single `AbortController`, disconnects both observers, deletes GL buffers
+  and programs, and calls `WEBGL_lose_context` — proactively releasing the
+  context rather than waiting on GC, since browsers cap live WebGL contexts
+  per page. Verified with 3x real SPA navigate-away-and-back: renders
+  correctly every time, zero console errors.
+- **Own visual identity, not a foreign console.** The HUD is restyled from
+  the site's own `--tc-*` tokens (border, ink, accent) instead of a bespoke
+  cyan/gold palette. Added one new semantic-only pair, `--tc-gold` /
+  `--tc-gold-soft`, explicitly for "regulated money" vs. "network machine" —
+  not a brand color. The artifact's own top brand bar was dropped entirely;
+  the site's real header does that job.
+- **Two new capabilities the standalone page didn't need:**
+  - Pauses the render loop when the tab is hidden or the stage scrolls out
+    of view (`IntersectionObserver` + `visibilitychange`) — real savings now
+    that this lives inside a normal scrollable page instead of being the
+    entire viewport.
+  - `/atlas?scene=eco&node=<id>` deep links pre-select a scene and entity on
+    mount. The search index now emits one of these per ecosystem entity
+    (8 new docs), so searching "Digital Asset Bank" lands pre-focused on
+    that exact node in the 3D graph, not just on the page.
+- **Grounded in the rest of the wiki, not an island.** Every ecosystem
+  entity's inspector panel carries a "Learn more" link into the matching
+  Deep Dive or Protocol section (TEL → `/protocol#proto-token`, TELx →
+  `/deep-dive#deep-incentives`, etc.), and the DAG inspector links to
+  `/protocol#proto-consensus` / `#proto-lifecycle`. These are plain `<a>`
+  tags (so right-click / open-in-new-tab still work) with a delegated
+  click handler that hands plain left-clicks to the router instead of a
+  full page reload. Added matching callouts on the Protocol and Deep Dive
+  hero cards linking back to `/atlas`.
+- **Lazy-loaded route** (12.4 kB gzipped) — the shaders and engine stay off
+  every other page's bundle.
+
+### Tests (24 new, 77 total across 11 suites)
+
+- `mat4.test.ts` — multiply-by-identity, `lookAt` orthonormality and eye
+  placement, `perspective`/`projectPoint` clip-space behavior.
+- `data.test.ts` — every ecosystem entity's `href` resolves to a real
+  Deep Dive or Protocol section id (regression guard, same shape as the
+  existing anchor tests); no orphan nodes; quorum is a genuine 2f+1
+  majority; `isEcosystemId` accepts every real id and rejects garbage.
+- `wiring.test.ts` — route/nav/header/mega-menu/page-meta all wired; every
+  `/atlas?scene=eco&node=` reference anywhere in source names a real entity.
+- `NetworkAtlas.test.tsx` — the no-WebGL fallback path (stubbed
+  deterministically, since jsdom's `getContext('webgl2')` behavior isn't
+  consistent across versions) renders without throwing; mount → unmount →
+  mount survives; garbage query params don't crash.
+- `jest.config.ts` `testMatch` extended to include `src/lib/**/__tests__/**`
+  — the existing glob only covered `components/` and `hooks/`, so these
+  wouldn't have run at all otherwise.
+
+### Verified
+
+tsc clean; 77/77 tests; lint unchanged at the pre-existing 10 problems;
+clean production build. Real-browser pass (48 checks): WebGL renders and
+draws real pixels, DAG simulation advances and commits, play/pause/resume,
+certificate and ecosystem-entity picking, cross-reference jump chips,
+SPA-navigating "Learn more" links (confirmed no full reload), header/mega-menu/
+callout navigation, 3x remount survival, valid and invalid deep-link query
+params, viewport-intersection pause verified with a genuine occlusion
+(not a too-short test viewport, which produced one false failure caught
+and root-caused before landing), 390px/768px with no overflow, and search
+surfacing the new per-entity `/atlas` docs alongside the existing Deep
+Dive ones.
+
 ## 2026-08-16 (3) – Protocol reference page
 
 New `/protocol` route: a working reference for Telcoin Network itself, researched

--- a/telcoinwiki-react/jest.config.ts
+++ b/telcoinwiki-react/jest.config.ts
@@ -24,6 +24,7 @@ const config: Config = {
   testMatch: [
     '**/src/components/**/__tests__/**/*.test.ts?(x)',
     '**/src/hooks/**/__tests__/**/*.test.ts?(x)',
+    '**/src/lib/**/__tests__/**/*.test.ts?(x)',
   ],
 }
 

--- a/telcoinwiki-react/public/data/search-index.json
+++ b/telcoinwiki-react/public/data/search-index.json
@@ -167,6 +167,53 @@
     "body": ""
   },
   {
+    "id": "atlas",
+    "kind": "page",
+    "title": "Network Atlas — an interactive 3D model of Telcoin",
+    "summary": "A live, orbitable WebGL model: the Narwhal/Bullshark consensus DAG simulated round by round, and an ecosystem graph connecting TEL, Telcoin Network, GSMA validators, TELx, the wallet, Digital Cash and the Digital Asset Bank.",
+    "url": "/atlas",
+    "tags": [
+      "Atlas",
+      "Interactive",
+      "3D"
+    ],
+    "headings": [
+      {
+        "id": "atlas-tel",
+        "title": "TEL"
+      },
+      {
+        "id": "atlas-network",
+        "title": "Telcoin Network"
+      },
+      {
+        "id": "atlas-validators",
+        "title": "GSMA Validators"
+      },
+      {
+        "id": "atlas-telx",
+        "title": "TELx"
+      },
+      {
+        "id": "atlas-wallet",
+        "title": "TAN · Wallet"
+      },
+      {
+        "id": "atlas-digitalcash",
+        "title": "Digital Cash"
+      },
+      {
+        "id": "atlas-bank",
+        "title": "Digital Asset Bank"
+      },
+      {
+        "id": "atlas-association",
+        "title": "Telcoin Association"
+      }
+    ],
+    "body": ""
+  },
+  {
     "id": "deep-about",
     "kind": "section",
     "title": "About Telcoin — Deep Dive",
@@ -501,5 +548,101 @@
     ],
     "headings": [],
     "body": "Everything above is drawn from Telcoin’s own published documentation. The index below maps the ecosystem’s documentation surface so you can go to the primary source for anything that matters — this wiki is a community summary and can lag behind or get things wrong. Protocol documentation — docs.telcoin.network Architecture — overview, native token, security, transaction lifecycle, consensus layer Getting started — reading chain data (cURL, programmatic, libraries), dapp development, development tools, faucet, hardware requirements Networks and RPC endpoints — endpoint and chain parameters RPC methods — the full eth_* and net_* surface: accounts, chain info, contract and state reads, balances and gas, blocks, transactions, submission, logs Filter methods — eth_newFilter , eth_newBlockFilter , eth_newPendingTransactionFilter , eth_getFilterChanges , eth_getFilterLogs , eth_uninstallFilter Staking — how staking works, why the membership model, how to stake, future direction Reference — constants, stablecoin contracts, Adiri testnet Protocol topics — basefees, gas limit penalty, EVM compatibility, epoch boundaries, canonical updates FAQs — economic incentives and rewards Governance documentation — telcoin.org Association — the non-profit Swiss Verein that governs the platform, and Telcoin Autonomous Ops (TAO) Participation — how to take part, including the route for GSMA mobile networks Platform — Telcoin Network, the TEL token, the TELx DeFi exchange, and the Telcoin Application Network Miners — validators, liquidity miners, developers and stakers Association governance — governance organisations, Miner Councils, the Miner Assembly, and association rules including harvesting rules Other primary surfaces telcoin.network — network overview and faucet tnips.telcoin.network — Telcoin Network Improvement Proposals roadmap.telcoin.network — published roadmap forum.telcoin.org — governance forum, proposals and council discussion github.com/Telcoin-Association — telcoin-network (protocol) and tn-contracts (smart contracts) telscan.io — block explorer Reviewed 16 August 2026 against docs.telcoin.network and telcoin.org. Figures such as the launch stake amount, chain IDs and hardware requirements are the values published at that date and are exactly the kind of thing that changes — check the source before relying on any of them."
+  },
+  {
+    "id": "atlas-tel",
+    "kind": "section",
+    "title": "TEL",
+    "summary": "The native token — The fuel and coordination asset of the whole platform. Fixed supply of 100 billion with just 2 decimal places — unusual for an ERC-20, and a reliable source of bugs when reading raw balances. — 100,000,000,000 fixed suppl",
+    "url": "/atlas?scene=eco&node=tel",
+    "tags": [
+      "Atlas"
+    ],
+    "headings": [],
+    "body": "The native token — The fuel and coordination asset of the whole platform. Fixed supply of 100 billion with just 2 decimal places — unusual for an ERC-20, and a reliable source of bugs when reading raw balances. — 100,000,000,000 fixed supply · 2 decimals — Gas on Telcoin Network — Staked by validators to secure consensus — LP rewards on TELx + governance weight"
+  },
+  {
+    "id": "atlas-network",
+    "kind": "section",
+    "title": "Telcoin Network",
+    "summary": "Settlement · Layer 1 — The EVM-compatible Layer 1 where value settles. A DAG consensus layer orders transactions and a Reth-based EVM executes them, giving instant deterministic finality suited to payments. — EVM-compatible — Solidity, Reth",
+    "url": "/atlas?scene=eco&node=network",
+    "tags": [
+      "Atlas"
+    ],
+    "headings": [],
+    "body": "Settlement · Layer 1 — The EVM-compatible Layer 1 where value settles. A DAG consensus layer orders transactions and a Reth-based EVM executes them, giving instant deterministic finality suited to payments. — EVM-compatible — Solidity, Reth execution — Narwhal/Bullshark DAG consensus — Validated by GSMA member mobile operators — Every transaction burns TEL as gas"
+  },
+  {
+    "id": "atlas-validators",
+    "kind": "section",
+    "title": "GSMA Validators",
+    "summary": "Security · block production — The block producers, and the decision that most sets Telcoin apart. Validator slots are permissioned to GSMA full-member mobile network operators, approved by the Compliance Council, who stake TEL and run the n",
+    "url": "/atlas?scene=eco&node=validators",
+    "tags": [
+      "Atlas"
+    ],
+    "headings": [],
+    "body": "Security · block production — The block producers, and the decision that most sets Telcoin apart. Validator slots are permissioned to GSMA full-member mobile network operators, approved by the Compliance Council, who stake TEL and run the nodes. — Permissioned to GSMA mobile operators — Stake 1,000,000 TEL for proof-of-stake consensus — Each runs Primary + Worker nodes — Earn TEL gas fees and issuance"
+  },
+  {
+    "id": "atlas-telx",
+    "kind": "section",
+    "title": "TELx",
+    "summary": "Liquidity layer — The liquidity engine. TELx layers TEL incentives over established AMMs so there is depth for TEL and Digital Cash — which is what keeps in-wallet swap rates tight. — Liquidity mining paid in TEL — Built on Uniswap + Balanc",
+    "url": "/atlas?scene=eco&node=telx",
+    "tags": [
+      "Atlas"
+    ],
+    "headings": [],
+    "body": "Liquidity layer — The liquidity engine. TELx layers TEL incentives over established AMMs so there is depth for TEL and Digital Cash — which is what keeps in-wallet swap rates tight. — Liquidity mining paid in TEL — Built on Uniswap + Balancer — Mainly Polygon, also Base — Migrating to Uniswap v4 (Telcoin Hook)"
+  },
+  {
+    "id": "atlas-wallet",
+    "kind": "section",
+    "title": "TAN · Wallet",
+    "summary": "Application layer — TAN — the Telcoin Application Network — is the third layer of the stack: self-custodial mobile apps built by GSMA telecom members. The Telcoin Wallet is a TAN app, and where the system becomes a product. — App layer atop",
+    "url": "/atlas?scene=eco&node=wallet",
+    "tags": [
+      "Atlas"
+    ],
+    "headings": [],
+    "body": "Application layer — TAN — the Telcoin Application Network — is the third layer of the stack: self-custodial mobile apps built by GSMA telecom members. The Telcoin Wallet is a TAN app, and where the system becomes a product. — App layer atop Network + TELx — Assisted self-custody: 2-of-3 keys — No seed phrase — access tied to your number — Holds Digital Cash + crypto, swaps, staking"
+  },
+  {
+    "id": "atlas-digitalcash",
+    "kind": "section",
+    "title": "Digital Cash",
+    "summary": "Regulated money — Fiat-backed digital currencies — eUSD, eGBP, eJPY and more — issued and redeemed by the Telcoin Digital Asset Bank and settled on Telcoin Network. Multi-currency by design, because a remittance is a currency pair. — Bank-i",
+    "url": "/atlas?scene=eco&node=digitalcash",
+    "tags": [
+      "Atlas"
+    ],
+    "headings": [],
+    "body": "Regulated money — Fiat-backed digital currencies — eUSD, eGBP, eJPY and more — issued and redeemed by the Telcoin Digital Asset Bank and settled on Telcoin Network. Multi-currency by design, because a remittance is a currency pair. — Bank-issued and fiat-backed (e.g. eUSD) — ~12 live on Polygon; more announced — Redeemable from 100% reserves — Named with an e- prefix (mostly ISO codes)"
+  },
+  {
+    "id": "atlas-bank",
+    "kind": "section",
+    "title": "Digital Asset Bank",
+    "summary": "The issuer — A distinct regulated entity holding Nebraska’s first Digital Asset Depository Institution charter, finalized 12 November 2025 — the first digital asset bank charter in the United States. — First US digital asset bank charter (N",
+    "url": "/atlas?scene=eco&node=bank",
+    "tags": [
+      "Atlas"
+    ],
+    "headings": [],
+    "body": "The issuer — A distinct regulated entity holding Nebraska’s first Digital Asset Depository Institution charter, finalized 12 November 2025 — the first digital asset bank charter in the United States. — First US digital asset bank charter (Nov 2025) — ≥100% USD-denominated reserves — No FDIC insurance (by statute) — Runs KYC/AML; mints and burns Digital Cash"
+  },
+  {
+    "id": "atlas-association",
+    "kind": "section",
+    "title": "Telcoin Association",
+    "summary": "Governance — A Swiss non-profit Verein domiciled in Lugano that stewards the protocol. Governance is polycentric: elected Miner Councils handle each domain, and the Miner Assembly holds constitutional authority. — Swiss Verein, domiciled in",
+    "url": "/atlas?scene=eco&node=association",
+    "tags": [
+      "Atlas"
+    ],
+    "headings": [],
+    "body": "Governance — A Swiss non-profit Verein domiciled in Lugano that stewards the protocol. Governance is polycentric: elected Miner Councils handle each domain, and the Miner Assembly holds constitutional authority. — Swiss Verein, domiciled in Lugano — Elected Miner Councils per domain — Miner Assembly = constitutional authority — Sets validator policy and TELx emissions"
   }
 ]

--- a/telcoinwiki-react/src/App.tsx
+++ b/telcoinwiki-react/src/App.tsx
@@ -14,6 +14,9 @@ import { NotFoundPage } from './pages/NotFoundPage'
 const ProtocolPage = lazy(() =>
   import('./pages/ProtocolPage').then((m) => ({ default: m.ProtocolPage })),
 )
+// The WebGL engine and its shaders are meaningful weight for a page most
+// visitors won't land on directly; keep it out of the main and Protocol chunks.
+const AtlasPage = lazy(() => import('./pages/AtlasPage').then((m) => ({ default: m.AtlasPage })))
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -66,6 +69,21 @@ function App() {
             >
               <Suspense fallback={<div className="min-h-screen" />}>
                 <ProtocolPage />
+              </Suspense>
+            </CinematicLayout>
+          }
+        />
+        <Route
+          path="/atlas"
+          element={
+            <CinematicLayout
+              pageId="atlas"
+              navItems={NAV_ITEMS}
+              pageMeta={PAGE_META}
+              searchConfig={SEARCH_CONFIG}
+            >
+              <Suspense fallback={<div className="min-h-screen" />}>
+                <AtlasPage />
               </Suspense>
             </CinematicLayout>
           }

--- a/telcoinwiki-react/src/components/atlas/NetworkAtlas.tsx
+++ b/telcoinwiki-react/src/components/atlas/NetworkAtlas.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useRef } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { createAtlasEngine } from '../../lib/atlas/engine'
+import type { AtlasScene } from '../../lib/atlas/engine'
+
+/**
+ * The interactive Network Atlas stage: a WebGL scene (live Narwhal/Bullshark
+ * DAG simulation, and an orbitable ecosystem graph) with a HUD overlay.
+ *
+ * All render-loop state lives inside the imperative engine, not React state
+ * — this runs a persistent 60fps loop and hand-writes its HUD panels via
+ * direct DOM updates, the same way the rest of the app's expandable panels
+ * animate outside React's render cycle. This component's job is just to
+ * own the DOM shell, mount the engine once, and guarantee it is fully torn
+ * down on unmount so navigating away and back doesn't leak a WebGL context.
+ */
+export function NetworkAtlas() {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+
+  const stageRef = useRef<HTMLDivElement | null>(null)
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const labelLayerRef = useRef<HTMLDivElement | null>(null)
+  const inspectRef = useRef<HTMLDivElement | null>(null)
+  const statsTitleRef = useRef<HTMLDivElement | null>(null)
+  const statsRef = useRef<HTMLDivElement | null>(null)
+  const legendRef = useRef<HTMLDivElement | null>(null)
+  const sceneTabListRef = useRef<HTMLDivElement | null>(null)
+  const sceneDagRef = useRef<HTMLButtonElement | null>(null)
+  const sceneEcoRef = useRef<HTMLButtonElement | null>(null)
+  const playRef = useRef<HTMLButtonElement | null>(null)
+  const resetRef = useRef<HTMLButtonElement | null>(null)
+  const hintRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (
+      !stageRef.current ||
+      !canvasRef.current ||
+      !labelLayerRef.current ||
+      !inspectRef.current ||
+      !statsTitleRef.current ||
+      !statsRef.current ||
+      !legendRef.current ||
+      !sceneTabListRef.current ||
+      !sceneDagRef.current ||
+      !sceneEcoRef.current ||
+      !playRef.current ||
+      !resetRef.current ||
+      !hintRef.current
+    ) {
+      return
+    }
+
+    // Read once at mount time: a search result can link to
+    // /atlas?scene=eco&node=digitalcash to land pre-focused on that entity.
+    // Later edits to the URL (e.g. from the engine's own scene switching)
+    // deliberately don't feed back in — this is an entry-point deep link,
+    // not a two-way synced state.
+    const initialScene = searchParams.get('scene') === 'eco' ? ('eco' as AtlasScene) : undefined
+    const initialEcoId = searchParams.get('node') ?? undefined
+
+    const handle = createAtlasEngine(
+      {
+        stage: stageRef.current,
+        canvas: canvasRef.current,
+        labelLayer: labelLayerRef.current,
+        inspect: inspectRef.current,
+        statsTitle: statsTitleRef.current,
+        stats: statsRef.current,
+        legend: legendRef.current,
+        sceneTabList: sceneTabListRef.current,
+        sceneDagButton: sceneDagRef.current,
+        sceneEcoButton: sceneEcoRef.current,
+        playButton: playRef.current,
+        resetButton: resetRef.current,
+        hint: hintRef.current,
+      },
+      { onNavigate: navigate, initialScene, initialEcoId },
+    )
+
+    return () => handle.destroy()
+    // Mount once per component instance: navigate is stable from
+    // react-router, and searchParams is intentionally read only at mount
+    // (see comment above) so this effect must not re-run on URL changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    <div className="atlas-stage" ref={stageRef}>
+      <canvas
+        className="atlas-canvas"
+        ref={canvasRef}
+        aria-label="Interactive 3D model. Drag to orbit, scroll to zoom, click a node to inspect it."
+      />
+      <div className="atlas-labels" ref={labelLayerRef} aria-hidden="true" />
+
+      <div className="atlas-nogl">
+        <div>
+          <p className="atlas-nogl-kicker">WebGL unavailable</p>
+          <p>
+            This model renders with hardware-accelerated WebGL. Your browser or device has it disabled, so the 3D
+            view can&rsquo;t start &mdash; the written reference on{' '}
+            <a href="/protocol">the Protocol page</a> and the{' '}
+            <a href="/deep-dive">Deep Dive</a> cover the same material.
+          </p>
+        </div>
+      </div>
+
+      <div className="atlas-hud atlas-hud--tl">
+        <div className="atlas-glass atlas-scenes" role="tablist" aria-label="Choose a model" ref={sceneTabListRef}>
+          <button type="button" className="atlas-scene-btn" ref={sceneDagRef} role="tab" aria-selected="true">
+            Consensus DAG
+          </button>
+          <button type="button" className="atlas-scene-btn" ref={sceneEcoRef} role="tab" aria-selected="false">
+            Ecosystem
+          </button>
+        </div>
+      </div>
+
+      <div className="atlas-hud atlas-hud--tr">
+        <button
+          type="button"
+          className="atlas-icon-btn atlas-icon-btn--playing"
+          ref={playRef}
+          aria-label="Pause simulation"
+          title="Play / pause"
+        >
+          <svg className="atlas-icon-play" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M8 5v14l11-7z" />
+          </svg>
+          <svg className="atlas-icon-pause" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <rect x="6" y="5" width="4" height="14" rx="1" />
+            <rect x="14" y="5" width="4" height="14" rx="1" />
+          </svg>
+        </button>
+        <button type="button" className="atlas-icon-btn" ref={resetRef} aria-label="Reset camera" title="Reset camera">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M3 12a9 9 0 1 0 3-6.7L3 8" />
+            <path d="M3 3v5h5" />
+          </svg>
+        </button>
+      </div>
+
+      <div className="atlas-hud atlas-hud--bl">
+        <div className="atlas-glass atlas-readout">
+          <div className="atlas-readout-title" ref={statsTitleRef}>
+            Narwhal / Bullshark — live
+          </div>
+          <div className="atlas-stats" ref={statsRef} />
+          <div className="atlas-legend" ref={legendRef} />
+        </div>
+      </div>
+
+      <div className="atlas-hud atlas-hud--br">
+        <div className="atlas-glass atlas-inspect" ref={inspectRef} aria-live="polite" />
+      </div>
+
+      <div className="atlas-hint" ref={hintRef}>
+        Drag to orbit · scroll to zoom · click a node
+      </div>
+    </div>
+  )
+}

--- a/telcoinwiki-react/src/components/atlas/__tests__/NetworkAtlas.test.tsx
+++ b/telcoinwiki-react/src/components/atlas/__tests__/NetworkAtlas.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { NetworkAtlas } from '../NetworkAtlas'
+
+/**
+ * jsdom has no real WebGL implementation. Rather than rely on however the
+ * current jsdom version happens to behave for `getContext('webgl2')`
+ * (returns null in some versions, throws "not implemented" in others), stub
+ * it explicitly so this test exercises the engine's defensive `if (!gl)`
+ * path deterministically — the same path a visitor with WebGL disabled hits.
+ */
+function stubNoWebGL() {
+  const original = HTMLCanvasElement.prototype.getContext
+  // @ts-expect-error – narrowing to the two context ids the engine requests
+  HTMLCanvasElement.prototype.getContext = function (id: string) {
+    if (id === 'webgl2' || id === 'webgl') return null
+    return original.call(this, id)
+  }
+  return () => {
+    HTMLCanvasElement.prototype.getContext = original
+  }
+}
+
+describe('NetworkAtlas (no WebGL)', () => {
+  let restoreGetContext: () => void
+  let errorSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    restoreGetContext = stubNoWebGL()
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    restoreGetContext()
+    errorSpy.mockRestore()
+  })
+
+  it('renders the fallback stage without throwing when WebGL is unavailable', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <NetworkAtlas />
+      </MemoryRouter>,
+    )
+    const stage = container.querySelector('.atlas-stage') as HTMLElement
+    expect(stage).toBeTruthy()
+    expect(stage.dataset.atlasFailed).toBe('true')
+  })
+
+  it('always renders an accessible canvas label and the scene tablist', () => {
+    render(
+      <MemoryRouter>
+        <NetworkAtlas />
+      </MemoryRouter>,
+    )
+    expect(screen.getByRole('tablist', { name: /choose a model/i })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /consensus dag/i })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /ecosystem/i })).toBeInTheDocument()
+  })
+
+  it('mounts and unmounts cleanly — the returned engine handle is always callable', () => {
+    // This is the regression guard for a real bug class: an early-return
+    // branch in createAtlasEngine that forgets to return a working
+    // `destroy()` would throw here when the effect cleanup runs.
+    const { unmount } = render(
+      <MemoryRouter>
+        <NetworkAtlas />
+      </MemoryRouter>,
+    )
+    expect(() => unmount()).not.toThrow()
+  })
+
+  it('survives mount → unmount → mount in immediate succession (React StrictMode shape)', () => {
+    const first = render(
+      <MemoryRouter>
+        <NetworkAtlas />
+      </MemoryRouter>,
+    )
+    first.unmount()
+    const second = render(
+      <MemoryRouter>
+        <NetworkAtlas />
+      </MemoryRouter>,
+    )
+    expect(() => second.unmount()).not.toThrow()
+  })
+
+  it('does not crash on a garbage ?node= query param', () => {
+    // jsdom has no real WebGL, so this suite can't exercise the engine's
+    // node-selection branch (see `isEcosystemId` in data.test.ts for that
+    // coverage) — what this confirms is that reading an invalid/unknown
+    // node id off the URL during mount never throws.
+    const { container } = render(
+      <MemoryRouter initialEntries={['/atlas?scene=eco&node=not-a-real-entity']}>
+        <NetworkAtlas />
+      </MemoryRouter>,
+    )
+    expect(container.querySelector('.atlas-stage')).toBeTruthy()
+  })
+})

--- a/telcoinwiki-react/src/components/layout/Header.tsx
+++ b/telcoinwiki-react/src/components/layout/Header.tsx
@@ -84,6 +84,9 @@ export function Header({
             <Link to="/protocol" className="header-nav-link">
               Protocol
             </Link>
+            <Link to="/atlas" className="header-nav-link">
+              Atlas
+            </Link>
             <Link to="/#faq-section" className="header-nav-link">
               FAQ
             </Link>
@@ -183,6 +186,7 @@ export function Header({
             </li>
             <li className="nav-item">
               <Link to="/protocol" onClick={handleMobileLinkClick}>Protocol</Link>
+              <Link to="/atlas" onClick={handleMobileLinkClick}>Atlas</Link>
               <Link to="/#faq-section" onClick={handleMobileLinkClick}>FAQ</Link>
             </li>
           </ul>

--- a/telcoinwiki-react/src/config/megaMenu.ts
+++ b/telcoinwiki-react/src/config/megaMenu.ts
@@ -62,6 +62,7 @@ export const megaMenuSections: MegaSection[] = [
       { label: 'Staking a validator', href: '/protocol#proto-staking', description: 'The membership model and the three transactions.' },
       { label: 'Fees', href: '/protocol#proto-fees', description: 'Epoch-based base fees and the gas limit penalty.' },
       { label: 'Documentation index', href: '/protocol#proto-sources', description: 'Every primary source, mapped.' },
+      { label: 'Network Atlas', href: '/atlas', description: 'Consensus and the ecosystem, as a live 3D model.' },
     ],
   },
   {

--- a/telcoinwiki-react/src/config/navigation.ts
+++ b/telcoinwiki-react/src/config/navigation.ts
@@ -6,5 +6,6 @@ export const NAV_ITEMS: NavItems = [
   { id: 'story', label: 'Story', href: '/#home-story-cards' },
   { id: 'deep-dive', label: 'Deep Dive', href: '/deep-dive' },
   { id: 'protocol', label: 'Protocol', href: '/protocol' },
+  { id: 'atlas', label: 'Atlas', href: '/atlas' },
   { id: 'faq', label: 'FAQ', href: '/#faq-section' },
 ]

--- a/telcoinwiki-react/src/config/pageMeta.ts
+++ b/telcoinwiki-react/src/config/pageMeta.ts
@@ -4,5 +4,6 @@ export const PAGE_META: PageMetaMap = {
   home: { label: 'Home', url: '/', parent: null, navId: 'home' },
   'deep-dive': { label: 'Deep Dive', url: '/deep-dive', parent: 'home', navId: 'deep-dive' },
   protocol: { label: 'Protocol', url: '/protocol', parent: 'home', navId: 'protocol' },
+  atlas: { label: 'Network Atlas', url: '/atlas', parent: 'home', navId: 'atlas' },
   '404': { label: 'Page not found', url: '/404', parent: 'home', navId: null },
 }

--- a/telcoinwiki-react/src/lib/atlas/__tests__/data.test.ts
+++ b/telcoinwiki-react/src/lib/atlas/__tests__/data.test.ts
@@ -1,0 +1,106 @@
+import { CONSENSUS, ECOSYSTEM, ECOSYSTEM_EDGES, ECOSYSTEM_IDS, isEcosystemId } from '../data'
+import { PROTOCOL_SECTIONS } from '../../../components/protocol/sections'
+import { SECTIONS as DEEP_DIVE_SECTIONS } from '../../../components/deepDive/sections'
+
+describe('atlas ecosystem data', () => {
+  it('has a unique, stable id for every entity matching its record key', () => {
+    ECOSYSTEM_IDS.forEach((id) => expect(ECOSYSTEM[id].id).toBe(id))
+    expect(new Set(ECOSYSTEM_IDS).size).toBe(ECOSYSTEM_IDS.length)
+  })
+
+  it('gives every entity a non-empty label, kicker, body and at least one fact', () => {
+    ECOSYSTEM_IDS.forEach((id) => {
+      const e = ECOSYSTEM[id]
+      expect(e.label.trim().length).toBeGreaterThan(0)
+      expect(e.kicker.trim().length).toBeGreaterThan(0)
+      expect(e.body.trim().length).toBeGreaterThan(20)
+      expect(e.facts.length).toBeGreaterThan(0)
+    })
+  })
+
+  it('every edge endpoint references a real entity', () => {
+    const bad = ECOSYSTEM_EDGES.filter((e) => !ECOSYSTEM_IDS.includes(e.a) || !ECOSYSTEM_IDS.includes(e.b))
+    expect(bad).toEqual([])
+  })
+
+  it('has no self-referencing or duplicate edges', () => {
+    const selfEdges = ECOSYSTEM_EDGES.filter((e) => e.a === e.b)
+    expect(selfEdges).toEqual([])
+
+    const seen = new Set<string>()
+    const dupes = ECOSYSTEM_EDGES.filter((e) => {
+      const key = [e.a, e.b].sort().join('::')
+      if (seen.has(key)) return true
+      seen.add(key)
+      return false
+    })
+    expect(dupes).toEqual([])
+  })
+
+  it('every entity participates in at least one relationship (no orphan nodes)', () => {
+    const connected = new Set<string>()
+    ECOSYSTEM_EDGES.forEach((e) => {
+      connected.add(e.a)
+      connected.add(e.b)
+    })
+    const orphans = ECOSYSTEM_IDS.filter((id) => !connected.has(id))
+    expect(orphans).toEqual([])
+  })
+
+  /**
+   * The whole point of grounding the Atlas in the rest of the site is that
+   * "Learn more" actually lands somewhere real. This is the regression guard
+   * for that — same shape as the deep-dive and protocol anchor tests.
+   */
+  it('every entity href resolves to a real deep-dive or protocol section', () => {
+    const protoIds = new Set(PROTOCOL_SECTIONS.map((s) => s.id))
+    const deepIds = new Set(DEEP_DIVE_SECTIONS.map((s) => s.id))
+    const broken: string[] = []
+
+    ECOSYSTEM_IDS.forEach((id) => {
+      const href = ECOSYSTEM[id].href
+      if (href.startsWith('/protocol#')) {
+        const anchor = href.replace('/protocol#', '')
+        if (!protoIds.has(anchor)) broken.push(`${id} -> ${href}`)
+      } else if (href.startsWith('/deep-dive#')) {
+        const anchor = href.replace('/deep-dive#', '')
+        if (!deepIds.has(anchor)) broken.push(`${id} -> ${href}`)
+      } else {
+        broken.push(`${id} -> ${href} (unrecognised route)`)
+      }
+    })
+
+    expect(broken).toEqual([])
+  })
+
+  it('every entity has a non-empty hrefLabel', () => {
+    ECOSYSTEM_IDS.forEach((id) => expect(ECOSYSTEM[id].hrefLabel.trim().length).toBeGreaterThan(0))
+  })
+})
+
+describe('isEcosystemId', () => {
+  it('accepts every real entity id', () => {
+    ECOSYSTEM_IDS.forEach((id) => expect(isEcosystemId(id)).toBe(true))
+  })
+
+  it('rejects unknown strings, empty strings, null and undefined', () => {
+    // This is the guard that stops a garbage ?node= query param (typo'd,
+    // stale after a rename, or hand-crafted) from ever reaching ecoSelected.
+    expect(isEcosystemId('not-a-real-entity')).toBe(false)
+    expect(isEcosystemId('')).toBe(false)
+    expect(isEcosystemId(null)).toBe(false)
+    expect(isEcosystemId(undefined)).toBe(false)
+  })
+})
+
+describe('atlas consensus constants', () => {
+  it('keeps the quorum at a real 2f+1 majority of the validator set', () => {
+    const f = Math.floor((CONSENSUS.validators.length - 1) / 3)
+    expect(CONSENSUS.quorum).toBe(2 * f + 1)
+    expect(CONSENSUS.quorum).toBeLessThanOrEqual(CONSENSUS.validators.length)
+  })
+
+  it('keeps the GC window wide enough that a quorum can always find eligible parents', () => {
+    expect(CONSENSUS.keepRounds).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/telcoinwiki-react/src/lib/atlas/__tests__/mat4.test.ts
+++ b/telcoinwiki-react/src/lib/atlas/__tests__/mat4.test.ts
@@ -1,0 +1,75 @@
+import { lookAt, multiply, perspective, projectPoint } from '../mat4'
+
+function identity(): Float32Array {
+  const m = new Float32Array(16)
+  m[0] = m[5] = m[10] = m[15] = 1
+  return m
+}
+
+describe('mat4', () => {
+  it('multiply by identity is a no-op', () => {
+    const a = new Float32Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])
+    const result = multiply(a, identity())
+    expect(Array.from(result)).toEqual(Array.from(a))
+  })
+
+  it('lookAt produces an orthonormal basis (columns are unit length and mutually perpendicular)', () => {
+    const view = lookAt([5, 3, 8], [0, 0, 0], [0, 1, 0])
+    const cols = [
+      [view[0], view[1], view[2]],
+      [view[4], view[5], view[6]],
+      [view[8], view[9], view[10]],
+    ]
+    cols.forEach((c) => {
+      const len = Math.hypot(c[0], c[1], c[2])
+      expect(len).toBeCloseTo(1, 5)
+    })
+    // dot products between distinct axes should be ~0
+    for (let i = 0; i < 3; i++) {
+      for (let j = i + 1; j < 3; j++) {
+        const dot = cols[i][0] * cols[j][0] + cols[i][1] * cols[j][1] + cols[i][2] * cols[j][2]
+        expect(dot).toBeCloseTo(0, 5)
+      }
+    }
+  })
+
+  it('lookAt places the eye at the origin of view space', () => {
+    const eye: [number, number, number] = [4, 2, -3]
+    const view = lookAt(eye, [0, 0, 0], [0, 1, 0])
+    // Transforming the eye point by the view matrix should land at (0,0,0).
+    const x = view[0] * eye[0] + view[4] * eye[1] + view[8] * eye[2] + view[12]
+    const y = view[1] * eye[0] + view[5] * eye[1] + view[9] * eye[2] + view[13]
+    const z = view[2] * eye[0] + view[6] * eye[1] + view[10] * eye[2] + view[14]
+    expect(x).toBeCloseTo(0, 4)
+    expect(y).toBeCloseTo(0, 4)
+    expect(z).toBeCloseTo(0, 4)
+  })
+
+  it('perspective maps a point on the near plane to clip w > 0', () => {
+    const proj = perspective(Math.PI / 4, 16 / 9, 0.1, 100)
+    const view = lookAt([0, 0, 5], [0, 0, 0], [0, 1, 0])
+    const vp = multiply(proj, view)
+    const projected = projectPoint(vp, [0, 0, 0])
+    expect(projected).not.toBeNull()
+    expect(projected!.w).toBeGreaterThan(0)
+  })
+
+  it('projectPoint returns null for a point behind the camera', () => {
+    const proj = perspective(Math.PI / 4, 1, 0.1, 100)
+    const view = lookAt([0, 0, 5], [0, 0, 0], [0, 1, 0])
+    const vp = multiply(proj, view)
+    // Far behind the eye, on the wrong side of the near plane.
+    const projected = projectPoint(vp, [0, 0, 50])
+    expect(projected).toBeNull()
+  })
+
+  it('a point dead ahead of the camera projects near clip-space center', () => {
+    const proj = perspective(Math.PI / 4, 1, 0.1, 100)
+    const view = lookAt([0, 0, 5], [0, 0, 0], [0, 1, 0])
+    const vp = multiply(proj, view)
+    const projected = projectPoint(vp, [0, 0, 0])
+    expect(projected).not.toBeNull()
+    expect(projected!.clipX).toBeCloseTo(0, 4)
+    expect(projected!.clipY).toBeCloseTo(0, 4)
+  })
+})

--- a/telcoinwiki-react/src/lib/atlas/__tests__/wiring.test.ts
+++ b/telcoinwiki-react/src/lib/atlas/__tests__/wiring.test.ts
@@ -1,0 +1,74 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { ECOSYSTEM_IDS } from '../data'
+import { NAV_ITEMS } from '../../../config/navigation'
+import { PAGE_META } from '../../../config/pageMeta'
+import { megaMenuSections } from '../../../config/megaMenu'
+
+const SRC_ROOT = join(__dirname, '..', '..', '..')
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      return entry === '__tests__' || entry === '__mocks__' ? [] : sourceFiles(full)
+    }
+    return /\.tsx?$/.test(entry) ? [full] : []
+  })
+}
+
+describe('atlas route wiring', () => {
+  it('is reachable from navigation and described in page meta', () => {
+    expect(NAV_ITEMS.some((n) => n.href === '/atlas')).toBe(true)
+    expect(PAGE_META.atlas).toBeDefined()
+    expect(PAGE_META.atlas.url).toBe('/atlas')
+  })
+
+  it('has a route registered for /atlas', () => {
+    const app = readFileSync(join(SRC_ROOT, 'App.tsx'), 'utf8')
+    expect(app).toContain('path="/atlas"')
+  })
+
+  it('is linked from the site header, desktop and mobile', () => {
+    const header = readFileSync(join(SRC_ROOT, 'components', 'layout', 'Header.tsx'), 'utf8')
+    const matches = header.match(/to="\/atlas"/g) ?? []
+    expect(matches.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('has at least one mega-menu entry pointing at /atlas', () => {
+    const hasAtlasItem = megaMenuSections.some((section) => section.items.some((item) => item.href === '/atlas'))
+    expect(hasAtlasItem).toBe(true)
+  })
+
+  it('is cross-linked from the Protocol and Deep Dive hero sections', () => {
+    const protocolPage = readFileSync(join(SRC_ROOT, 'pages', 'ProtocolPage.tsx'), 'utf8')
+    const deepDivePage = readFileSync(join(SRC_ROOT, 'pages', 'DeepDivePage.tsx'), 'utf8')
+    expect(protocolPage).toMatch(/to="\/atlas"/)
+    expect(deepDivePage).toMatch(/to="\/atlas"/)
+  })
+})
+
+describe('atlas node deep links', () => {
+  /**
+   * Every `/atlas?scene=eco&node=<id>` reference anywhere in the app —
+   * whether hand-written or generated — must name a real ecosystem entity.
+   * This is what the search index's per-entity docs rely on to actually
+   * land on the right node instead of a blank ecosystem view.
+   */
+  it('has no reference to an unknown ecosystem node id', () => {
+    const broken: string[] = []
+    for (const file of sourceFiles(SRC_ROOT)) {
+      const contents = readFileSync(file, 'utf8')
+      for (const m of contents.matchAll(/\/atlas\?scene=eco&node=([a-z0-9-]+)/g)) {
+        if (!ECOSYSTEM_IDS.includes(m[1])) broken.push(`${file.replace(SRC_ROOT, 'src')} → node=${m[1]}`)
+      }
+    }
+    expect(broken).toEqual([])
+  })
+
+  it('generates a query-param deep link for every ecosystem entity in the search index build', () => {
+    const generator = readFileSync(join(SRC_ROOT, '..', 'tools', 'build-search-index.mjs'), 'utf8')
+    expect(generator).toContain('scene=eco&node=')
+    expect(generator).toContain("ECOSYSTEM_IDS } from")
+  })
+})

--- a/telcoinwiki-react/src/lib/atlas/data.ts
+++ b/telcoinwiki-react/src/lib/atlas/data.ts
@@ -1,0 +1,208 @@
+export type Vec3 = readonly [number, number, number]
+export type NodeKind = 'cyan' | 'gold' | 'neutral'
+
+export interface EcosystemEntity {
+  id: string
+  label: string
+  kind: NodeKind
+  position: Vec3
+  size: number
+  kicker: string
+  body: string
+  facts: readonly string[]
+  /**
+   * Where this entity is covered in depth elsewhere on the wiki. The 3D
+   * model is deliberately not the only place this information lives — it
+   * is a map, and the inspector should always offer a way to the prose.
+   */
+  href: string
+  hrefLabel: string
+}
+
+export interface EcosystemEdge {
+  a: string
+  b: string
+  kind: 'value' | 'money' | 'gov'
+  label: string
+}
+
+export const ECOSYSTEM: Record<string, EcosystemEntity> = {
+  tel: {
+    id: 'tel',
+    label: 'TEL',
+    kind: 'cyan',
+    position: [-6.4, 1.4, 0],
+    size: 1.55,
+    kicker: 'The native token',
+    body: 'The fuel and coordination asset of the whole platform. Fixed supply of 100 billion with just 2 decimal places — unusual for an ERC-20, and a reliable source of bugs when reading raw balances.',
+    facts: [
+      '100,000,000,000 fixed supply · 2 decimals',
+      'Gas on Telcoin Network',
+      'Staked by validators to secure consensus',
+      'LP rewards on TELx + governance weight',
+    ],
+    href: '/protocol#proto-token',
+    hrefLabel: 'Native token & 0x7e1 precompile',
+  },
+  network: {
+    id: 'network',
+    label: 'Telcoin Network',
+    kind: 'cyan',
+    position: [0, 0, 0],
+    size: 1.35,
+    kicker: 'Settlement · Layer 1',
+    body: 'The EVM-compatible Layer 1 where value settles. A DAG consensus layer orders transactions and a Reth-based EVM executes them, giving instant deterministic finality suited to payments.',
+    facts: [
+      'EVM-compatible — Solidity, Reth execution',
+      'Narwhal/Bullshark DAG consensus',
+      'Validated by GSMA member mobile operators',
+      'Every transaction burns TEL as gas',
+    ],
+    href: '/protocol#proto-architecture',
+    hrefLabel: 'Architecture — the four layers',
+  },
+  validators: {
+    id: 'validators',
+    label: 'GSMA Validators',
+    kind: 'cyan',
+    position: [0, -3.4, 0],
+    size: 1.1,
+    kicker: 'Security · block production',
+    body: 'The block producers, and the decision that most sets Telcoin apart. Validator slots are permissioned to GSMA full-member mobile network operators, approved by the Compliance Council, who stake TEL and run the nodes.',
+    facts: [
+      'Permissioned to GSMA mobile operators',
+      'Stake 1,000,000 TEL for proof-of-stake consensus',
+      'Each runs Primary + Worker nodes',
+      'Earn TEL gas fees and issuance',
+    ],
+    href: '/protocol#proto-staking',
+    hrefLabel: 'The membership model & staking',
+  },
+  telx: {
+    id: 'telx',
+    label: 'TELx',
+    kind: 'cyan',
+    position: [0, 3.6, 0],
+    size: 1.15,
+    kicker: 'Liquidity layer',
+    body: 'The liquidity engine. TELx layers TEL incentives over established AMMs so there is depth for TEL and Digital Cash — which is what keeps in-wallet swap rates tight.',
+    facts: [
+      'Liquidity mining paid in TEL',
+      'Built on Uniswap + Balancer',
+      'Mainly Polygon, also Base',
+      'Migrating to Uniswap v4 (Telcoin Hook)',
+    ],
+    href: '/deep-dive#deep-incentives',
+    hrefLabel: 'Incentives & staking deep dive',
+  },
+  wallet: {
+    id: 'wallet',
+    label: 'TAN · Wallet',
+    kind: 'neutral',
+    position: [0, 7.0, 0],
+    size: 1.2,
+    kicker: 'Application layer',
+    body: 'TAN — the Telcoin Application Network — is the third layer of the stack: self-custodial mobile apps built by GSMA telecom members. The Telcoin Wallet is a TAN app, and where the system becomes a product.',
+    facts: [
+      'App layer atop Network + TELx',
+      'Assisted self-custody: 2-of-3 keys',
+      'No seed phrase — access tied to your number',
+      'Holds Digital Cash + crypto, swaps, staking',
+    ],
+    href: '/deep-dive#deep-wallet',
+    hrefLabel: 'The Telcoin Wallet deep dive',
+  },
+  digitalcash: {
+    id: 'digitalcash',
+    label: 'Digital Cash',
+    kind: 'gold',
+    position: [6.4, 3.0, 2.4],
+    size: 1.3,
+    kicker: 'Regulated money',
+    body: 'Fiat-backed digital currencies — eUSD, eGBP, eJPY and more — issued and redeemed by the Telcoin Digital Asset Bank and settled on Telcoin Network. Multi-currency by design, because a remittance is a currency pair.',
+    facts: [
+      'Bank-issued and fiat-backed (e.g. eUSD)',
+      '~12 live on Polygon; more announced',
+      'Redeemable from 100% reserves',
+      'Named with an e- prefix (mostly ISO codes)',
+    ],
+    href: '/deep-dive#deep-digital-cash',
+    hrefLabel: 'Digital Cash deep dive',
+  },
+  bank: {
+    id: 'bank',
+    label: 'Digital Asset Bank',
+    kind: 'gold',
+    position: [6.4, 6.6, 2.4],
+    size: 1.25,
+    kicker: 'The issuer',
+    body: 'A distinct regulated entity holding Nebraska’s first Digital Asset Depository Institution charter, finalized 12 November 2025 — the first digital asset bank charter in the United States.',
+    facts: [
+      'First US digital asset bank charter (Nov 2025)',
+      '≥100% USD-denominated reserves',
+      'No FDIC insurance (by statute)',
+      'Runs KYC/AML; mints and burns Digital Cash',
+    ],
+    href: '/deep-dive#deep-bank',
+    hrefLabel: 'Telcoin Digital Asset Bank deep dive',
+  },
+  association: {
+    id: 'association',
+    label: 'Telcoin Association',
+    kind: 'neutral',
+    position: [-6.4, 6.6, -2.4],
+    size: 1.2,
+    kicker: 'Governance',
+    body: 'A Swiss non-profit Verein domiciled in Lugano that stewards the protocol. Governance is polycentric: elected Miner Councils handle each domain, and the Miner Assembly holds constitutional authority.',
+    facts: [
+      'Swiss Verein, domiciled in Lugano',
+      'Elected Miner Councils per domain',
+      'Miner Assembly = constitutional authority',
+      'Sets validator policy and TELx emissions',
+    ],
+    href: '/deep-dive#deep-governance',
+    hrefLabel: 'Governance deep dive',
+  },
+}
+
+export const ECOSYSTEM_EDGES: readonly EcosystemEdge[] = [
+  { a: 'validators', b: 'network', kind: 'value', label: 'secure · validate' },
+  { a: 'network', b: 'telx', kind: 'value', label: 'settles trades' },
+  { a: 'telx', b: 'wallet', kind: 'value', label: 'swap liquidity' },
+  { a: 'tel', b: 'network', kind: 'value', label: 'gas + issuance' },
+  { a: 'tel', b: 'validators', kind: 'value', label: 'staked by' },
+  { a: 'tel', b: 'telx', kind: 'value', label: 'LP rewards' },
+  { a: 'bank', b: 'digitalcash', kind: 'money', label: 'issues · redeems' },
+  { a: 'digitalcash', b: 'telx', kind: 'money', label: 'traded on' },
+  { a: 'digitalcash', b: 'wallet', kind: 'money', label: 'held in' },
+  { a: 'association', b: 'network', kind: 'gov', label: 'validator policy' },
+  { a: 'association', b: 'telx', kind: 'gov', label: 'sets emissions' },
+]
+
+export const ECOSYSTEM_IDS = Object.keys(ECOSYSTEM)
+
+/** Type guard used to validate a `?node=` query param before trusting it as an entity id. */
+export function isEcosystemId(id: string | null | undefined): id is string {
+  return typeof id === 'string' && ECOSYSTEM_IDS.includes(id)
+}
+
+/** Consensus simulation constants (Narwhal/Bullshark DAG). */
+export const CONSENSUS = {
+  validators: ['alpha', 'bravo', 'charlie', 'delta'] as const,
+  /** 2f+1 with n=4, f=1. */
+  quorum: 3,
+  roundSpacing: 2.75,
+  laneSpacing: 2.5,
+  /** Garbage-collection window, mirroring Narwhal's own pruning. */
+  keepRounds: 6,
+  stepMs: 1650,
+}
+
+/** RGB triples in 0..1, matched to `NodeKind` plus a couple of scene-only accents. */
+export const PALETTE = {
+  slate: [0.36, 0.46, 0.55] as Vec3,
+  cyan: [0.23, 0.82, 0.85] as Vec3,
+  gold: [0.94, 0.75, 0.39] as Vec3,
+  hot: [1.0, 0.93, 0.74] as Vec3,
+  grid: [0.3, 0.42, 0.52] as Vec3,
+}

--- a/telcoinwiki-react/src/lib/atlas/engine.ts
+++ b/telcoinwiki-react/src/lib/atlas/engine.ts
@@ -1,0 +1,1123 @@
+import { lookAt, multiply, perspective, projectPoint } from './mat4'
+import type { Mat4, Vec3 } from './mat4'
+import { CONSENSUS, ECOSYSTEM, ECOSYSTEM_EDGES, ECOSYSTEM_IDS, PALETTE, isEcosystemId } from './data'
+import type { EcosystemEntity, NodeKind } from './data'
+
+export type AtlasScene = 'dag' | 'eco'
+
+export interface AtlasElements {
+  /** The section containing the canvas — gets a `data-atlas-failed` flag if WebGL is unavailable. */
+  stage: HTMLElement
+  canvas: HTMLCanvasElement
+  labelLayer: HTMLElement
+  inspect: HTMLElement
+  statsTitle: HTMLElement
+  stats: HTMLElement
+  legend: HTMLElement
+  sceneDagButton: HTMLButtonElement
+  sceneEcoButton: HTMLButtonElement
+  sceneTabList: HTMLElement
+  playButton: HTMLButtonElement
+  resetButton: HTMLButtonElement
+  hint: HTMLElement
+}
+
+export interface AtlasEngineOptions {
+  /**
+   * Called when the visitor activates a "Learn more" link inside a HUD panel.
+   * The engine writes plain hrefs into its generated HTML (so they remain
+   * real, right-clickable, open-in-new-tab-able links) and intercepts plain
+   * left-clicks to hand off to the app router instead of a full page reload.
+   */
+  onNavigate: (path: string) => void
+  /** Pre-select a scene on mount — e.g. arriving from a search result. */
+  initialScene?: AtlasScene
+  /** Pre-select an ecosystem entity on mount (only used when the initial scene is 'eco'). */
+  initialEcoId?: string
+}
+
+export interface AtlasEngineHandle {
+  destroy: () => void
+}
+
+interface Certificate {
+  id: number
+  round: number
+  validatorIndex: number
+  parents: Certificate[]
+  state: 'certified' | 'leader' | 'committed'
+  bornAt: number
+  commitAt: number
+  support: number
+}
+
+interface RenderNode {
+  position: Vec3
+  color: Vec3
+  size: number
+  alpha: number
+  kind: 'cert' | 'eco'
+  cert?: Certificate
+  ecoId?: string
+}
+
+interface RenderEdge {
+  a: Vec3
+  b: Vec3
+  color: Vec3
+  alpha: number
+  width: number
+}
+
+interface ScreenPoint {
+  x: number
+  y: number
+  w: number
+  radius: number
+  node: RenderNode
+}
+
+type Picked = { kind: 'eco'; id: string } | { kind: 'cert'; cert: Certificate } | null
+
+const NODE_VERTEX_SHADER = `
+precision highp float;
+attribute vec3 aCenter; attribute vec2 aCorner; attribute vec3 aColor;
+attribute float aSize; attribute float aAlpha;
+uniform mat4 uView; uniform mat4 uProj;
+varying vec2 vUV; varying vec3 vColor; varying float vAlpha;
+void main(){
+  vec4 vp = uView * vec4(aCenter, 1.0);
+  vp.xy += aCorner * aSize;
+  gl_Position = uProj * vp;
+  vUV = aCorner / max(aSize, 0.0001);
+  vColor = aColor; vAlpha = aAlpha;
+}`
+
+const NODE_FRAGMENT_SHADER = `
+precision highp float;
+varying vec2 vUV; varying vec3 vColor; varying float vAlpha;
+void main(){
+  float d = length(vUV) * 2.0;
+  if (d > 1.0) discard;
+  float core = smoothstep(0.62, 0.24, d);
+  float glow = exp(-d * d * 3.2);
+  float a = clamp(core * 0.95 + glow * 0.5, 0.0, 1.0) * vAlpha;
+  if (a < 0.004) discard;
+  vec3 c = vColor * (0.45 + core * 1.15);
+  gl_FragColor = vec4(c * a, a);
+}`
+
+const EDGE_VERTEX_SHADER = `
+precision highp float;
+attribute vec3 aA; attribute vec3 aB; attribute float aSide; attribute float aT;
+attribute vec3 aColor; attribute float aAlpha; attribute float aWidth;
+uniform mat4 uView; uniform mat4 uProj;
+varying vec3 vColor; varying float vAlpha; varying float vSide;
+void main(){
+  vec4 va = uView * vec4(aA, 1.0);
+  vec4 vb = uView * vec4(aB, 1.0);
+  vec4 p = mix(va, vb, aT);
+  vec2 dir = vb.xy - va.xy;
+  float L = length(dir);
+  vec2 n = L > 0.00001 ? vec2(-dir.y, dir.x) / L : vec2(0.0, 1.0);
+  p.xy += n * aSide * aWidth;
+  gl_Position = uProj * p;
+  vColor = aColor; vAlpha = aAlpha; vSide = aSide;
+}`
+
+const EDGE_FRAGMENT_SHADER = `
+precision highp float;
+varying vec3 vColor; varying float vAlpha; varying float vSide;
+void main(){
+  float feather = 1.0 - smoothstep(0.15, 1.0, abs(vSide) * 2.0);
+  float a = vAlpha * feather;
+  if (a < 0.003) discard;
+  gl_FragColor = vec4(vColor * a, a);
+}`
+
+function ease(t: number): number {
+  if (t < 0) return 0
+  if (t > 1) return 1
+  return 1 - Math.pow(1 - t, 3)
+}
+
+function mixVec3(a: Vec3, b: Vec3, t: number): Vec3 {
+  return [a[0] + (b[0] - a[0]) * t, a[1] + (b[1] - a[1]) * t, a[2] + (b[2] - a[2]) * t]
+}
+
+function rgbCss(c: Vec3): string {
+  return `rgb(${Math.round(c[0] * 255)},${Math.round(c[1] * 255)},${Math.round(c[2] * 255)})`
+}
+
+function escapeHtml(input: string): string {
+  return input.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}
+
+/**
+ * Mounts the Network Atlas WebGL scene onto the given DOM elements and
+ * starts its render loop. Returns a handle whose `destroy()` fully tears
+ * everything down — this runs inside a React effect and must be safe to
+ * call on every route change, not just once per page load.
+ */
+export function createAtlasEngine(el: AtlasElements, options: AtlasEngineOptions): AtlasEngineHandle {
+  const { canvas, stage } = el
+  const gl =
+    (canvas.getContext('webgl2', { antialias: true, alpha: false, preserveDrawingBuffer: true }) as
+      | WebGL2RenderingContext
+      | WebGLRenderingContext
+      | null) ??
+    (canvas.getContext('webgl', { antialias: true, alpha: false, preserveDrawingBuffer: true }) as
+      | WebGLRenderingContext
+      | null)
+
+  if (!gl) {
+    stage.dataset.atlasFailed = 'true'
+    return { destroy: () => {} }
+  }
+
+  function compileShader(type: number, source: string): WebGLShader | null {
+    const shader = gl!.createShader(type)
+    if (!shader) return null
+    gl!.shaderSource(shader, source)
+    gl!.compileShader(shader)
+    if (!gl!.getShaderParameter(shader, gl!.COMPILE_STATUS)) {
+      console.error('[atlas] shader compile failed:', gl!.getShaderInfoLog(shader))
+      gl!.deleteShader(shader)
+      return null
+    }
+    return shader
+  }
+
+  function linkProgram(vsSrc: string, fsSrc: string): WebGLProgram | null {
+    const vs = compileShader(gl!.VERTEX_SHADER, vsSrc)
+    const fs = compileShader(gl!.FRAGMENT_SHADER, fsSrc)
+    if (!vs || !fs) return null
+    const program = gl!.createProgram()
+    if (!program) return null
+    gl!.attachShader(program, vs)
+    gl!.attachShader(program, fs)
+    gl!.linkProgram(program)
+    // Shader objects are refcounted by the program once linked; freeing our
+    // reference here avoids leaking them for the life of the context.
+    gl!.deleteShader(vs)
+    gl!.deleteShader(fs)
+    if (!gl!.getProgramParameter(program, gl!.LINK_STATUS)) {
+      console.error('[atlas] program link failed:', gl!.getProgramInfoLog(program))
+      gl!.deleteProgram(program)
+      return null
+    }
+    return program
+  }
+
+  const nodeProgram = linkProgram(NODE_VERTEX_SHADER, NODE_FRAGMENT_SHADER)
+  const edgeProgram = linkProgram(EDGE_VERTEX_SHADER, EDGE_FRAGMENT_SHADER)
+  if (!nodeProgram || !edgeProgram) {
+    stage.dataset.atlasFailed = 'true'
+    return { destroy: () => {} }
+  }
+
+  const nLoc = {
+    aCenter: gl.getAttribLocation(nodeProgram, 'aCenter'),
+    aCorner: gl.getAttribLocation(nodeProgram, 'aCorner'),
+    aColor: gl.getAttribLocation(nodeProgram, 'aColor'),
+    aSize: gl.getAttribLocation(nodeProgram, 'aSize'),
+    aAlpha: gl.getAttribLocation(nodeProgram, 'aAlpha'),
+    uView: gl.getUniformLocation(nodeProgram, 'uView'),
+    uProj: gl.getUniformLocation(nodeProgram, 'uProj'),
+  }
+  const eLoc = {
+    aA: gl.getAttribLocation(edgeProgram, 'aA'),
+    aB: gl.getAttribLocation(edgeProgram, 'aB'),
+    aSide: gl.getAttribLocation(edgeProgram, 'aSide'),
+    aT: gl.getAttribLocation(edgeProgram, 'aT'),
+    aColor: gl.getAttribLocation(edgeProgram, 'aColor'),
+    aAlpha: gl.getAttribLocation(edgeProgram, 'aAlpha'),
+    aWidth: gl.getAttribLocation(edgeProgram, 'aWidth'),
+    uView: gl.getUniformLocation(edgeProgram, 'uView'),
+    uProj: gl.getUniformLocation(edgeProgram, 'uProj'),
+  }
+
+  const nodeBuffer = gl.createBuffer()
+  const edgeBuffer = gl.createBuffer()
+  // node: center(3) corner(2) color(3) size(1) alpha(1)      = 10
+  // edge: a(3) b(3) side(1) t(1) color(3) alpha(1) width(1)  = 13
+  const NODE_STRIDE = 10
+  const EDGE_STRIDE = 13
+  let nodeArray = new Float32Array(0)
+  let edgeArray = new Float32Array(0)
+  let nodeVertexCount = 0
+  let edgeVertexCount = 0
+
+  const CORNERS: ReadonlyArray<readonly [number, number]> = [
+    [-0.5, -0.5],
+    [0.5, -0.5],
+    [0.5, 0.5],
+    [-0.5, -0.5],
+    [0.5, 0.5],
+    [-0.5, 0.5],
+  ]
+
+  function uploadNodes(list: RenderNode[]) {
+    const need = list.length * 6 * NODE_STRIDE
+    if (nodeArray.length < need) nodeArray = new Float32Array(need * 2)
+    let o = 0
+    for (const n of list) {
+      for (const [cx, cy] of CORNERS) {
+        nodeArray[o++] = n.position[0]
+        nodeArray[o++] = n.position[1]
+        nodeArray[o++] = n.position[2]
+        nodeArray[o++] = cx * n.size
+        nodeArray[o++] = cy * n.size
+        nodeArray[o++] = n.color[0]
+        nodeArray[o++] = n.color[1]
+        nodeArray[o++] = n.color[2]
+        nodeArray[o++] = n.size
+        nodeArray[o++] = n.alpha
+      }
+    }
+    nodeVertexCount = list.length * 6
+    gl!.bindBuffer(gl!.ARRAY_BUFFER, nodeBuffer)
+    gl!.bufferData(gl!.ARRAY_BUFFER, nodeArray.subarray(0, o), gl!.DYNAMIC_DRAW)
+  }
+
+  const EQ: ReadonlyArray<readonly [number, number]> = [
+    [-1, 0],
+    [1, 0],
+    [1, 1],
+    [-1, 0],
+    [1, 1],
+    [-1, 1],
+  ]
+
+  function uploadEdges(list: RenderEdge[]) {
+    const need = list.length * 6 * EDGE_STRIDE
+    if (edgeArray.length < need) edgeArray = new Float32Array(need * 2)
+    let o = 0
+    for (const e of list) {
+      for (const [side, t] of EQ) {
+        edgeArray[o++] = e.a[0]
+        edgeArray[o++] = e.a[1]
+        edgeArray[o++] = e.a[2]
+        edgeArray[o++] = e.b[0]
+        edgeArray[o++] = e.b[1]
+        edgeArray[o++] = e.b[2]
+        edgeArray[o++] = side * 0.5
+        edgeArray[o++] = t
+        edgeArray[o++] = e.color[0]
+        edgeArray[o++] = e.color[1]
+        edgeArray[o++] = e.color[2]
+        edgeArray[o++] = e.alpha
+        edgeArray[o++] = e.width
+      }
+    }
+    edgeVertexCount = list.length * 6
+    gl!.bindBuffer(gl!.ARRAY_BUFFER, edgeBuffer)
+    gl!.bufferData(gl!.ARRAY_BUFFER, edgeArray.subarray(0, o), gl!.DYNAMIC_DRAW)
+  }
+
+  function vertexAttrib(location: number, size: number, stride: number, offset: number) {
+    if (location < 0) return
+    gl!.enableVertexAttribArray(location)
+    gl!.vertexAttribPointer(location, size, gl!.FLOAT, false, stride * 4, offset * 4)
+  }
+
+  // ==================================================================
+  // Camera
+  // ==================================================================
+  const HOME: Record<AtlasScene, { az: number; el: number; dist: number; tx: number; ty: number; tz: number }> = {
+    dag: { az: -0.52, el: 0.5, dist: 21, tx: -5.0, ty: -0.2, tz: 0 },
+    eco: { az: -0.42, el: 0.24, dist: 24, tx: 1.6, ty: 1.8, tz: 0 },
+  }
+  const cam = { ...HOME.dag }
+  const camTarget = { ...HOME.dag }
+  let scene: AtlasScene = 'dag'
+  let lastWidth = 1
+  let lastHeight = 1
+  let userTouched = false
+
+  function goHome(instant: boolean) {
+    const h = HOME[scene]
+    const aspect = lastWidth / Math.max(lastHeight, 1)
+    // Narrow viewports see far less width at the same distance, so pull back
+    // enough to keep the whole graph in frame on a phone.
+    const boost = aspect < 0.75 ? 1.75 : aspect < 1.05 ? 1.42 : aspect < 1.45 ? 1.15 : 1
+    const tx = h.tx * (aspect < 1.05 ? 0.55 : 1)
+    camTarget.az = h.az
+    camTarget.el = h.el
+    camTarget.dist = h.dist * boost
+    camTarget.tx = tx
+    camTarget.ty = h.ty
+    camTarget.tz = h.tz
+    if (instant) Object.assign(cam, camTarget)
+  }
+
+  function eyePosition(): Vec3 {
+    const ce = Math.cos(cam.el)
+    return [
+      cam.tx + cam.dist * ce * Math.sin(cam.az),
+      cam.ty + cam.dist * Math.sin(cam.el),
+      cam.tz + cam.dist * ce * Math.cos(cam.az),
+    ]
+  }
+
+  // AbortController lets every listener registered below be removed with a
+  // single call, instead of hand-tracking each one for teardown.
+  const controller = new AbortController()
+  const { signal } = controller
+
+  let dragging = false
+  let lastX = 0
+  let lastY = 0
+
+  const hintEl = el.hint
+  const hintTimer = window.setTimeout(hideHint, 9000)
+  function hideHint() {
+    hintEl.classList.add('atlas-hint--gone')
+    window.clearTimeout(hintTimer)
+  }
+
+  canvas.addEventListener(
+    'pointerdown',
+    (e) => {
+      dragging = true
+      lastX = e.clientX
+      lastY = e.clientY
+      canvas.classList.add('atlas-canvas--dragging')
+      canvas.setPointerCapture(e.pointerId)
+      userTouched = true
+      hideHint()
+    },
+    { signal },
+  )
+  canvas.addEventListener(
+    'pointermove',
+    (e) => {
+      if (!dragging) return
+      camTarget.az -= (e.clientX - lastX) * 0.0062
+      camTarget.el = Math.max(-0.35, Math.min(1.32, camTarget.el + (e.clientY - lastY) * 0.0052))
+      lastX = e.clientX
+      lastY = e.clientY
+    },
+    { signal },
+  )
+  function endDrag(e: PointerEvent) {
+    if (!dragging) return
+    dragging = false
+    canvas.classList.remove('atlas-canvas--dragging')
+    try {
+      canvas.releasePointerCapture(e.pointerId)
+    } catch {
+      /* pointer already released */
+    }
+  }
+  canvas.addEventListener('pointerup', endDrag, { signal })
+  canvas.addEventListener('pointercancel', endDrag, { signal })
+  canvas.addEventListener(
+    'wheel',
+    (e) => {
+      e.preventDefault()
+      camTarget.dist = Math.max(7, Math.min(52, camTarget.dist * (1 + Math.sign(e.deltaY) * 0.11)))
+      userTouched = true
+      hideHint()
+    },
+    { signal, passive: false },
+  )
+
+  // ==================================================================
+  // Scene 1 — Narwhal / Bullshark DAG simulation
+  // ==================================================================
+  const { validators: VALIDATORS, quorum: QUORUM, roundSpacing: ROUND_SPACING, laneSpacing: LANE_SPACING, keepRounds: KEEP_ROUNDS } = CONSENSUS
+  const NV = VALIDATORS.length
+
+  const dag = { certs: [] as Certificate[], round: -1, commits: 0, seq: 0 }
+
+  function laneZ(v: number): number {
+    return (v - (NV - 1) / 2) * LANE_SPACING
+  }
+  function leaderFor(round: number): number {
+    return Math.floor(round / 2) % NV
+  }
+
+  function dagStep() {
+    dag.round++
+    const r = dag.round
+    const prev = dag.certs.filter((c) => c.round === r - 1)
+    const made: Certificate[] = []
+
+    for (let v = 0; v < NV; v++) {
+      const parents: Certificate[] = []
+      if (prev.length) {
+        const start = (v + r) % prev.length
+        for (let i = 0; i < Math.min(QUORUM, prev.length); i++) parents.push(prev[(start + i) % prev.length])
+      }
+      const isLeader = r % 2 === 0 && v === leaderFor(r)
+      const c: Certificate = {
+        id: ++dag.seq,
+        round: r,
+        validatorIndex: v,
+        parents,
+        state: isLeader ? 'leader' : 'certified',
+        bornAt: performance.now(),
+        commitAt: 0,
+        support: 0,
+      }
+      dag.certs.push(c)
+      made.push(c)
+    }
+
+    const lr = r - 1
+    if (lr >= 0 && lr % 2 === 0) {
+      const leader = dag.certs.find((c) => c.round === lr && c.validatorIndex === leaderFor(lr))
+      if (leader) {
+        const support = made.filter((c) => c.parents.includes(leader)).length
+        leader.support = support
+        if (support >= QUORUM) commitFrom(leader)
+      }
+    }
+
+    const cut = dag.round - KEEP_ROUNDS
+    dag.certs = dag.certs.filter((c) => c.round > cut)
+  }
+
+  function commitFrom(leader: Certificate) {
+    const seen: Certificate[] = []
+    const stack: Certificate[] = [leader]
+    const now = performance.now()
+    while (stack.length) {
+      const c = stack.pop()
+      if (!c || c.state === 'committed' || seen.includes(c)) continue
+      seen.push(c)
+      stack.push(...c.parents)
+    }
+    seen.sort((a, b) => b.round - a.round)
+    seen.forEach((c, i) => {
+      c.state = 'committed'
+      c.commitAt = now + i * 38 // staggered so the wave reads
+    })
+    dag.commits++
+  }
+
+  function dagWorldPosition(c: Certificate): Vec3 {
+    return [(c.round - dag.round) * ROUND_SPACING, c.state === 'leader' ? 0.62 : 0, laneZ(c.validatorIndex)]
+  }
+
+  function buildDagScene(now: number, nodes: RenderNode[], edges: RenderEdge[]) {
+    for (const c of dag.certs) {
+      const p = dagWorldPosition(c)
+      const age = (now - c.bornAt) / 420
+      const grow = age < 1 ? 0.35 + 0.65 * ease(age) : 1
+      let fade = 1
+      const oldness = dag.round - c.round
+      if (oldness > KEEP_ROUNDS - 2) fade = Math.max(0, 1 - (oldness - (KEEP_ROUNDS - 2)) / 2)
+
+      let color = PALETTE.cyan
+      let size = 0.62
+      const alpha = 0.9
+      if (c.state === 'leader') {
+        color = PALETTE.gold
+        size = 0.92
+      }
+      if (c.state === 'committed') {
+        const since = now - c.commitAt
+        if (since >= 0) {
+          const pulse = since < 520 ? 1 - since / 520 : 0
+          color = mixVec3(PALETTE.gold, PALETTE.hot, pulse)
+          size = 0.66 + pulse * 0.5
+        }
+      }
+      let nodeSize = size * grow
+      if (picked?.kind === 'cert' && picked.cert === c) {
+        nodeSize *= 1.45
+        color = PALETTE.hot
+      }
+      nodes.push({ position: p, color, size: nodeSize, alpha: alpha * fade, kind: 'cert', cert: c })
+
+      for (const parent of c.parents) {
+        if (!dag.certs.includes(parent)) continue
+        const bothCommitted = c.state === 'committed' && parent.state === 'committed'
+        edges.push({
+          a: p,
+          b: dagWorldPosition(parent),
+          color: bothCommitted ? PALETTE.gold : PALETTE.cyan,
+          alpha: (bothCommitted ? 0.4 : 0.14) * fade,
+          width: bothCommitted ? 0.03 : 0.02,
+        })
+      }
+    }
+
+    const back = -Math.min(dag.round, KEEP_ROUNDS) * ROUND_SPACING
+    for (let v = 0; v < NV; v++) {
+      edges.push({ a: [back - 1.2, -0.9, laneZ(v)], b: [1.6, -0.9, laneZ(v)], color: PALETTE.grid, alpha: 0.1, width: 0.012 })
+    }
+    for (let rr = 0; rr <= Math.min(dag.round, KEEP_ROUNDS); rr++) {
+      const x = -rr * ROUND_SPACING
+      edges.push({
+        a: [x, -0.9, laneZ(0) - 1.1],
+        b: [x, -0.9, laneZ(NV - 1) + 1.1],
+        color: PALETTE.grid,
+        alpha: 0.055,
+        width: 0.01,
+      })
+    }
+  }
+
+  function dagLabels(): LabelSpec[] {
+    const out: LabelSpec[] = VALIDATORS.map((name, v) => ({ p: [1.85, -0.55, laneZ(v)], text: name, cls: '' }))
+    out.push({ p: [0, 2.6, 0], text: `round ${Math.max(dag.round, 0)}`, cls: 'atlas-label--strong atlas-label--cyan' })
+    return out
+  }
+
+  // ==================================================================
+  // Scene 2 — Ecosystem graph
+  // ==================================================================
+  let ecoSelected = 'network'
+
+  function ecosystemRelated(id: string): Record<string, boolean> {
+    const related: Record<string, boolean> = { [id]: true }
+    for (const e of ECOSYSTEM_EDGES) {
+      if (e.a === id) related[e.b] = true
+      if (e.b === id) related[e.a] = true
+    }
+    return related
+  }
+
+  function kindColor(kind: NodeKind): Vec3 {
+    return kind === 'gold' ? PALETTE.gold : kind === 'cyan' ? PALETTE.cyan : PALETTE.slate
+  }
+
+  function buildEcoScene(now: number, nodes: RenderNode[], edges: RenderEdge[]) {
+    const focusId = hovered?.kind === 'eco' ? hovered.id : ecoSelected
+    const related = ecosystemRelated(focusId)
+    const breathe = 1 + Math.sin(now / 1400) * 0.03
+
+    for (const id of ECOSYSTEM_IDS) {
+      const entity = ECOSYSTEM[id]
+      const on = !!related[id]
+      let color = kindColor(entity.kind)
+      let size = entity.size * breathe
+      if (id === ecoSelected) size *= 1.22
+      if (picked?.kind === 'eco' && picked.id === id) color = PALETTE.hot
+      nodes.push({ position: entity.position, color, size, alpha: on ? 1 : 0.22, kind: 'eco', ecoId: id })
+    }
+
+    for (const e of ECOSYSTEM_EDGES) {
+      const hot = related[e.a] && related[e.b]
+      const color = e.kind === 'gov' ? PALETTE.slate : e.kind === 'money' ? PALETTE.gold : PALETTE.cyan
+      edges.push({
+        a: ECOSYSTEM[e.a].position,
+        b: ECOSYSTEM[e.b].position,
+        color,
+        alpha: hot ? (e.kind === 'gov' ? 0.3 : 0.48) : 0.055,
+        width: hot ? 0.032 : 0.016,
+      })
+    }
+
+    for (let g = -4; g <= 4; g++) {
+      edges.push({ a: [g * 2.6, -4.6, -7], b: [g * 2.6, -4.6, 7], color: PALETTE.grid, alpha: 0.05, width: 0.008 })
+      edges.push({ a: [-10.4, -4.6, g * 1.8], b: [10.4, -4.6, g * 1.8], color: PALETTE.grid, alpha: 0.05, width: 0.008 })
+    }
+  }
+
+  function ecoLabels(): LabelSpec[] {
+    const focusId = hovered?.kind === 'eco' ? hovered.id : ecoSelected
+    const related = ecosystemRelated(focusId)
+    return ECOSYSTEM_IDS.map((id) => {
+      const entity = ECOSYSTEM[id]
+      const on = !!related[id]
+      const cls = [
+        id === ecoSelected ? 'atlas-label--strong' : '',
+        on ? (entity.kind === 'gold' ? 'atlas-label--gold' : entity.kind === 'cyan' ? 'atlas-label--cyan' : '') : '',
+      ]
+        .filter(Boolean)
+        .join(' ')
+      return {
+        p: [entity.position[0], entity.position[1] - entity.size - 0.62, entity.position[2]] as Vec3,
+        text: entity.label,
+        cls,
+        dim: !on,
+      }
+    })
+  }
+
+  // ==================================================================
+  // Shared render/pick state
+  // ==================================================================
+  let picked: Picked = null
+  let hovered: Picked = null
+  let playing = true
+  const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+  let lastVP: Mat4 | null = null
+  let screenPoints: ScreenPoint[] = []
+
+  function project(p: Vec3): { x: number; y: number; w: number } | null {
+    if (!lastVP) return null
+    const clip = projectPoint(lastVP, p)
+    if (!clip) return null
+    return { x: (clip.clipX * 0.5 + 0.5) * lastWidth, y: (1 - (clip.clipY * 0.5 + 0.5)) * lastHeight, w: clip.w }
+  }
+
+  function hitTest(mx: number, my: number): RenderNode | null {
+    let best: ScreenPoint | null = null
+    let bestDist = 26
+    for (const s of screenPoints) {
+      const d = Math.hypot(s.x - mx, s.y - my)
+      const r = Math.max(11, s.radius)
+      if (d < r && d < bestDist + r) {
+        if (!best || s.w < best.w) {
+          best = s
+          bestDist = d
+        }
+      }
+    }
+    return best ? best.node : null
+  }
+
+  canvas.addEventListener(
+    'pointermove',
+    (e) => {
+      if (dragging) return
+      const r = canvas.getBoundingClientRect()
+      const n = hitTest(e.clientX - r.left, e.clientY - r.top)
+      hovered = n ? (n.kind === 'eco' ? { kind: 'eco', id: n.ecoId! } : { kind: 'cert', cert: n.cert! }) : null
+      canvas.style.cursor = n ? 'pointer' : 'grab'
+    },
+    { signal },
+  )
+
+  let pointerDownAt: { x: number; y: number } | null = null
+  canvas.addEventListener('pointerdown', (e) => (pointerDownAt = { x: e.clientX, y: e.clientY }), { signal })
+  canvas.addEventListener(
+    'pointerup',
+    (e) => {
+      if (!pointerDownAt) return
+      const moved = Math.hypot(e.clientX - pointerDownAt.x, e.clientY - pointerDownAt.y)
+      pointerDownAt = null
+      if (moved > 5) return // was an orbit drag, not a click
+      const r = canvas.getBoundingClientRect()
+      const n = hitTest(e.clientX - r.left, e.clientY - r.top)
+      if (!n) return
+      if (n.kind === 'eco') {
+        ecoSelected = n.ecoId!
+        picked = { kind: 'eco', id: n.ecoId! }
+      } else {
+        picked = { kind: 'cert', cert: n.cert! }
+      }
+      renderInspector()
+    },
+    { signal },
+  )
+
+  // ==================================================================
+  // HUD
+  // ==================================================================
+  function bindNavLinks(root: HTMLElement) {
+    root.addEventListener(
+      'click',
+      (e) => {
+        const target = e.target as HTMLElement
+        const link = target.closest('a[data-atlas-nav]') as HTMLAnchorElement | null
+        if (!link) return
+        const isPlainLeftClick =
+          e.button === 0 && !e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey && link.target !== '_blank'
+        if (!isPlainLeftClick) return
+        e.preventDefault()
+        options.onNavigate(link.getAttribute('href') || '/')
+      },
+      { signal },
+    )
+  }
+  bindNavLinks(el.inspect)
+
+  function renderLegend() {
+    const items: Array<[Vec3, string]> =
+      scene === 'dag'
+        ? [
+            [PALETTE.cyan, 'certified — 2f+1 signed'],
+            [PALETTE.gold, 'leader — even round'],
+            [PALETTE.hot, 'committing — causal history'],
+            [PALETTE.grid, 'validator lane'],
+          ]
+        : [
+            [PALETTE.cyan, 'network machine · TEL'],
+            [PALETTE.gold, 'regulated money'],
+            [PALETTE.slate, 'governance / application'],
+          ]
+    el.legend.innerHTML = items
+      .map(([c, label]) => `<div class="atlas-legend-row"><i style="background:${rgbCss(c)};box-shadow:0 0 8px ${rgbCss(c)}"></i>${label}</div>`)
+      .join('')
+  }
+
+  function renderStats() {
+    if (scene === 'dag') {
+      el.statsTitle.textContent = 'Narwhal / Bullshark — live'
+      el.stats.innerHTML =
+        `<div class="atlas-stat atlas-stat--cyan"><b>${Math.max(dag.round, 0)}</b><i>round</i></div>` +
+        `<div class="atlas-stat"><b>${dag.certs.length}</b><i>certs in DAG</i></div>` +
+        `<div class="atlas-stat atlas-stat--gold"><b>${dag.commits}</b><i>commits</i></div>` +
+        `<div class="atlas-stat"><b>${NV}/${QUORUM}</b><i>nodes / quorum</i></div>`
+    } else {
+      el.statsTitle.textContent = 'Ecosystem topology'
+      el.stats.innerHTML =
+        `<div class="atlas-stat atlas-stat--cyan"><b>${ECOSYSTEM_IDS.length}</b><i>entities</i></div>` +
+        `<div class="atlas-stat"><b>${ECOSYSTEM_EDGES.length}</b><i>relationships</i></div>` +
+        `<div class="atlas-stat atlas-stat--gold"><b>2</b><i>kinds of money</i></div>`
+    }
+  }
+
+  function factList(items: readonly string[]): string {
+    return `<ul class="atlas-facts">${items.map((f) => `<li>${escapeHtml(f)}</li>`).join('')}</ul>`
+  }
+
+  function learnMoreLink(href: string, label: string): string {
+    return `<a class="atlas-learn-more" href="${escapeHtml(href)}" data-atlas-nav>${escapeHtml(label)} →</a>`
+  }
+
+  function renderInspector() {
+    if (scene === 'eco') {
+      const entity: EcosystemEntity = ECOSYSTEM[ecoSelected]
+      const related = ECOSYSTEM_EDGES.filter((e) => e.a === ecoSelected || e.b === ecoSelected)
+      el.inspect.className = `atlas-inspect ${entity.kind === 'gold' ? 'atlas-inspect--gold' : entity.kind === 'neutral' ? 'atlas-inspect--neutral' : 'atlas-inspect--cyan'}`
+      el.inspect.innerHTML =
+        `<div class="atlas-inspect-kicker">${escapeHtml(entity.kicker)}</div>` +
+        `<h3>${escapeHtml(entity.label)}</h3>` +
+        `<p>${escapeHtml(entity.body)}</p>` +
+        factList(entity.facts) +
+        learnMoreLink(entity.href, entity.hrefLabel) +
+        `<div class="atlas-jump">${related
+          .map((e) => {
+            const otherId = e.a === ecoSelected ? e.b : e.a
+            return `<button type="button" data-atlas-jump="${otherId}" title="${escapeHtml(e.label)}">${escapeHtml(ECOSYSTEM[otherId].label)}</button>`
+          })
+          .join('')}</div>`
+      el.inspect.querySelectorAll<HTMLButtonElement>('[data-atlas-jump]').forEach((btn) => {
+        btn.addEventListener(
+          'click',
+          () => {
+            ecoSelected = btn.dataset.atlasJump!
+            picked = { kind: 'eco', id: ecoSelected }
+            renderInspector()
+          },
+          { signal },
+        )
+      })
+      return
+    }
+
+    if (!picked || picked.kind !== 'cert' || !dag.certs.includes(picked.cert)) {
+      el.inspect.className = 'atlas-inspect atlas-inspect--neutral'
+      el.inspect.innerHTML =
+        '<div class="atlas-inspect-kicker">Consensus layer</div><h3>The DAG, round by round</h3>' +
+        '<p>Every round each validator issues one certificate anchored to a quorum of parents in the round before it. On even rounds one validator is the leader; when it collects quorum support, Bullshark commits its whole causal history.</p>' +
+        factList(['Click any certificate to inspect it', 'Drag to orbit · scroll to zoom']) +
+        learnMoreLink('/protocol#proto-consensus', 'Narwhal & Bullshark, in the docs')
+      return
+    }
+
+    const c = picked.cert
+    const stateLabel = c.state === 'committed' ? 'committed' : c.state === 'leader' ? 'leader (even round)' : 'certified'
+    el.inspect.className = `atlas-inspect ${c.state === 'certified' ? 'atlas-inspect--cyan' : 'atlas-inspect--gold'}`
+    const desc =
+      c.state === 'committed'
+        ? 'Part of a committed sub-DAG. Its ordering is final and it has been handed to the execution layer.'
+        : c.state === 'leader'
+          ? "This round's elected leader. If a quorum of the next round anchors to it, everything in its causal history commits."
+          : 'Signed by a 2f+1 quorum of validator stake and inserted into the DAG, its parents already present.'
+    el.inspect.innerHTML =
+      `<div class="atlas-inspect-kicker">Certificate</div><h3>${escapeHtml(VALIDATORS[c.validatorIndex])} · round ${c.round}</h3>` +
+      `<p>${desc}</p>` +
+      '<div class="atlas-kv">' +
+      `<div><span class="atlas-kv-k">state</span><span class="atlas-kv-v">${stateLabel}</span></div>` +
+      `<div><span class="atlas-kv-k">validator</span><span class="atlas-kv-v">${escapeHtml(VALIDATORS[c.validatorIndex])}</span></div>` +
+      `<div><span class="atlas-kv-k">round</span><span class="atlas-kv-v">${c.round}</span></div>` +
+      `<div><span class="atlas-kv-k">parents</span><span class="atlas-kv-v">${c.parents.length} / ${QUORUM}</span></div>` +
+      (c.state === 'leader' || c.support ? `<div><span class="atlas-kv-k">support</span><span class="atlas-kv-v">${c.support} / ${QUORUM}</span></div>` : '') +
+      '</div>' +
+      learnMoreLink('/protocol#proto-lifecycle', 'The full transaction lifecycle')
+  }
+
+  interface LabelSpec {
+    p: Vec3
+    text: string
+    cls: string
+    dim?: boolean
+  }
+  const labelPool: HTMLDivElement[] = []
+  function syncLabels(list: LabelSpec[]) {
+    while (labelPool.length < list.length) {
+      const d = document.createElement('div')
+      d.className = 'atlas-label'
+      el.labelLayer.appendChild(d)
+      labelPool.push(d)
+    }
+    labelPool.forEach((div, i) => {
+      if (i >= list.length) {
+        div.style.display = 'none'
+        return
+      }
+      const L = list[i]
+      const s = project(L.p)
+      if (!s || s.x < -80 || s.x > lastWidth + 80 || s.y < -40 || s.y > lastHeight + 40) {
+        div.style.display = 'none'
+        return
+      }
+      div.style.display = 'block'
+      div.style.left = `${s.x}px`
+      div.style.top = `${s.y}px`
+      div.style.opacity = L.dim ? '0.28' : '1'
+      div.className = `atlas-label ${L.cls}`.trim()
+      if (div.textContent !== L.text) div.textContent = L.text
+    })
+  }
+
+  // ==================================================================
+  // Scene switching + controls
+  // ==================================================================
+  function setScene(next: AtlasScene) {
+    scene = next
+    el.sceneDagButton.setAttribute('aria-selected', next === 'dag' ? 'true' : 'false')
+    el.sceneEcoButton.setAttribute('aria-selected', next === 'eco' ? 'true' : 'false')
+    el.sceneDagButton.tabIndex = next === 'dag' ? 0 : -1
+    el.sceneEcoButton.tabIndex = next === 'eco' ? 0 : -1
+    picked = null
+    hovered = null
+    goHome(false)
+    renderLegend()
+    renderStats()
+    renderInspector()
+  }
+  el.sceneDagButton.addEventListener('click', () => setScene('dag'), { signal })
+  el.sceneEcoButton.addEventListener('click', () => setScene('eco'), { signal })
+  el.sceneTabList.addEventListener(
+    'keydown',
+    (e) => {
+      const order: AtlasScene[] = ['dag', 'eco']
+      const i = order.indexOf(scene)
+      let next: number | null = null
+      if (e.key === 'ArrowRight' || e.key === 'ArrowDown') next = (i + 1) % 2
+      else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') next = (i + 1) % 2
+      else if (e.key === 'Home') next = 0
+      else if (e.key === 'End') next = 1
+      if (next === null) return
+      e.preventDefault()
+      setScene(order[next])
+      ;(order[next] === 'dag' ? el.sceneDagButton : el.sceneEcoButton).focus()
+    },
+    { signal },
+  )
+
+  el.playButton.addEventListener(
+    'click',
+    () => {
+      playing = !playing
+      el.playButton.classList.toggle('atlas-icon-btn--playing', playing)
+      el.playButton.setAttribute('aria-label', playing ? 'Pause simulation' : 'Play simulation')
+    },
+    { signal },
+  )
+  el.resetButton.addEventListener('click', () => goHome(false), { signal })
+
+  // ==================================================================
+  // Resize, visibility and viewport-intersection pausing
+  // ==================================================================
+  function resize() {
+    const dpr = Math.min(window.devicePixelRatio || 1, 2)
+    const w = canvas.clientWidth || 1
+    const h = canvas.clientHeight || 1
+    const bw = Math.round(w * dpr)
+    const bh = Math.round(h * dpr)
+    if (canvas.width !== bw || canvas.height !== bh) {
+      canvas.width = bw
+      canvas.height = bh
+    }
+    lastWidth = w
+    lastHeight = h
+  }
+
+  const resizeObserver = new ResizeObserver(() => {
+    resize()
+    if (!userTouched) goHome(false)
+  })
+  resizeObserver.observe(canvas)
+  window.addEventListener('resize', resize, { signal })
+
+  // The Atlas now lives inside a normal, scrollable page rather than being
+  // the entire viewport — pausing the loop while it's off-screen or the tab
+  // is hidden avoids burning a render thread for a scene nobody can see.
+  let isIntersecting = true
+  const intersectionObserver =
+    typeof IntersectionObserver !== 'undefined'
+      ? new IntersectionObserver(
+          ([entry]) => {
+            const wasVisible = isIntersecting
+            isIntersecting = entry.isIntersecting
+            if (isIntersecting && !wasVisible) {
+              nextStepAt = performance.now() + CONSENSUS.stepMs
+              scheduleFrame()
+            }
+          },
+          { threshold: 0.05 },
+        )
+      : null
+  intersectionObserver?.observe(stage)
+
+  let isDocumentVisible = !document.hidden
+  document.addEventListener(
+    'visibilitychange',
+    () => {
+      const wasVisible = isDocumentVisible
+      isDocumentVisible = !document.hidden
+      if (isDocumentVisible && !wasVisible) {
+        nextStepAt = performance.now() + CONSENSUS.stepMs
+        scheduleFrame()
+      }
+    },
+    { signal },
+  )
+
+  // ==================================================================
+  // Main loop
+  // ==================================================================
+  let nextStepAt = 0
+  let rafHandle = 0
+  let destroyed = false
+
+  function scheduleFrame() {
+    if (destroyed || rafHandle) return
+    rafHandle = requestAnimationFrame(frame)
+  }
+
+  function frame(now: number) {
+    rafHandle = 0
+    if (destroyed) return
+    if (!isIntersecting || !isDocumentVisible) return // resumed by the observers above
+
+    resize()
+
+    if (scene === 'dag' && playing && now >= nextStepAt) {
+      dagStep()
+      nextStepAt = now + CONSENSUS.stepMs
+      renderStats()
+      if (picked?.kind === 'cert' && !dag.certs.includes(picked.cert)) {
+        picked = null
+        renderInspector()
+      }
+    }
+
+    if (!reducedMotion && !dragging && !userTouched) camTarget.az += 0.00042
+    const k = 0.1
+    cam.az += (camTarget.az - cam.az) * k
+    cam.el += (camTarget.el - cam.el) * k
+    cam.dist += (camTarget.dist - cam.dist) * k
+    cam.tx += (camTarget.tx - cam.tx) * k
+    cam.ty += (camTarget.ty - cam.ty) * k
+    cam.tz += (camTarget.tz - cam.tz) * k
+
+    const aspect = Math.max(lastWidth / Math.max(lastHeight, 1), 0.35)
+    const proj = perspective(Math.PI / 4.6, aspect, 0.1, 300)
+    const view = lookAt(eyePosition(), [cam.tx, cam.ty, cam.tz], [0, 1, 0])
+    lastVP = multiply(proj, view)
+
+    const nodes: RenderNode[] = []
+    const edges: RenderEdge[] = []
+    if (scene === 'dag') buildDagScene(now, nodes, edges)
+    else buildEcoScene(now, nodes, edges)
+
+    const eye = eyePosition()
+    nodes.sort((a, b) => {
+      const da = (a.position[0] - eye[0]) ** 2 + (a.position[1] - eye[1]) ** 2 + (a.position[2] - eye[2]) ** 2
+      const db = (b.position[0] - eye[0]) ** 2 + (b.position[1] - eye[1]) ** 2 + (b.position[2] - eye[2]) ** 2
+      return db - da
+    })
+
+    screenPoints = []
+    for (const n of nodes) {
+      const s = project(n.position)
+      if (s) screenPoints.push({ x: s.x, y: s.y, w: s.w, radius: (n.size / Math.max(s.w, 0.001)) * lastHeight * 0.55, node: n })
+    }
+
+    uploadNodes(nodes)
+    uploadEdges(edges)
+
+    gl!.viewport(0, 0, canvas.width, canvas.height)
+    gl!.clearColor(0.016, 0.027, 0.047, 1)
+    gl!.clear(gl!.COLOR_BUFFER_BIT)
+    gl!.disable(gl!.DEPTH_TEST)
+    gl!.enable(gl!.BLEND)
+    gl!.blendFunc(gl!.ONE, gl!.ONE_MINUS_SRC_ALPHA) // premultiplied
+
+    gl!.useProgram(edgeProgram)
+    gl!.uniformMatrix4fv(eLoc.uView, false, view)
+    gl!.uniformMatrix4fv(eLoc.uProj, false, proj)
+    gl!.bindBuffer(gl!.ARRAY_BUFFER, edgeBuffer)
+    vertexAttrib(eLoc.aA, 3, EDGE_STRIDE, 0)
+    vertexAttrib(eLoc.aB, 3, EDGE_STRIDE, 3)
+    vertexAttrib(eLoc.aSide, 1, EDGE_STRIDE, 6)
+    vertexAttrib(eLoc.aT, 1, EDGE_STRIDE, 7)
+    vertexAttrib(eLoc.aColor, 3, EDGE_STRIDE, 8)
+    vertexAttrib(eLoc.aAlpha, 1, EDGE_STRIDE, 11)
+    vertexAttrib(eLoc.aWidth, 1, EDGE_STRIDE, 12)
+    gl!.drawArrays(gl!.TRIANGLES, 0, edgeVertexCount)
+
+    gl!.useProgram(nodeProgram)
+    gl!.uniformMatrix4fv(nLoc.uView, false, view)
+    gl!.uniformMatrix4fv(nLoc.uProj, false, proj)
+    gl!.bindBuffer(gl!.ARRAY_BUFFER, nodeBuffer)
+    vertexAttrib(nLoc.aCenter, 3, NODE_STRIDE, 0)
+    vertexAttrib(nLoc.aCorner, 2, NODE_STRIDE, 3)
+    vertexAttrib(nLoc.aColor, 3, NODE_STRIDE, 5)
+    vertexAttrib(nLoc.aSize, 1, NODE_STRIDE, 8)
+    vertexAttrib(nLoc.aAlpha, 1, NODE_STRIDE, 9)
+    gl!.drawArrays(gl!.TRIANGLES, 0, nodeVertexCount)
+
+    syncLabels(scene === 'dag' ? dagLabels() : ecoLabels())
+
+    scheduleFrame()
+  }
+
+  // ==================================================================
+  // Boot
+  // ==================================================================
+  resize()
+  if (options.initialScene === 'eco') {
+    scene = 'eco'
+    el.sceneDagButton.setAttribute('aria-selected', 'false')
+    el.sceneDagButton.tabIndex = -1
+    el.sceneEcoButton.setAttribute('aria-selected', 'true')
+    el.sceneEcoButton.tabIndex = 0
+    if (isEcosystemId(options.initialEcoId)) {
+      ecoSelected = options.initialEcoId
+      picked = { kind: 'eco', id: options.initialEcoId }
+    }
+  }
+  goHome(true)
+  for (let i = 0; i < 5; i++) dagStep() // warm start so the scene has depth
+  nextStepAt = performance.now() + CONSENSUS.stepMs
+  renderLegend()
+  renderStats()
+  renderInspector()
+  scheduleFrame()
+
+  return {
+    destroy() {
+      if (destroyed) return
+      destroyed = true
+      if (rafHandle) cancelAnimationFrame(rafHandle)
+      window.clearTimeout(hintTimer)
+      controller.abort()
+      resizeObserver.disconnect()
+      intersectionObserver?.disconnect()
+      el.labelLayer.replaceChildren()
+
+      gl!.deleteBuffer(nodeBuffer)
+      gl!.deleteBuffer(edgeBuffer)
+      gl!.deleteProgram(nodeProgram)
+      gl!.deleteProgram(edgeProgram)
+      // Proactively release the context rather than waiting on GC — browsers
+      // cap the number of live WebGL contexts per page, and this component
+      // can mount and unmount many times in one SPA session.
+      const loseCtx = gl!.getExtension('WEBGL_lose_context')
+      loseCtx?.loseContext()
+    },
+  }
+}

--- a/telcoinwiki-react/src/lib/atlas/mat4.ts
+++ b/telcoinwiki-react/src/lib/atlas/mat4.ts
@@ -1,0 +1,87 @@
+/**
+ * Minimal column-major mat4 / vec3 helpers for the Network Atlas WebGL scene.
+ *
+ * No dependency (gl-matrix, three) is pulled in for this: the render loop
+ * only ever needs multiply, perspective and lookAt, and hand-rolling three
+ * functions is cheaper than a library plus its types for this single use site.
+ */
+
+export type Mat4 = Float32Array
+export type Vec3 = readonly [number, number, number]
+
+/** Column-major 4x4 multiply: returns a * b. */
+export function multiply(a: Mat4, b: Mat4): Mat4 {
+  const o = new Float32Array(16)
+  for (let c = 0; c < 4; c++) {
+    for (let r = 0; r < 4; r++) {
+      o[c * 4 + r] =
+        a[r] * b[c * 4] + a[4 + r] * b[c * 4 + 1] + a[8 + r] * b[c * 4 + 2] + a[12 + r] * b[c * 4 + 3]
+    }
+  }
+  return o
+}
+
+export function perspective(fovYRadians: number, aspect: number, near: number, far: number): Mat4 {
+  const f = 1 / Math.tan(fovYRadians / 2)
+  const nf = 1 / (near - far)
+  const o = new Float32Array(16)
+  o[0] = f / aspect
+  o[5] = f
+  o[10] = (far + near) * nf
+  o[11] = -1
+  o[14] = 2 * far * near * nf
+  return o
+}
+
+export function lookAt(eye: Vec3, target: Vec3, up: Vec3): Mat4 {
+  let zx = eye[0] - target[0]
+  let zy = eye[1] - target[1]
+  let zz = eye[2] - target[2]
+  const zl = Math.hypot(zx, zy, zz) || 1
+  zx /= zl
+  zy /= zl
+  zz /= zl
+
+  let xx = up[1] * zz - up[2] * zy
+  let xy = up[2] * zx - up[0] * zz
+  let xz = up[0] * zy - up[1] * zx
+  const xl = Math.hypot(xx, xy, xz) || 1
+  xx /= xl
+  xy /= xl
+  xz /= xl
+
+  const yx = zy * xz - zz * xy
+  const yy = zz * xx - zx * xz
+  const yz = zx * xy - zy * xx
+
+  const o = new Float32Array(16)
+  o[0] = xx
+  o[1] = yx
+  o[2] = zx
+  o[3] = 0
+  o[4] = xy
+  o[5] = yy
+  o[6] = zy
+  o[7] = 0
+  o[8] = xz
+  o[9] = yz
+  o[10] = zz
+  o[11] = 0
+  o[12] = -(xx * eye[0] + xy * eye[1] + xz * eye[2])
+  o[13] = -(yx * eye[0] + yy * eye[1] + yz * eye[2])
+  o[14] = -(zx * eye[0] + zy * eye[1] + zz * eye[2])
+  o[15] = 1
+  return o
+}
+
+/** Project a world-space point through a combined view-projection matrix into clip space. */
+export function projectPoint(
+  vp: Mat4,
+  p: Vec3,
+): { clipX: number; clipY: number; w: number } | null {
+  const x = vp[0] * p[0] + vp[4] * p[1] + vp[8] * p[2] + vp[12]
+  const y = vp[1] * p[0] + vp[5] * p[1] + vp[9] * p[2] + vp[13]
+  const w = vp[3] * p[0] + vp[7] * p[1] + vp[11] * p[2] + vp[15]
+  if (w <= 0.0001) return null
+  return { clipX: x / w, clipY: y / w, w }
+}

--- a/telcoinwiki-react/src/pages/AtlasPage.tsx
+++ b/telcoinwiki-react/src/pages/AtlasPage.tsx
@@ -1,0 +1,68 @@
+import { NetworkAtlas } from '../components/atlas/NetworkAtlas'
+
+export function AtlasPage() {
+  return (
+    <>
+      <section id="atlas-hero" aria-labelledby="atlas-hero-heading" className="anchor-offset">
+        <div className="mx-auto w-full max-w-[min(1600px,95vw)] px-4 sm:px-8 lg:px-12 xl:px-16 pt-[calc(var(--header-height)+3rem)] pb-6 sm:pb-8">
+          <div className="text-center">
+            <p className="proto-eyebrow">Interactive model</p>
+            <h1 id="atlas-hero-heading" className="font-semibold text-telcoin-ink text-4xl sm:text-5xl lg:text-6xl mt-3">
+              Network Atlas
+            </h1>
+            <p className="w-full max-w-3xl text-telcoin-ink-muted mt-4 mx-auto text-center text-base sm:text-lg">
+              Telcoin Network splits its work in two: a <strong>DAG-based consensus layer</strong> decides the
+              order of transactions, and a <strong>Reth-based EVM</strong> executes it. The scene below runs the
+              consensus half live — four validator lanes, one certificate each per round, each anchored to a
+              quorum of parents in the round before it. When a leader wins quorum support, its whole causal
+              history commits at once, the gold wave sweeping back through the graph. Switch to{' '}
+              <strong>Ecosystem</strong> to orbit how TEL, the network, TELx, the wallet and Digital Cash connect.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <NetworkAtlas />
+
+      <section className="mx-auto w-full max-w-[min(1120px,92vw)] px-4 sm:px-8 py-10 sm:py-14">
+        <div className="grid gap-4 sm:grid-cols-3">
+          <a className="atlas-deeper-card" href="/protocol#proto-consensus">
+            <span className="atlas-deeper-kicker">Read more</span>
+            <span className="atlas-deeper-title">Narwhal &amp; Bullshark</span>
+            <span className="atlas-deeper-body">How the DAG mempool and the leader-election protocol actually work.</span>
+          </a>
+          <a className="atlas-deeper-card" href="/protocol#proto-lifecycle">
+            <span className="atlas-deeper-kicker">Read more</span>
+            <span className="atlas-deeper-title">Transaction lifecycle</span>
+            <span className="atlas-deeper-body">Signature to irreversible finality, in under half a second.</span>
+          </a>
+          <a className="atlas-deeper-card" href="/deep-dive#deep-tokenomics">
+            <span className="atlas-deeper-kicker">Read more</span>
+            <span className="atlas-deeper-title">TEL tokenomics</span>
+            <span className="atlas-deeper-body">Fixed supply, 2 decimals, and where the current holder count stands.</span>
+          </a>
+        </div>
+        <p className="mt-8 text-sm text-telcoin-ink-subtle max-w-3xl mx-auto text-center">
+          Protocol internals are grounded in the{' '}
+          <a
+            href="https://deepwiki.com/Telcoin-Association/telcoin-network"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-telcoin-accent hover:underline"
+          >
+            Telcoin-Association/telcoin-network
+          </a>{' '}
+          source as documented on DeepWiki — the component names used here (Worker, Proposer, Certifier,
+          Bullshark, CommittedSubDag, ConsensusOutput) are the ones in the codebase. The simulation is a faithful
+          illustration of the protocol&rsquo;s shape, not a live feed of mainnet: round timing, validator count and
+          parent selection are stylised for legibility. Ecosystem facts come from Telcoin&rsquo;s official
+          documentation and public announcements — see the{' '}
+          <a href="/protocol#proto-sources" className="text-telcoin-accent hover:underline">
+            documentation index
+          </a>{' '}
+          for primary sources.
+        </p>
+      </section>
+    </>
+  )
+}

--- a/telcoinwiki-react/src/pages/DeepDivePage.tsx
+++ b/telcoinwiki-react/src/pages/DeepDivePage.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense } from 'react'
+import { Link } from 'react-router-dom'
 
 // Lazy load DeepDiveFaqSections to reduce initial bundle size
 const DeepDiveFaqSections = lazy(() => import('../components/deepDive/DeepDiveFaqSections').then(module => ({ default: module.DeepDiveFaqSections })))
@@ -74,6 +75,11 @@ export function DeepDivePage() {
               Glossary & Sources
             </a>
           </nav>
+
+          <div className="atlas-callout">
+            <p>Consensus, TEL and the wallet — this ecosystem, orbitable in 3D.</p>
+            <Link to="/atlas">Open the Network Atlas →</Link>
+          </div>
           </div>
         </div>
       </section>

--- a/telcoinwiki-react/src/pages/ProtocolPage.tsx
+++ b/telcoinwiki-react/src/pages/ProtocolPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { useLocation } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 import { PROTOCOL_SECTIONS } from '../components/protocol/sections'
 import type { ProtocolSection } from '../components/protocol/sections'
 
@@ -128,6 +128,11 @@ export function ProtocolPage() {
                 </a>
               ))}
             </nav>
+
+            <div className="atlas-callout">
+              <p>Prefer to see it move? Consensus and the ecosystem, as a live 3D model.</p>
+              <Link to="/atlas">Open the Network Atlas →</Link>
+            </div>
           </div>
         </div>
       </section>

--- a/telcoinwiki-react/src/styles/site.css
+++ b/telcoinwiki-react/src/styles/site.css
@@ -5358,3 +5358,209 @@ mark {
 
 
 
+
+/* ============================================================
+   Network Atlas — interactive WebGL scene (/atlas)
+   Built from the site's own tokens; the canvas itself commits
+   to a near-black ground because the emissive scene only reads
+   on a dark surface, but every panel around it uses --tc-*.
+   ============================================================ */
+.atlas-stage {
+  position: relative;
+  width: 100%;
+  height: min(78vh, 760px);
+  min-height: 460px;
+  overflow: hidden;
+  background: radial-gradient(120% 90% at 50% 0%, #0d1420 0%, #04070c 62%);
+  border-bottom: 1px solid var(--tc-border);
+}
+.atlas-canvas { display: block; width: 100%; height: 100%; touch-action: none; cursor: grab; }
+.atlas-canvas--dragging { cursor: grabbing; }
+
+.atlas-nogl {
+  position: absolute; inset: 0; display: none; place-items: center; text-align: center; padding: 2rem;
+}
+.atlas-nogl p { max-width: 46ch; color: var(--tc-ink-subtle); }
+.atlas-nogl-kicker {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  color: var(--tc-accent); font-size: 0.7rem; letter-spacing: 0.18em; text-transform: uppercase;
+}
+.atlas-nogl a { color: var(--tc-accent); }
+.atlas-stage[data-atlas-failed='true'] .atlas-nogl { display: grid; }
+.atlas-stage[data-atlas-failed='true'] .atlas-canvas { display: none; }
+
+.atlas-labels { position: absolute; inset: 0; pointer-events: none; }
+.atlas-label {
+  position: absolute; transform: translate(-50%, -50%);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; white-space: nowrap;
+  color: rgba(232, 242, 245, 0.72);
+  text-shadow: 0 0 12px #04070c, 0 0 4px #04070c;
+  transition: color 0.2s ease, opacity 0.2s ease;
+}
+.atlas-label--strong { color: #fff; font-size: 12px; }
+.atlas-label--cyan { color: var(--tc-accent); }
+.atlas-label--gold { color: var(--tc-gold); }
+
+/* ---------------- HUD chrome ---------------- */
+.atlas-hud { position: absolute; pointer-events: none; }
+.atlas-hud > * { pointer-events: auto; }
+.atlas-glass {
+  background: rgba(14, 22, 33, 0.72);
+  -webkit-backdrop-filter: blur(14px) saturate(1.2);
+  backdrop-filter: blur(14px) saturate(1.2);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius);
+}
+
+.atlas-hud--tl { top: 14px; left: 14px; }
+.atlas-scenes { display: inline-flex; padding: 4px; gap: 3px; }
+.atlas-scene-btn {
+  font: inherit; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--tc-ink-subtle); background: transparent; border: 0; cursor: pointer;
+  padding: 8px 13px; border-radius: 8px; transition: color 0.18s ease, background 0.18s ease;
+}
+.atlas-scene-btn[aria-selected='true'] { color: #06121a; background: #e6f0f2; font-weight: 700; }
+.atlas-scene-btn:hover:not([aria-selected='true']) { color: var(--tc-ink); background: rgba(255, 255, 255, 0.06); }
+.atlas-scene-btn:focus-visible { outline: 2px solid var(--tc-accent); outline-offset: 2px; }
+
+.atlas-hud--tr { top: 14px; right: 14px; display: flex; gap: 8px; }
+.atlas-icon-btn {
+  width: 36px; height: 36px; display: grid; place-items: center; cursor: pointer;
+  background: rgba(14, 22, 33, 0.72); border: 1px solid var(--tc-border); border-radius: 10px;
+  color: var(--tc-ink-subtle); transition: color 0.18s ease, border-color 0.18s ease;
+  -webkit-backdrop-filter: blur(14px); backdrop-filter: blur(14px);
+}
+.atlas-icon-btn:hover { color: var(--tc-ink); border-color: var(--tc-border-strong); }
+.atlas-icon-btn:focus-visible { outline: 2px solid var(--tc-accent); outline-offset: 2px; }
+.atlas-icon-btn svg { width: 16px; height: 16px; }
+.atlas-icon-btn .atlas-icon-pause { display: none; }
+.atlas-icon-btn--playing .atlas-icon-play { display: none; }
+.atlas-icon-btn--playing .atlas-icon-pause { display: block; }
+
+.atlas-hud--bl { left: 14px; bottom: 14px; max-width: min(320px, calc(100vw - 28px)); }
+.atlas-readout { padding: 12px 14px; display: grid; gap: 8px; }
+.atlas-readout-title {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 9.5px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--tc-ink-subtle);
+}
+.atlas-stats { display: flex; gap: 14px; flex-wrap: wrap; }
+.atlas-stat b {
+  display: block; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 18px; font-weight: 700; color: #fff; font-variant-numeric: tabular-nums; line-height: 1.1;
+}
+.atlas-stat i {
+  font-style: normal; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 9px; letter-spacing: 0.11em; text-transform: uppercase; color: var(--tc-ink-subtle);
+}
+.atlas-stat--gold b { color: var(--tc-gold); }
+.atlas-stat--cyan b { color: var(--tc-accent); }
+
+.atlas-legend { display: grid; gap: 5px; padding-top: 3px; border-top: 1px solid var(--tc-border); }
+.atlas-legend-row {
+  display: flex; align-items: center; gap: 8px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 10px; color: var(--tc-ink-subtle); letter-spacing: 0.03em;
+}
+.atlas-legend-row i { width: 9px; height: 9px; border-radius: 50%; flex: none; }
+
+.atlas-hud--br { right: 14px; bottom: 14px; width: min(320px, calc(100vw - 28px)); max-height: min(58%, 440px); overflow-y: auto; }
+.atlas-inspect { padding: 14px 16px; }
+.atlas-inspect-kicker {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 9.5px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--tc-accent);
+}
+.atlas-inspect--gold .atlas-inspect-kicker { color: var(--tc-gold); }
+.atlas-inspect--neutral .atlas-inspect-kicker { color: var(--tc-ink-subtle); }
+.atlas-inspect h3 { margin: 6px 0 0; font-size: 1rem; font-weight: 700; letter-spacing: -0.01em; color: #fff; }
+.atlas-inspect p { margin: 8px 0 0; font-size: 0.82rem; color: rgba(232, 242, 245, 0.78); line-height: 1.6; }
+.atlas-facts { list-style: none; margin: 11px 0 0; padding: 0; display: grid; gap: 6px; }
+.atlas-facts li {
+  position: relative; padding-left: 14px; font-size: 0.78rem; color: rgba(232, 242, 245, 0.7); line-height: 1.5;
+}
+.atlas-facts li::before {
+  content: ''; position: absolute; left: 0; top: 7px; width: 5px; height: 5px; border-radius: 50%;
+  background: var(--tc-accent);
+}
+.atlas-inspect--gold .atlas-facts li::before { background: var(--tc-gold); }
+.atlas-inspect--neutral .atlas-facts li::before { background: var(--tc-ink-subtle); }
+
+.atlas-learn-more {
+  display: inline-flex; margin-top: 12px; font-size: 0.78rem; font-weight: 600;
+  color: var(--tc-accent); text-decoration: none;
+}
+.atlas-learn-more:hover, .atlas-learn-more:focus-visible { text-decoration: underline; }
+.atlas-inspect--gold .atlas-learn-more { color: var(--tc-gold-strong); }
+
+.atlas-kv { margin: 12px 0 0; display: grid; gap: 5px; }
+.atlas-kv div { display: flex; justify-content: space-between; gap: 12px; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 10.5px; }
+.atlas-kv-k { color: var(--tc-ink-subtle); letter-spacing: 0.06em; text-transform: uppercase; }
+.atlas-kv-v { color: #fff; text-align: right; font-variant-numeric: tabular-nums; }
+
+.atlas-jump { margin-top: 12px; display: flex; gap: 5px; flex-wrap: wrap; }
+.atlas-jump button {
+  font: inherit; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 10px; letter-spacing: 0.05em; cursor: pointer;
+  color: var(--tc-ink-subtle); background: rgba(255, 255, 255, 0.04); border: 1px solid var(--tc-border);
+  padding: 4px 9px; border-radius: 999px; transition: color 0.16s ease, border-color 0.16s ease;
+}
+.atlas-jump button:hover { color: var(--tc-accent); border-color: var(--tc-accent); }
+.atlas-jump button:focus-visible { outline: 2px solid var(--tc-accent); outline-offset: 2px; }
+
+.atlas-hint {
+  position: absolute; left: 50%; bottom: 14px; transform: translateX(-50%);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--tc-ink-subtle); pointer-events: none; transition: opacity 0.5s ease;
+}
+.atlas-hint--gone { opacity: 0; }
+@media (prefers-reduced-motion: reduce) { .atlas-hint { transition: none; } }
+
+@media (max-width: 640px) {
+  .atlas-stage { height: min(64vh, 560px); min-height: 420px; }
+  .atlas-hud--bl { max-width: min(200px, calc(52vw - 20px)); }
+  .atlas-legend { display: none; }
+  .atlas-hint { display: none; }
+  .atlas-readout { padding: 9px 11px; }
+  .atlas-stats { gap: 10px; }
+  .atlas-stat b { font-size: 15px; }
+}
+
+/* ---------------- Cross-link callouts (Deep Dive / Protocol heroes) ---------------- */
+.atlas-callout {
+  display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; justify-content: center;
+  margin-top: var(--space-6);
+  padding: 0.85rem 1.1rem;
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius);
+  background: rgba(255, 255, 255, 0.03);
+}
+.atlas-callout p { margin: 0; color: var(--tc-ink-muted); font-size: 0.88rem; }
+.atlas-callout a {
+  display: inline-flex; align-items: center; gap: 0.35rem; flex: none;
+  font-size: 0.85rem; font-weight: 600; color: var(--tc-accent); text-decoration: none;
+  white-space: nowrap;
+}
+.atlas-callout a:hover, .atlas-callout a:focus-visible { text-decoration: underline; }
+
+.atlas-deeper-card {
+  display: flex; flex-direction: column; gap: 0.3rem;
+  padding: 1.1rem 1.2rem;
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius);
+  background: rgba(255, 255, 255, 0.03);
+  text-decoration: none;
+  transition: border-color 0.18s ease, background 0.18s ease, transform 0.18s ease;
+}
+.atlas-deeper-card:hover, .atlas-deeper-card:focus-visible {
+  border-color: var(--tc-border-strong);
+  background: rgba(255, 255, 255, 0.06);
+  transform: translateY(-1px);
+}
+.atlas-deeper-kicker {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.66rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--tc-accent);
+}
+.atlas-deeper-title { font-size: 1rem; font-weight: 700; color: var(--tc-ink); }
+.atlas-deeper-body { font-size: 0.85rem; color: var(--tc-ink-muted); line-height: 1.5; }

--- a/telcoinwiki-react/src/styles/tokens.css
+++ b/telcoinwiki-react/src/styles/tokens.css
@@ -53,4 +53,11 @@
   --tc-radius: 1rem;
   --tc-radius-lg: 1.25rem;
   --tc-shadow: 0 8px 24px rgba(5, 7, 20, 0.35);
+
+  /* Semantic-only accent, not a brand color: distinguishes "regulated fiat
+     money" (Digital Cash, the Bank) from network/token concepts across the
+     Network Atlas visualization. Never use for anything else. */
+  --tc-gold: #f0bf63;
+  --tc-gold-soft: rgba(240, 191, 99, 0.16);
+  --tc-gold-strong: #f7d493;
 }

--- a/telcoinwiki-react/tools/build-search-index.mjs
+++ b/telcoinwiki-react/tools/build-search-index.mjs
@@ -67,6 +67,7 @@ async function loadContentModules() {
         export { faqItems, faqGroups } from ${JSON.stringify(join(projectRoot, 'src/components/faq/data.tsx'))}
         export { SECTIONS } from ${JSON.stringify(join(projectRoot, 'src/components/deepDive/sections.tsx'))}
         export { PROTOCOL_SECTIONS } from ${JSON.stringify(join(projectRoot, 'src/components/protocol/sections.tsx'))}
+        export { ECOSYSTEM, ECOSYSTEM_IDS } from ${JSON.stringify(join(projectRoot, 'src/lib/atlas/data.ts'))}
       `,
       resolveDir: projectRoot,
       loader: 'ts',
@@ -148,24 +149,51 @@ const PAGE_DOCS = [
     tags: ['Deep Dive', 'Reference'],
     headings: [],
   },
+  {
+    id: 'atlas',
+    title: 'Network Atlas — an interactive 3D model of Telcoin',
+    summary:
+      'A live, orbitable WebGL model: the Narwhal/Bullshark consensus DAG simulated round by round, and an ecosystem graph connecting TEL, Telcoin Network, GSMA validators, TELx, the wallet, Digital Cash and the Digital Asset Bank.',
+    url: '/atlas',
+    tags: ['Atlas', 'Interactive', '3D'],
+    // Populated below from the real ecosystem entity data, not hand-copied.
+    headings: [],
+  },
 ]
 
 async function main() {
   const { modules, cleanup } = await loadContentModules()
 
   try {
-    const { faqItems, faqGroups, SECTIONS, PROTOCOL_SECTIONS } = modules
+    const { faqItems, faqGroups, SECTIONS, PROTOCOL_SECTIONS, ECOSYSTEM, ECOSYSTEM_IDS } = modules
 
-    if (!Array.isArray(faqItems) || !Array.isArray(SECTIONS) || !Array.isArray(PROTOCOL_SECTIONS)) {
+    if (
+      !Array.isArray(faqItems) ||
+      !Array.isArray(SECTIONS) ||
+      !Array.isArray(PROTOCOL_SECTIONS) ||
+      !Array.isArray(ECOSYSTEM_IDS) ||
+      typeof ECOSYSTEM !== 'object'
+    ) {
       throw new Error('content modules did not export the expected arrays')
     }
 
     const faqDocs = buildFaqDocs(faqItems, faqGroups)
     const deepDocs = buildSectionDocs(SECTIONS, '/deep-dive')
     const protoDocs = buildSectionDocs(PROTOCOL_SECTIONS, '/protocol')
-    const sectionDocs = [...deepDocs, ...protoDocs]
+    // Ecosystem entities aren't accordion sections — each is a node in the
+    // WebGL scene, deep-linked via query params rather than a hash anchor.
+    const atlasDocs = ECOSYSTEM_IDS.map((id) => {
+      const entity = ECOSYSTEM[id]
+      return {
+        id: `atlas-${id}`,
+        title: entity.label,
+        body: [entity.kicker, entity.body, ...entity.facts].join(' — '),
+        url: `/atlas?scene=eco&node=${id}`,
+      }
+    })
+    const sectionDocs = [...deepDocs, ...protoDocs, ...atlasDocs]
 
-    const headingsFor = { 'deep-dive': deepDocs, protocol: protoDocs }
+    const headingsFor = { 'deep-dive': deepDocs, protocol: protoDocs, atlas: atlasDocs }
     const pageDocs = PAGE_DOCS.map((page) =>
       headingsFor[page.id]
         ? { ...page, headings: headingsFor[page.id].map((s) => ({ id: s.id, title: s.title })) }
@@ -189,7 +217,13 @@ async function main() {
         title: section.title,
         summary: section.body.slice(0, 240),
         url: section.url,
-        tags: [section.url.startsWith('/protocol') ? 'Protocol' : 'Deep Dive'],
+        tags: [
+          section.url.startsWith('/protocol')
+            ? 'Protocol'
+            : section.url.startsWith('/atlas')
+              ? 'Atlas'
+              : 'Deep Dive',
+        ],
         headings: [],
         body: section.body,
       })),
@@ -201,7 +235,7 @@ async function main() {
 
     const bytes = (o) => (JSON.stringify(o).length / 1024).toFixed(1)
     console.log(
-      `[search-index] ${searchIndex.length} docs (${pageDocs.length} pages, ${deepDocs.length} deep-dive + ${protoDocs.length} protocol sections, ${bytes(searchIndex)} kB) + ${faqDocs.length} FAQ entries (${bytes(faqDocs)} kB)`,
+      `[search-index] ${searchIndex.length} docs (${pageDocs.length} pages, ${deepDocs.length} deep-dive + ${protoDocs.length} protocol + ${atlasDocs.length} atlas sections, ${bytes(searchIndex)} kB) + ${faqDocs.length} FAQ entries (${bytes(faqDocs)} kB)`,
     )
   } finally {
     await cleanup()


### PR DESCRIPTION
## Summary

Ports the standalone WebGL "Telcoin Network Atlas" artifact (built earlier this session) into a real `/atlas` route — rebuilt for the site rather than dropped in as-is.

- **Rewritten as typed, per-instance TypeScript**, not a page-scoped IIFE: `lib/atlas/mat4.ts` (matrix math), `lib/atlas/data.ts` (ecosystem/consensus data), `lib/atlas/engine.ts` (the WebGL engine), `components/atlas/NetworkAtlas.tsx` (the React shell). All simulation/camera/picking state lives inside the engine's closure so multiple mounts can never share state.
- **Full lifecycle correctness for an SPA.** The artifact was a static page that never unmounted; this route can mount/unmount many times per session. `destroy()` cancels the rAF handle, aborts every listener via one `AbortController`, disconnects both observers, deletes GL buffers/programs, and proactively releases the WebGL context via `WEBGL_lose_context` rather than waiting on GC. Verified with 3x real SPA navigate-away-and-back — zero console errors, still renders.
- **Own visual identity, not a foreign console.** HUD restyled from the site's own `--tc-*` tokens instead of a bespoke palette. Added one new semantic pair, `--tc-gold` / `--tc-gold-soft`, for "regulated money" vs "network machine" — explicitly not a brand color. Dropped the artifact's own brand bar since the real header does that job.
- **Two new capabilities the standalone page didn't need:** pauses the render loop when the tab is hidden or the stage scrolls out of view (`IntersectionObserver` + `visibilitychange`); `/atlas?scene=eco&node=<id>` deep links pre-select a scene and entity, wired into the search index generator so searching "Digital Asset Bank" lands pre-focused on that exact node in the 3D graph.
- **Grounded in the rest of the wiki.** Every ecosystem entity's inspector links to its matching Deep Dive/Protocol section (TEL → `/protocol#proto-token`, TELx → `/deep-dive#deep-incentives`, etc.), and the DAG inspector links to consensus/lifecycle. These are real `<a>` tags with a delegated click handler that hands plain left-clicks to the router instead of a full reload. Added matching callouts on the Protocol and Deep Dive heroes.
- **Lazy-loaded route** (12.4 kB gzipped), off every other page's bundle.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npx jest` — 24 new tests, 77 total across 11 suites: mat4 correctness (identity, `lookAt` orthonormality, `perspective`/`projectPoint` clip-space behavior), ecosystem data integrity (every `href` resolves to a real section — regression guard, same shape as the existing anchor tests — no orphan nodes, genuine 2f+1 quorum), full route/nav/header/mega-menu wiring, and the no-WebGL fallback path (stubbed deterministically since jsdom's `getContext('webgl2')` isn't consistent across versions)
- [x] `jest.config.ts` `testMatch` extended to cover `src/lib/**/__tests__/**` — the existing glob only covered `components/` and `hooks/`, so these wouldn't have run at all otherwise
- [x] `npm run lint` — unchanged at the pre-existing 10 problems, none new
- [x] `npm run build` clean
- [x] Real-browser pass, 48 checks: WebGL renders and draws real pixels, DAG simulation advances and commits, play/pause/resume, certificate and ecosystem-entity picking, cross-reference jump chips, SPA-navigating "Learn more" links (confirmed no full reload), header/mega-menu/callout navigation, 3x remount survival, valid and invalid deep-link query params, viewport-intersection pause verified with genuine occlusion, 390px/768px with no overflow, search surfacing the new per-entity `/atlas` docs

See `CHANGELOG.md` for full details.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UucW9gAXvDRmDDD8SQpyzC)_