### PR TITLE
Fix homepage sticky sub-cards never engaging position: sticky

### DIFF
--- a/telcoinwiki-react/src/components/cinematic/SlidingStack.tsx
+++ b/telcoinwiki-react/src/components/cinematic/SlidingStack.tsx
@@ -378,8 +378,63 @@ export function SlidingStack({
     return <CardContent item={item} prefersReducedMotion={prefersReducedMotion} />
   }, [prefersReducedMotion])
 
-  // Calculate container height and CSS variables for sticky positioning
-  // Optimized to match avax.network's approach (100lvh per card)
+  // Measured deck height, in px. Null until the first real layout pass —
+  // see the effect below for why this can't be a flat vh-based formula.
+  const [measuredHeight, setMeasuredHeight] = useState<number | null>(null)
+
+  // The deck's forced height must be tall enough that the LAST card's natural
+  // (pre-sticky) flow position — cumulative margin-top + height of every card
+  // before it, plus its own height — still ends before the deck's own bottom
+  // edge. Position: sticky can only ever hold a card at `top` while the
+  // element's static position hasn't reached the container's bottom yet; if
+  // the container is shorter than that cumulative offset, the sticky window
+  // is negative and the card never sticks at all — it just tracks scroll 1:1.
+  // A flat `viewportHeight * (0.5 + cardCount * 0.8)` heuristic can't know
+  // this, because per-card margins (the 60vh push-down on the first card,
+  // the header-height push on the second) and real content height (text +
+  // optional image) aren't fixed multiples of the viewport. So measure it.
+  useLayoutEffect(() => {
+    if (typeof window === 'undefined' || !enableStickyStack) return
+
+    const measure = () => {
+      if (window.innerWidth <= 768) return // mobile uses static layout, not sticky stacking
+
+      const cards = cardRefs.current.filter((card): card is HTMLElement => card !== null)
+      if (cards.length === 0) return
+
+      let contentHeight = 0
+      cards.forEach((card) => {
+        const marginTop = parseFloat(getComputedStyle(card).marginTop) || 0
+        contentHeight += marginTop + card.getBoundingClientRect().height
+      })
+
+      // Real dwell room for the last card to hold its pinned position before
+      // the section ends, instead of overflowing straight through it.
+      const stickWindow = window.innerHeight * 0.9
+      setMeasuredHeight(Math.round(contentHeight + stickWindow))
+    }
+
+    measure()
+
+    const cards = cardRefs.current.filter((card): card is HTMLElement => card !== null)
+    const resizeObserver = new ResizeObserver(measure)
+    cards.forEach((card) => resizeObserver.observe(card))
+
+    let resizeTimeout: ReturnType<typeof setTimeout> | null = null
+    const handleResize = () => {
+      if (resizeTimeout !== null) clearTimeout(resizeTimeout)
+      resizeTimeout = setTimeout(measure, 150)
+    }
+    window.addEventListener('resize', handleResize, { passive: true })
+
+    return () => {
+      resizeObserver.disconnect()
+      window.removeEventListener('resize', handleResize)
+      if (resizeTimeout !== null) clearTimeout(resizeTimeout)
+    }
+  }, [enableStickyStack, items.length])
+
+  // Calculate CSS variables for sticky positioning
   const cssVars = useMemo(() => {
     if (!enableStickyStack) {
       return {} as CSSProperties
@@ -387,15 +442,12 @@ export function SlidingStack({
 
     const viewportHeight = typeof window !== 'undefined' ? window.innerHeight : 800
     const cardCount = items.length
-    
-    // Container height calculation (matches avax.network pattern)
-    // avax.network uses 100lvh (large viewport height) per card
-    // Cards stack within this space, so we need enough height for all cards
-    // Formula: Base offset + (cardCount * viewport height)
-    // Base: 0.5 viewport for initial positioning
-    // Per card: 0.8 viewport (cards overlap, so less than 1.0)
-    const containerHeight = viewportHeight * (0.5 + (cardCount * 0.8))
-    
+
+    // Fallback for the very first paint, before the measurement effect above
+    // has run — avoids a zero-height flash. Real layout always overrides it.
+    const fallbackHeight = viewportHeight * (0.5 + (cardCount * 0.8))
+    const containerHeight = measuredHeight ?? fallbackHeight
+
     // Tab height is set via CSS and doesn't need dynamic calculation
     const tabHeight = 88
 
@@ -408,9 +460,9 @@ export function SlidingStack({
       '--card-count': String(cardCount),
       '--card-tab-offset': `${tabHeight}px`,
     }
-    
+
     return vars
-  }, [items.length, enableStickyStack])
+  }, [items.length, enableStickyStack, measuredHeight])
 
   // Copy CSS variable from SlidingStack container to parent section
   // This allows the section to use --sticky-container-height in its height calculation

--- a/telcoinwiki-react/src/hooks/useHomeScrollSections.ts
+++ b/telcoinwiki-react/src/hooks/useHomeScrollSections.ts
@@ -72,8 +72,11 @@ export function useHomeBrokenMoneyScroll(): SlidingSectionState {
     }
   }
 
-// Second section: Measure section 1's main card height and position section 2 accordingly
-export function useHomeSection2Scroll(): SlidingSectionState {
+// Sections 2-5 share one shape: measure the PREVIOUS section's main card
+// height and offset this section by half of it, so each section's stack
+// starts right where the one before it released. Only the previous
+// section's DOM id differs between them.
+function useHomeCascadedSectionScroll(previousSectionId: string): SlidingSectionState {
   const sectionRef = useRef<HTMLElement | null>(null)
   const systemPrefersReducedMotion = usePrefersReducedMotion()
   const isHandheld = useMediaQuery('(max-width: 40rem)')
@@ -84,23 +87,22 @@ export function useHomeSection2Scroll(): SlidingSectionState {
   const [stackProgress, setStackProgress] = useState(0)
   const [mainCardOffset, setMainCardOffset] = useState<number | undefined>(undefined)
 
-  // Measure section 1's main card height and set offset for section 2
   useEffect(() => {
     if (typeof window === 'undefined' || prefersReducedMotion) {
       return
     }
 
-    const section1 = document.getElementById('home-broken-money')
-    if (!section1) return
+    const previousSection = document.getElementById(previousSectionId)
+    if (!previousSection) return
 
     const measureAndSetOffset = () => {
-      const section1MainCard = section1.querySelector<HTMLElement>('[data-sticky-module-lead]')
-      if (!section1MainCard) return
+      const previousMainCard = previousSection.querySelector<HTMLElement>('[data-sticky-module-lead]')
+      if (!previousMainCard) return
 
       // Measure the main card's height
-      const mainCardHeight = section1MainCard.getBoundingClientRect().height
-      
-      // Set the offset to half the main card height - section 2 should position itself 1/2 height down
+      const mainCardHeight = previousMainCard.getBoundingClientRect().height
+
+      // Set the offset to half the main card height - this section should position itself 1/2 height down
       setMainCardOffset(mainCardHeight / 2)
     }
 
@@ -129,7 +131,7 @@ export function useHomeSection2Scroll(): SlidingSectionState {
       }
       window.removeEventListener('resize', handleResize)
     }
-  }, [prefersReducedMotion])
+  }, [prefersReducedMotion, previousSectionId])
 
   // Sticky style matches first section (no special positioning)
   const stickyStyle = useMemo(() => {
@@ -148,238 +150,24 @@ export function useHomeSection2Scroll(): SlidingSectionState {
     stackCardsEnabled: true, // Always enabled - no special timing
     sectionOffset: mainCardOffset, // Pass measured height for CSS positioning
   }
+}
+
+// Second section: Measure section 1's main card height and position section 2 accordingly
+export function useHomeSection2Scroll(): SlidingSectionState {
+  return useHomeCascadedSectionScroll('home-broken-money')
 }
 
 // Third section: Measure section 2's main card height and position section 3 accordingly
 export function useHomeSection3Scroll(): SlidingSectionState {
-  const sectionRef = useRef<HTMLElement | null>(null)
-  const systemPrefersReducedMotion = usePrefersReducedMotion()
-  const isHandheld = useMediaQuery('(max-width: 40rem)')
-  const prefersReducedMotion = systemPrefersReducedMotion || isHandheld
-
-  const introStyle = useMemo(() => createFadeInStyle(prefersReducedMotion), [prefersReducedMotion])
-  const stackStyle = useMemo(() => createFadeInStyle(prefersReducedMotion), [prefersReducedMotion])
-  const [stackProgress, setStackProgress] = useState(0)
-  const [mainCardOffset, setMainCardOffset] = useState<number | undefined>(undefined)
-
-  // Measure section 2's main card height and set offset for section 3
-  useEffect(() => {
-    if (typeof window === 'undefined' || prefersReducedMotion) {
-      return
-    }
-
-    const section2 = document.getElementById('home-section-2')
-    if (!section2) return
-
-    const measureAndSetOffset = () => {
-      const section2MainCard = section2.querySelector<HTMLElement>('[data-sticky-module-lead]')
-      if (!section2MainCard) return
-
-      // Measure the main card's height
-      const mainCardHeight = section2MainCard.getBoundingClientRect().height
-      
-      // Set the offset to half the main card height - section 3 should position itself 1/2 height down
-      setMainCardOffset(mainCardHeight / 2)
-    }
-
-    // Measure after layout
-    const rafId = requestAnimationFrame(() => {
-      measureAndSetOffset()
-    })
-
-    // Re-measure on resize with debouncing (150ms delay for better performance)
-    let resizeTimeout: ReturnType<typeof setTimeout> | null = null
-    const handleResize = () => {
-      if (resizeTimeout !== null) {
-        clearTimeout(resizeTimeout)
-      }
-      resizeTimeout = setTimeout(() => {
-        measureAndSetOffset()
-        resizeTimeout = null
-      }, 150)
-    }
-    window.addEventListener('resize', handleResize, { passive: true })
-
-    return () => {
-      cancelAnimationFrame(rafId)
-      if (resizeTimeout !== null) {
-        clearTimeout(resizeTimeout)
-      }
-      window.removeEventListener('resize', handleResize)
-    }
-  }, [prefersReducedMotion])
-
-  // Sticky style matches first section (no special positioning)
-  const stickyStyle = useMemo(() => {
-    return prefersReducedMotion ? undefined : { top: '20vh' }
-  }, [prefersReducedMotion])
-
-    return {
-    sectionRef,
-    prefersReducedMotion,
-    stageProgress: 1,
-    stackProgress,
-    introStyle,
-    stackStyle,
-    stickyStyle,
-    onStackProgress: prefersReducedMotion ? undefined : setStackProgress,
-    stackCardsEnabled: true, // Always enabled - no special timing
-    sectionOffset: mainCardOffset, // Pass measured height for CSS positioning
-  }
+  return useHomeCascadedSectionScroll('home-section-2')
 }
 
 // Fourth section: Measure section 3's main card height and position section 4 accordingly
 export function useHomeSection4Scroll(): SlidingSectionState {
-  const sectionRef = useRef<HTMLElement | null>(null)
-  const systemPrefersReducedMotion = usePrefersReducedMotion()
-  const isHandheld = useMediaQuery('(max-width: 40rem)')
-  const prefersReducedMotion = systemPrefersReducedMotion || isHandheld
-
-  const introStyle = useMemo(() => createFadeInStyle(prefersReducedMotion), [prefersReducedMotion])
-  const stackStyle = useMemo(() => createFadeInStyle(prefersReducedMotion), [prefersReducedMotion])
-  const [stackProgress, setStackProgress] = useState(0)
-  const [mainCardOffset, setMainCardOffset] = useState<number | undefined>(undefined)
-
-  // Measure section 3's main card height and set offset for section 4
-  useEffect(() => {
-    if (typeof window === 'undefined' || prefersReducedMotion) {
-      return
-    }
-
-    const section3 = document.getElementById('home-section-3')
-    if (!section3) return
-
-    const measureAndSetOffset = () => {
-      const section3MainCard = section3.querySelector<HTMLElement>('[data-sticky-module-lead]')
-      if (!section3MainCard) return
-
-      // Measure the main card's height
-      const mainCardHeight = section3MainCard.getBoundingClientRect().height
-      
-      // Set the offset to half the main card height - section 4 should position itself 1/2 height down
-      setMainCardOffset(mainCardHeight / 2)
-    }
-
-    // Measure after layout
-    const rafId = requestAnimationFrame(() => {
-      measureAndSetOffset()
-    })
-
-    // Re-measure on resize with debouncing (150ms delay for better performance)
-    let resizeTimeout: ReturnType<typeof setTimeout> | null = null
-    const handleResize = () => {
-      if (resizeTimeout !== null) {
-        clearTimeout(resizeTimeout)
-      }
-      resizeTimeout = setTimeout(() => {
-        measureAndSetOffset()
-        resizeTimeout = null
-      }, 150)
-    }
-    window.addEventListener('resize', handleResize, { passive: true })
-
-    return () => {
-      cancelAnimationFrame(rafId)
-      if (resizeTimeout !== null) {
-        clearTimeout(resizeTimeout)
-      }
-      window.removeEventListener('resize', handleResize)
-    }
-  }, [prefersReducedMotion])
-
-  // Sticky style matches first section (no special positioning)
-  const stickyStyle = useMemo(() => {
-    return prefersReducedMotion ? undefined : { top: '20vh' }
-  }, [prefersReducedMotion])
-
-  return {
-    sectionRef,
-    prefersReducedMotion,
-    stageProgress: 1,
-    stackProgress,
-    introStyle,
-    stackStyle,
-    stickyStyle,
-    onStackProgress: prefersReducedMotion ? undefined : setStackProgress,
-    stackCardsEnabled: true, // Always enabled - no special timing
-    sectionOffset: mainCardOffset, // Pass measured height for CSS positioning
-  }
+  return useHomeCascadedSectionScroll('home-section-3')
 }
 
 // Fifth section: Measure section 4's main card height and position section 5 accordingly
 export function useHomeSection5Scroll(): SlidingSectionState {
-  const sectionRef = useRef<HTMLElement | null>(null)
-  const systemPrefersReducedMotion = usePrefersReducedMotion()
-  const isHandheld = useMediaQuery('(max-width: 40rem)')
-  const prefersReducedMotion = systemPrefersReducedMotion || isHandheld
-
-  const introStyle = useMemo(() => createFadeInStyle(prefersReducedMotion), [prefersReducedMotion])
-  const stackStyle = useMemo(() => createFadeInStyle(prefersReducedMotion), [prefersReducedMotion])
-  const [stackProgress, setStackProgress] = useState(0)
-  const [mainCardOffset, setMainCardOffset] = useState<number | undefined>(undefined)
-
-  // Measure section 4's main card height and set offset for section 5
-  useEffect(() => {
-    if (typeof window === 'undefined' || prefersReducedMotion) {
-      return
-    }
-
-    const section4 = document.getElementById('home-section-4')
-    if (!section4) return
-
-    const measureAndSetOffset = () => {
-      const section4MainCard = section4.querySelector<HTMLElement>('[data-sticky-module-lead]')
-      if (!section4MainCard) return
-
-      // Measure the main card's height
-      const mainCardHeight = section4MainCard.getBoundingClientRect().height
-      
-      // Set the offset to half the main card height - section 5 should position itself 1/2 height down
-      setMainCardOffset(mainCardHeight / 2)
-    }
-
-    // Measure after layout
-    const rafId = requestAnimationFrame(() => {
-      measureAndSetOffset()
-    })
-
-    // Re-measure on resize with debouncing (150ms delay for better performance)
-    let resizeTimeout: ReturnType<typeof setTimeout> | null = null
-    const handleResize = () => {
-      if (resizeTimeout !== null) {
-        clearTimeout(resizeTimeout)
-      }
-      resizeTimeout = setTimeout(() => {
-        measureAndSetOffset()
-        resizeTimeout = null
-      }, 150)
-    }
-    window.addEventListener('resize', handleResize, { passive: true })
-
-    return () => {
-      cancelAnimationFrame(rafId)
-      if (resizeTimeout !== null) {
-        clearTimeout(resizeTimeout)
-      }
-      window.removeEventListener('resize', handleResize)
-    }
-  }, [prefersReducedMotion])
-
-  // Sticky style matches first section (no special positioning)
-  const stickyStyle = useMemo(() => {
-    return prefersReducedMotion ? undefined : { top: '20vh' }
-  }, [prefersReducedMotion])
-
-  return {
-    sectionRef,
-    prefersReducedMotion,
-    stageProgress: 1,
-    stackProgress,
-    introStyle,
-    stackStyle,
-    stickyStyle,
-    onStackProgress: prefersReducedMotion ? undefined : setStackProgress,
-    stackCardsEnabled: true, // Always enabled - no special timing
-    sectionOffset: mainCardOffset, // Pass measured height for CSS positioning
-  }
+  return useHomeCascadedSectionScroll('home-section-4')
 }

--- a/telcoinwiki-react/src/styles/site.css
+++ b/telcoinwiki-react/src/styles/site.css
@@ -3718,67 +3718,16 @@ html.intro-lock-sections .site-main > :not(#home-hero) {
 }
 
 /* First card positioning - ensure it's visible below header when section enters view */
-/* Desktop only */
+/* Desktop only. Every home section (home-broken-money, home-section-2..5) renders
+   through the same StickyModule/SlidingStack loop in HomePage.tsx, so this rule
+   applies uniformly — no per-section ID scoping needed. */
 @media (min-width: 48rem) {
-  /* First card starts with margin to push stack to bottom initially */
   [data-sliding-stack][data-sticky-stack] .sliding-stack__deck > :first-child {
-    /* Push card down initially */
-    margin-top: calc(100vh - var(--header-height, 6.375rem) - var(--padding-md, 1.25rem) - 150px);
-  }
-  
-  /* Ensure first section's first card is visible below header */
-  /* When section first enters viewport, first card should be below header */
-  /* Direct approach: Add large margin-top to first card to push it down */
-  /* Use very specific selector to override any Tailwind classes */
-  #home-broken-money [data-sliding-stack][data-sticky-stack] .sliding-stack__deck > :first-child.sliding-stack__card,
-  #home-broken-money [data-sliding-stack][data-sticky-stack] .sliding-stack__deck > :first-child,
-  #home-broken-money [data-sliding-stack][data-sticky-stack] .sliding-stack__deck > :first-child.color-morph-card {
-    /* Push card down significantly - use actual header height (100.75px) + larger viewport offset */
-    /* This ensures card appears much lower on page when section first enters view */
-    margin-top: calc(60vh + 100.75px + 4rem) !important;
-    margin-bottom: 0 !important;
-}
-
-  /* Section 2: Same styling as first section for consistent behavior */
-  #home-section-2 [data-sliding-stack][data-sticky-stack] .sliding-stack__deck > :first-child.sliding-stack__card,
-  #home-section-2 [data-sliding-stack][data-sticky-stack] .sliding-stack__deck > :first-child,
-  #home-section-2 [data-sliding-stack][data-sticky-stack] .sliding-stack__deck > :first-child.color-morph-card {
-    /* Push card down significantly - use actual header height (100.75px) + larger viewport offset */
-    /* This ensures card appears much lower on page when section first enters view */
+    /* Push card down significantly - use actual header height (100.75px) + larger viewport offset,
+       so it's still below the header when the section first enters view. */
     margin-top: calc(60vh + 100.75px + 4rem) !important;
     margin-bottom: 0 !important;
   }
-
-  /* Section 3: Same styling as first section for consistent behavior */
-  #home-section-3 [data-sliding-stack][data-sticky-stack] .sliding-stack__deck > :first-child.sliding-stack__card,
-  #home-section-3 [data-sliding-stack][data-sticky-stack] .sliding-stack__deck > :first-child,
-  #home-section-3 [data-sliding-stack][data-sticky-stack] .sliding-stack__deck > :first-child.color-morph-card {
-    /* Push card down significantly - use actual header height (100.75px) + larger viewport offset */
-    /* This ensures card appears much lower on page when section first enters view */
-    margin-top: calc(60vh + 100.75px + 4rem) !important;
-    margin-bottom: 0 !important;
-}
-
-  /* Section 4: Same styling as first section for consistent behavior */
-  #home-section-4 [data-sliding-stack][data-sticky-stack] .sliding-stack__deck > :first-child.sliding-stack__card,
-  #home-section-4 [data-sliding-stack][data-sticky-stack] .sliding-stack__deck > :first-child,
-  #home-section-4 [data-sliding-stack][data-sticky-stack] .sliding-stack__deck > :first-child.color-morph-card {
-    /* Push card down significantly - use actual header height (100.75px) + larger viewport offset */
-    /* This ensures card appears much lower on page when section first enters view */
-    margin-top: calc(60vh + 100.75px + 4rem) !important;
-    margin-bottom: 0 !important;
-  }
-
-  /* Section 5: Same styling as first section for consistent behavior */
-  #home-section-5 [data-sliding-stack][data-sticky-stack] .sliding-stack__deck > :first-child.sliding-stack__card,
-  #home-section-5 [data-sliding-stack][data-sticky-stack] .sliding-stack__deck > :first-child,
-  #home-section-5 [data-sliding-stack][data-sticky-stack] .sliding-stack__deck > :first-child.color-morph-card {
-    /* Push card down significantly - use actual header height (100.75px) + larger viewport offset */
-    /* This ensures card appears much lower on page when section first enters view */
-    margin-top: calc(60vh + 100.75px + 4rem) !important;
-    margin-bottom: 0 !important;
-  }
-  
 }
 
 /* Main card (parent) - pure CSS sticky like avax.network */
@@ -3786,10 +3735,11 @@ html.intro-lock-sections .site-main > :not(#home-hero) {
 @media (min-width: 48rem) {
 [data-sticky-module][data-sticky-stack] [data-sticky-module-lead] {
   position: sticky !important;
-    /* Pin when main card's bottom reaches header bottom, then position 30px lower */
-    /* Header height is 100.75px, so pin at 130.75px from top */
-    /* This makes the card's bottom align with header bottom + 30px when it sticks */
-    top: calc(100.75px + 30px) !important;
+    /* Pin when main card's bottom reaches header bottom, then position 55px lower.
+       Header height is 100.75px, so pin at 155.75px from top. Applies uniformly to
+       every home section (home-broken-money, home-section-2..5) — they all render
+       through the same StickyModule loop in HomePage.tsx, so no ID scoping needed. */
+    top: calc(100.75px + 30px + 25px) !important;
   z-index: 2; /* Main card: z-index 2 */
   align-self: start;
   /* Performance optimizations for sticky positioning */
@@ -3797,34 +3747,6 @@ html.intro-lock-sections .site-main > :not(#home-hero) {
   /* Main card unsticks when its containing block (Section) scrolls out */
   /* Removed will-change - sticky positioning doesn't need it */
   /* Section bottom aligns with Deck bottom so all cards release together */
-  }
-  
-  /* First section (Problem): Lower main card pin location by 25px */
-  #home-broken-money[data-sticky-module][data-sticky-stack] [data-sticky-module-lead] {
-    /* Pin location lowered by 25px for problem section */
-    top: calc(100.75px + 30px + 25px) !important;
-  }
-  
-  /* Section 2: Same pin location as first section */
-  /* Main card visibility and stack cards are controlled by JavaScript (introStyle/stackStyle) */
-  #home-section-2[data-sticky-module][data-sticky-stack] [data-sticky-module-lead] {
-    /* Pin location lowered by 25px for section 2 */
-    top: calc(100.75px + 30px + 25px) !important;
-  }
-
-  #home-section-3[data-sticky-module][data-sticky-stack] [data-sticky-module-lead] {
-    /* Pin location lowered by 25px for section 3 - matches sections 1 and 2 */
-    top: calc(100.75px + 30px + 25px) !important;
-  }
-
-  #home-section-4[data-sticky-module][data-sticky-stack] [data-sticky-module-lead] {
-    /* Pin location lowered by 25px for section 4 - matches other sections */
-    top: calc(100.75px + 30px + 25px) !important;
-  }
-
-  #home-section-5[data-sticky-module][data-sticky-stack] [data-sticky-module-lead] {
-    /* Pin location lowered by 25px for section 5 - matches other sections */
-    top: calc(100.75px + 30px + 25px) !important;
   }
 }
 
@@ -3839,63 +3761,6 @@ html.intro-lock-sections .site-main > :not(#home-hero) {
   /* CRITICAL: Use !important to override any content-based height calculations */
   height: var(--sticky-container-height, 400vh) !important;
   min-height: var(--sticky-container-height, 400vh) !important;
-}
-
-/* Target only Section 1 (broken-money / "The Problem") - adjust its main card release timing */
-#home-broken-money[data-sticky-module][data-sticky-stack] {
-  /* Section height remains at full height */
-  /* Keep isolation: auto - isolate breaks sticky positioning */
-  isolation: auto !important;
-  /* CRITICAL: Each section must be completely independent */
-  /* Position relative ensures sticky children are scoped to this section */
-  position: relative;
-  /* Sections are sequential - each must complete before next begins */
-  /* Each section flows naturally in document order - no overlap */
-  display: block;
-}
-
-/* Section 2: Same styling as first section for consistent behavior */
-#home-section-2[data-sticky-module][data-sticky-stack] {
-  /* Section height remains at full height */
-  /* Keep isolation: auto - isolate breaks sticky positioning */
-  isolation: auto !important;
-  /* CRITICAL: Each section must be completely independent */
-  /* Position relative ensures sticky children are scoped to this section */
-  position: relative;
-  /* Sections are sequential - each must complete before next begins */
-  /* Each section flows naturally in document order - no overlap */
-  display: block;
-}
-
-/* Section 3: Same styling as first section for consistent behavior */
-#home-section-3[data-sticky-module][data-sticky-stack] {
-  /* Section height remains at full height */
-  /* Keep isolation: auto - isolate breaks sticky positioning */
-  isolation: auto !important;
-  /* CRITICAL: Each section must be completely independent */
-  /* Position relative ensures sticky children are scoped to this section */
-  position: relative;
-  /* Sections are sequential - each must complete before next begins */
-  /* Each section flows naturally in document order - no overlap */
-  display: block;
-}
-
-/* Section 4: Same styling as first section for consistent behavior */
-#home-section-4[data-sticky-module][data-sticky-stack] {
-  /* Section height remains at full height */
-  /* Keep isolation: auto - isolate breaks sticky positioning */
-  isolation: auto !important;
-  /* CRITICAL: Each section must be completely independent */
-  /* Position relative ensures sticky children are scoped to this section */
-  position: relative;
-  /* Sections are sequential - each must complete before next begins */
-  /* Each section flows naturally in document order - no overlap */
-  display: block;
-}
-
-/* Section 5: Same styling as first section for consistent behavior */
-#home-section-5[data-sticky-module][data-sticky-stack] {
-  /* Section height remains at full height */
   /* Keep isolation: auto - isolate breaks sticky positioning */
   isolation: auto !important;
   /* CRITICAL: Each section must be completely independent */


### PR DESCRIPTION
## Summary

- Root-caused the homepage scroll-mechanics bug tracked in `SCROLL_MECHANICS_ANALYSIS.md`: the **last card in every `SlidingStack`** (all 5 home sections) never actually engaged `position: sticky` — it tracked scroll 1:1 the entire time, with zero stable plateau.
- Cause: `--sticky-container-height` came from a flat `viewportHeight * (0.5 + cardCount * 0.8)` heuristic, decoupled from the real rendered layout. Measured at rest, the last card's natural flow position + height (2954.7px) overflowed **345px past** the deck's forced box height (2610px) — a negative sticky window, so the card could never simultaneously be "at its pinned top" and "still inside its containing block."
- Fix: measure the deck's real required height from the DOM (cumulative margin + rendered height of every card, kept correct via `ResizeObserver` as images load) instead of guessing, plus a genuine stick-window buffer so the last card holds before releasing.
- Also collapsed the duplication this bug was hiding behind:
  - 5 byte-identical per-section-ID CSS overrides (`#home-broken-money`, `#home-section-2..5`) → single shared rules.
  - 4 near-identical `useHomeSection2Scroll`..`useHomeSection5Scroll` hooks → one parameterized `useHomeCascadedSectionScroll(previousSectionId)`.

## Verification

- Ruled out Lenis smooth-scroll interference via a controlled A/B test (temporarily stopping the Lenis instance mid-scroll-scan) before concluding this was a CSS/geometry bug, not a scroll-library timing issue.
- `tsc --noEmit`, `eslint` (back to the pre-existing baseline — no new violations), and `jest` (53/53) all pass.
- Playwright scroll scans against **both** the dev server and the built `vite preview` bundle confirm all 5 home sections now show a genuine stable sticky plateau for the last card (previously none did), with no console errors.
- Confirmed mobile (390×844) still uses the static (non-sticky) layout path and scrolls the full page with no console errors.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npx jest`
- [x] `npm run build` + `npm run preview` scroll verification
- [x] Manual Playwright scroll scan across all 5 home sections, desktop + mobile viewports


---
_Generated by [Claude Code](https://claude.ai/code/session_01UucW9gAXvDRmDDD8SQpyzC)_