### PR TITLE
Fix runaway RAF cascade in Lenis causing progressive slowdown

### DIFF
--- a/telcoinwiki-react/src/utils/lenisScroll.ts
+++ b/telcoinwiki-react/src/utils/lenisScroll.ts
@@ -39,7 +39,17 @@ export function initLenisScroll(): Lenis | null {
 
   // Initialize Lenis with optimized settings for maximum performance
   lenisInstance = new Lenis({
-    autoRaf: true,
+    // autoRaf must stay OFF: Lenis is driven manually below via the GSAP
+    // ticker. Lenis's raf() reschedules itself via requestAnimationFrame
+    // whenever autoRaf is on, even when raf() is invoked externally — so
+    // with both enabled, every GSAP ticker tick spawned a brand-new,
+    // permanent, self-perpetuating Lenis RAF loop that never got cancelled
+    // (only the most recently started loop's id is tracked for cleanup).
+    // Confirmed via profiling: ~2,200 requestAnimationFrame calls/sec from
+    // inside Lenis alone after 8s on the page, FPS collapsing from ~60 to
+    // ~20 within a minute — this was the "performance degrades horribly
+    // after a while" bug.
+    autoRaf: false,
     prevent: (element: HTMLElement) => {
       // Prevent Lenis on specific elements
       return element.id === 'tags-items' || element.id === 'categories-items'


### PR DESCRIPTION
## Summary

- Root-caused the reported "performance degrades horribly after being on the page a while, from using the scroll wheel" bug.
- `lenisScroll.ts` configured Lenis with **both** `autoRaf: true` **and** a manual GSAP-ticker driver calling `lenisInstance.raf()` on every tick. Lenis's own `raf()` reschedules itself via `requestAnimationFrame` whenever `autoRaf` is on — including when `raf()` is invoked externally. With both enabled, every GSAP ticker tick (~60/s) spawned a brand-new, permanent, self-perpetuating Lenis RAF loop that never got cancelled (only the most-recently-started loop's id is tracked, so `destroy()` could only ever cancel one of them). The number of live parallel loops only ever grew.
- Fix: `autoRaf: false`, so Lenis is driven solely by the existing GSAP ticker — which is what the surrounding code ("Use GSAP ticker for RAF") already intended.

## Verification

Instrumented `requestAnimationFrame` and profiled the **production build** (not dev — React StrictMode's double-effect-invoke would contaminate a dev-mode measurement):

| | Before | After |
|---|---|---|
| RAF calls from inside Lenis (8s window) | 17,909 | 0 |
| Total RAF calls over a 60s sustained scroll-wheel session | 725,516 (unbounded growth) | 7,106 (flat rate, ~75-140/s throughout, not accelerating) |
| Measured FPS during sustained scrolling | collapsing | stable |

- Re-confirmed Lenis's smooth-scroll easing still works correctly post-fix (a genuine multi-step eased ramp after a wheel tick, not an instant jump or a stuck value).
- Re-ran the homepage sticky sub-card scroll scan (all 5 sections) against the fixed build — identical plateaus to before, confirming this change doesn't regress the earlier sticky-stacking fix.
- `tsc --noEmit`, `eslint` (unchanged from the pre-existing baseline), and `jest` (53/53) all pass.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npx jest`
- [x] `npm run build` + `npm run preview`, instrumented RAF profiling before/after the fix
- [x] Manual verification that Lenis's smooth-scroll easing still animates correctly
- [x] Re-ran the 5-section sticky sub-card scroll scan to confirm no regression


---
_Generated by [Claude Code](https://claude.ai/code/session_01UucW9gAXvDRmDDD8SQpyzC)_